### PR TITLE
feat: per-task package exclusions

### DIFF
--- a/.changes/unreleased/Added-20260711-162553.yaml
+++ b/.changes/unreleased/Added-20260711-162553.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add per-task member path exclusions, including a shared release exclusion for changelog, version, tag, and publish commands.
+time: 2026-07-11T16:25:53.205567-07:00

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,55 @@
+name: PR Validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  changelog:
+    name: Changelog
+    runs-on: ${{ vars.RUNS_ON_CHANGELOG || vars.RUNS_ON || 'ubuntu-latest' }}
+    if: github.event.pull_request.draft != true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: tylerbutler/actions/changie-check@ee7def5950abcf0a519add705a95719ab345c05e # ratchet:tylerbutler/actions/changie-check@main
+        id: changelog
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
+      - name: Comment with changelog preview
+        if: steps.changelog.outputs.has-entries == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # ratchet:marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: changelog
+          message: |
+            ## Changelog Preview
+
+            This PR adds the following changelog entries:
+
+            ${{ steps.changelog.outputs.preview }}
+      - name: Comment about missing changelog
+        if: steps.changelog.outputs.has-entries == 'false' && steps.changelog.outputs.needs-entry == 'true'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # ratchet:marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: changelog
+          message: |
+            ## Missing Changelog Entry
+
+            This PR includes commits with types that typically require a changelog entry (`${{ steps.changelog.outputs.commit-types-found }}`), but no changie fragment was found.
+
+            To add one, run:
+
+            ```
+            changie new
+            ```
+      - name: Remove changelog comment
+        if: steps.changelog.outputs.has-entries == 'false' && steps.changelog.outputs.needs-entry == 'false'
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # ratchet:marocchino/sticky-pull-request-comment@v3.0.5
+        with:
+          header: changelog
+          delete: true

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ gleam package that also anchors the workspace. Only `members` is required:
 # gleam.toml at the repo root
 [tools.trellis]
 members = ["packages/*", "examples"]
-# Matching members participate in task fan-out but are excluded from
-# changelog, versioning, tagging, and publishing.
-ignore-release = ["examples"]
+# Exclusions are globbed against member paths and scoped by task. `release`
+# covers changelog, versioning, tagging, and publishing.
+exclude = { docs = ["examples"], release = ["examples"] }
 
 # Custom tasks for `trellis run <name>`. Built-in verbs (build, test, check,
 # format, docs, deps, clean) need no declaration.
@@ -138,7 +138,19 @@ package at a time in dependency order.
 
 Built-in tasks map 1:1 onto gleam verbs: `build`, `test`, `check`, `format`
 (`--check` variant), `docs`, `deps`, `clean`. A `[tools.trellis.tasks]` entry with the same
-name overrides a built-in.
+name overrides a built-in. Any built-in or custom task can exclude member paths
+through its key in `exclude`; exclusions still apply when packages are named
+explicitly. For larger maps, use a table:
+
+```toml
+[tools.trellis.exclude]
+docs = ["examples", "packages/internal-*"]
+release = ["examples"]
+```
+
+The special `release` key defines the package set used by changelog, version,
+tag, and publish commands. The older `ignore-release` array remains supported
+and is combined with `exclude.release`.
 
 ### Changelog & versioning
 
@@ -237,7 +249,7 @@ trellis doctor
 
 Checks every workspace invariant and reports all problems at once: member
 globs resolve and parse, path deps stay inside the workspace, the graph is
-acyclic, `ignore-release` globs match real members, no releasable package
+acyclic, task exclusion globs match real members, no releasable package
 depends on an unreleasable one, tag formats don't collide, `manifest.toml`
 locked versions match workspace-internal `gleam.toml` versions, no package's
 version is behind its CHANGELOG, and every unreleased changelog fragment

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -104,11 +104,9 @@ workspace marker lives in the manifest format the ecosystem already uses
 # gleam.toml at the workspace root
 [tools.trellis]
 members = ["packages/lattice_*", "examples"]
-# Glob array matched against member paths. Matching members participate in all
-# task fan-out (format/lint/build/test) like any other member, but are excluded
-# from changelog, versioning, tagging, and publishing. Replaces the hand
-# special-casing of examples/ in the justfile.
-ignore-release = ["examples"]
+# Glob arrays matched against member paths and scoped by task. The special
+# release key covers changelog, versioning, tagging, and publishing.
+exclude = { docs = ["examples"], release = ["examples"] }
 
 # Custom tasks, available to `trellis run <name>`. Built-in verbs (build, test,
 # check, format, docs, deps, clean) need no declaration.
@@ -179,6 +177,10 @@ trellis exec [pkgs...] -- <command...>
 
 - Built-in tasks map 1:1 onto gleam verbs: `build`, `test`, `check`, `format`
   (`--check` variant), `docs`, `deps`, `clean`. Custom tasks come from `[tasks]`.
+  Any built-in or custom task may have a same-named entry under
+  `[tools.trellis.exclude]`; excluded member-path globs are removed after normal
+  CLI package selection. `exclude.release` defines the releasable set, with the
+  older `ignore-release` array retained as a compatible alias.
 - Scheduling is **graph-parallel by default**: a package runs as soon as its
   workspace deps have finished, up to `--jobs N`. Output is streamed with a
   `pkg ▏` prefix, followed by a summary table. The justfile's serial loops become
@@ -284,8 +286,8 @@ Checks, each of which is an unenforced invariant in lattice today:
    and each has a changelog file where expected.
 5. `manifest.toml` locked versions of workspace-internal deps match those deps'
    actual `gleam.toml` versions (catches a missed lockfile patch).
-6. Every `ignore-release` glob matches at least one member (catches typos), and
-   no releasable member path-depends on an ignore-release member — a published
+6. Every task exclusion glob matches at least one member (catches typos), and
+   no releasable member path-depends on a release-excluded member — a published
    package cannot require a project that will never exist on Hex.
 7. Tag-format collisions (two members whose names would produce ambiguous tags).
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -30,7 +30,7 @@ pub fn run(root: &Path) -> Result<bool> {
     };
 
     if let Some(workspace) = &workspace {
-        check_ignore_release(workspace, &mut report);
+        check_exclusions(workspace, &mut report);
         check_tag_collisions(workspace, &mut report);
         check_lockfiles(workspace, &mut report);
         check_changelogs(workspace, &mut report);
@@ -41,7 +41,7 @@ pub fn run(root: &Path) -> Result<bool> {
     let checked = [
         "member globs resolve and every member has a parseable gleam.toml",
         "path dependencies stay inside the workspace; graph is acyclic",
-        "ignore-release globs match members; no releasable member depends on an unreleasable one",
+        "task exclusion globs match members; no releasable member depends on an unreleasable one",
         "tag format produces a unique tag per releasable member",
         "manifest.toml locked versions match workspace-internal gleam.toml versions",
         "each releasable member's version is not behind its CHANGELOG",
@@ -130,26 +130,15 @@ fn check_tool_versions(workspace: &Workspace, report: &mut Report) {
     }
 }
 
-/// Check 6: every ignore-release glob matches at least one member (catches
-/// typos), and no releasable member path-depends on an ignore-release member —
-/// a published package cannot require a project that will never be on Hex.
-fn check_ignore_release(workspace: &Workspace, report: &mut Report) {
+/// Check 6: every exclusion glob matches at least one member (catches typos),
+/// and no releasable member path-depends on a release-excluded member.
+fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     for pattern in &workspace.config.ignore_release {
-        let matches = globset::Glob::new(pattern)
-            .ok()
-            .map(|g| g.compile_matcher())
-            .map(|m| {
-                workspace
-                    .members
-                    .iter()
-                    .any(|member| m.is_match(&member.rel_path))
-            });
-        match matches {
-            Some(true) => {}
-            Some(false) => report.error(format!(
-                "ignore-release glob `{pattern}` matches no member (typo?)"
-            )),
-            None => report.error(format!("ignore-release glob `{pattern}` is invalid")),
+        check_exclusion_pattern(workspace, "ignore-release", pattern, report);
+    }
+    for (task, patterns) in &workspace.config.exclude {
+        for pattern in patterns {
+            check_exclusion_pattern(workspace, task, pattern, report);
         }
     }
 
@@ -162,11 +151,30 @@ fn check_ignore_release(workspace: &Workspace, report: &mut Report) {
             if !dep.releasable {
                 report.error(format!(
                     "releasable package `{}` path-depends on `{}`, which is excluded from release \
-                     by ignore-release and will never exist on Hex",
+                     and will never exist on Hex",
                     member.name, dep.name
                 ));
             }
         }
+    }
+}
+
+fn check_exclusion_pattern(workspace: &Workspace, task: &str, pattern: &str, report: &mut Report) {
+    let matches = globset::Glob::new(pattern)
+        .ok()
+        .map(|glob| glob.compile_matcher())
+        .map(|matcher| {
+            workspace
+                .members
+                .iter()
+                .any(|member| matcher.is_match(&member.rel_path))
+        });
+    match matches {
+        Some(true) => {}
+        Some(false) => report.error(format!(
+            "`{task}` exclusion glob `{pattern}` matches no member (typo?)"
+        )),
+        None => report.error(format!("`{task}` exclusion glob `{pattern}` is invalid")),
     }
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -29,12 +29,20 @@ pub struct TaskOptions {
 const BUILTIN_TASKS: &[&str] = &["build", "test", "check", "format", "docs", "deps", "clean"];
 
 pub fn run(workspace: &Workspace, options: &TaskOptions) -> Result<bool> {
-    let selected = workspace.select(&SelectionFilter {
+    let mut selected = workspace.select(&SelectionFilter {
         names: options.packages.clone(),
         since: options.since.clone(),
         with_dependents: options.with_dependents,
         releasable_only: false,
     })?;
+    if let Some(patterns) = workspace.config.exclude.get(&options.task) {
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in patterns {
+            builder.add(globset::Glob::new(pattern)?);
+        }
+        let excluded = builder.build()?;
+        selected.retain(|&idx| !excluded.is_match(&workspace.members[idx].rel_path));
+    }
 
     let mut jobs = Vec::new();
     for idx in selected {

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,11 @@ pub struct ConfigFile {
     /// excluded from changelog, versioning, tagging, and publishing.
     #[serde(default)]
     pub ignore_release: Vec<String>,
+    /// Per-task glob arrays matched against member paths. The special
+    /// `release` key excludes members from changelog, versioning, tagging, and
+    /// publishing.
+    #[serde(default)]
+    pub exclude: BTreeMap<String, Vec<String>>,
     #[serde(default)]
     pub tasks: BTreeMap<String, TaskConfig>,
     #[serde(default)]
@@ -256,6 +261,7 @@ mod tests {
             [tools.trellis]
             members = ["packages/lattice_*", "examples"]
             ignore-release = ["examples"]
+            exclude = { docs = ["examples"], release = ["packages/private-*"] }
 
             [tools.trellis.tasks.lint]
             command = "gleam run -m glinter"
@@ -277,6 +283,8 @@ mod tests {
         let config = ConfigFile::from_gleam_toml(text).unwrap();
         assert_eq!(config.members.len(), 2);
         assert_eq!(config.ignore_release, vec!["examples"]);
+        assert_eq!(config.exclude["docs"], vec!["examples"]);
+        assert_eq!(config.exclude["release"], vec!["packages/private-*"]);
         assert!(config.tasks["lint"].needs_deps);
         assert_eq!(config.publish.retry.attempts, 5);
         assert_eq!(config.changelog.dir, "changes");
@@ -289,6 +297,7 @@ mod tests {
         let config =
             ConfigFile::from_gleam_toml("[tools.trellis]\nmembers = [\"packages/*\"]").unwrap();
         assert!(config.ignore_release.is_empty());
+        assert!(config.exclude.is_empty());
         assert_eq!(config.publish.tag_format, "{name}-v{version}");
         assert_eq!(
             config.publish.path_dep_requirement,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -126,9 +126,21 @@ impl Workspace {
         let member_dirs = expand_member_globs(root, &config.members, &mut diagnostics);
 
         // Parse each member manifest; unparseable members are reported and dropped.
-        let ignore_release = build_globset(&config.ignore_release)
+        for (task, patterns) in &config.exclude {
+            if let Err(err) = build_globset(patterns) {
+                diagnostics.error(format!("invalid `{task}` exclusion glob: {err:#}"));
+            }
+        }
+
+        let release_exclusions = config
+            .ignore_release
+            .iter()
+            .chain(config.exclude.get("release").into_iter().flatten())
+            .cloned()
+            .collect::<Vec<_>>();
+        let ignore_release = build_globset(&release_exclusions)
             .map_err(|err| {
-                diagnostics.error(format!("invalid ignore-release glob: {err:#}"));
+                diagnostics.error(format!("invalid release exclusion glob: {err:#}"));
             })
             .ok();
         let mut members = Vec::new();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -123,8 +123,31 @@ fn run_custom_task_fans_out_with_prefixes() {
         .success()
         .stdout(predicate::str::contains("lat_core"))
         // once for the echoed `$ ...` command line and once for its output
-        .stdout(predicate::str::contains("hello-from-task").count(8))
+        .stdout(predicate::str::contains("hello-from-task").count(6))
+        .stdout(predicate::str::contains("examples").not())
         .stdout(predicate::str::contains("ok"));
+}
+
+#[test]
+fn task_exclusions_apply_to_explicit_package_selection() {
+    trellis(&fixture("basic"))
+        .args(["run", "hello", "examples"])
+        .assert()
+        .success()
+        .stdout("no packages selected\n");
+}
+
+#[test]
+fn built_in_task_can_be_excluded_without_overriding_its_command() {
+    trellis(&fixture("basic"))
+        .env("TRELLIS_GLEAM_BIN", "echo")
+        .args(["run", "docs", "--serial"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lat_core"))
+        .stdout(predicate::str::contains("lat_mid"))
+        .stdout(predicate::str::contains("lat_cli"))
+        .stdout(predicate::str::contains("examples").not());
 }
 
 #[test]
@@ -232,7 +255,7 @@ fn doctor_reports_all_problems_at_once() {
     let root = dir.path();
     write(
         &root.join("gleam.toml"),
-        "[tools.trellis]\nmembers = [\"packages/*\"]\nignore-release = [\"nomatch\"]\n",
+        "[tools.trellis]\nmembers = [\"packages/*\"]\nignore-release = [\"nomatch\"]\nexclude = { docs = [\"also-missing\"] }\n",
     );
     // a: stale lockfile for b, and a path dep escaping the workspace
     write(
@@ -260,7 +283,10 @@ fn doctor_reports_all_problems_at_once() {
         .failure()
         .stdout(predicate::str::contains("points outside the workspace"))
         .stdout(predicate::str::contains(
-            "ignore-release glob `nomatch` matches no member",
+            "`ignore-release` exclusion glob `nomatch` matches no member",
+        ))
+        .stdout(predicate::str::contains(
+            "`docs` exclusion glob `also-missing` matches no member",
         ))
         .stdout(predicate::str::contains("locks `b` at 0.9.0"))
         .stdout(predicate::str::contains("behind its CHANGELOG"));

--- a/tests/fixtures/basic/gleam.toml
+++ b/tests/fixtures/basic/gleam.toml
@@ -3,7 +3,7 @@
 
 [tools.trellis]
 members = ["packages/*", "examples"]
-ignore-release = ["examples"]
+exclude = { docs = ["examples"], hello = ["examples"], release = ["examples"] }
 
 [tools.trellis.tasks.hello]
 command = "echo hello-from-task"


### PR DESCRIPTION
## Summary

- add concise per-task member path exclusions through `[tools.trellis.exclude]`
- use the special `release` key across changelog, version, tag, and publish operations
- retain `ignore-release` compatibility and validate exclusion globs in `doctor`
- mirror repoverlay's PR validation workflow to preview Changie fragments and flag missing entries
- document the configuration and add a Changie fragment

## Testing

- `cargo test --all-targets --quiet`
- `cargo clippy --all-targets --all-features --quiet -- -D warnings`
- `actionlint .github/workflows/pr.yml`
