### PR TITLE
docs(website): reflect v0.2.0 exclusions

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 ---
 name: Trellis
-description: The missing Gleam workspace — landing page and documentation site
+description: A Gleam workspace manager — landing page and documentation site
 colors:
   bg: "oklch(0.16 0.02 230)"
   surface: "oklch(0.205 0.026 230)"

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -10,22 +10,22 @@ web
 
 ## Users
 
-Gleam monorepo maintainers: developers already running (or about to run) multi-package Gleam repositories who feel the pain of hand-built workspace glue today — bash loops in justfiles, per-package YAML blocks, inline sed in CI workflows. They are experienced engineers evaluating a tool, not browsing; they arrive skeptical and want to understand how it works before they run anything.
+Gleam monorepo maintainers: developers already running (or about to run) multi-package Gleam repositories who may coordinate packages with bash loops in justfiles, per-package YAML blocks, or inline sed in CI workflows. They are experienced engineers evaluating a tool, not browsing; they arrive skeptical and want to understand how it works before they run anything.
 
 ## Product Purpose
 
-This surface is the public website for trellis — a landing page that pitches the tool plus reference documentation for its commands and configuration. Trellis itself is a single Rust binary that gives Gleam monorepos the workspace layer the language lacks: task fan-out, dependency-graph introspection, versioning, changelogs, and publish orchestration, all derived from `gleam.toml` files that already exist. Success for the site is adoption: a visitor reads enough of the docs to trust the model, then installs trellis and adds it to their workspace.
+This surface is the public website for trellis — a landing page that introduces the tool plus reference documentation for its commands and configuration. Trellis itself is a single Rust binary that offers workspace tooling for multi-package Gleam repositories: task fan-out, dependency-graph introspection, versioning, changelogs, and publish orchestration, all derived from `gleam.toml` files that already exist. Success for the site is adoption: a visitor reads enough of the docs to trust the model, then installs trellis and adds it to their workspace.
 
 ## Positioning
 
-The missing Gleam workspace. Gleam has no workspace concept — trellis is it. Lead with the gap it fills; the derivation mechanism is how it earns the claim, not the headline.
+Workspace tooling for multi-package Gleam repositories. Present trellis as one practical option, not the canonical way to organize Gleam projects. Describe the scope of Gleam's package commands factually when relevant, without framing the language's design as a failure. Lead with what trellis does and how it derives its workspace model from existing manifests.
 
 ## Conversion & proof
 
 - Primary CTA: read the docs — the conversion path is evaluation-first, so the site's job is to get visitors into the documentation. Secondary CTA: the one-line install command (shell installer, Homebrew, or mise) for visitors ready to try it now.
-- The line a visitor remembers after 10 seconds: "Gleam has no workspace concept — trellis is it."
-- Belief ladder: (1) My bash-loop and YAML glue is real, compounding pain — not just mess. (2) Trellis derives all of it from the `gleam.toml` files I already have; nothing new to configure. (3) It's safe to adopt: one binary, no lock-in, and `doctor` verifies every invariant that used to be enforced by hope.
-- Proof on hand: lattice as the case study — the real inventory of hand-maintained glue (justfile package lists, changie project blocks, workflow sed scripts, an external SHA-pinned action) that trellis deleted. The before/after table lives in `docs/DESIGN.md` §1.
+- The line a visitor remembers after 10 seconds: "Workspace tooling for multi-package Gleam repositories, derived from gleam.toml."
+- Belief ladder: (1) Coordinating a growing multi-package repository can involve repeated package lists, shell loops, and CI configuration. (2) Trellis can derive much of that information from the `gleam.toml` files already present. (3) It's safe to try: one binary, no lock-in, and `doctor` checks the invariants that remain explicit.
+- Proof on hand: lattice as the case study — a real inventory of hand-maintained glue (justfile package lists, changie project blocks, workflow sed scripts, an external SHA-pinned action) that lattice replaced with trellis. The before/after table lives in `docs/DESIGN.md` §1.
 
 ## Brand Personality
 
@@ -40,7 +40,7 @@ Precise, calm, trustworthy. Engineering-grade confidence: the tool quietly does 
 
 - **Docs are the pitch.** The conversion path runs through understanding, so documentation quality IS marketing. Reference pages get the same design attention as the landing page.
 - **Proof by concrete example, not adjectives.** The lattice before/after — the actual glue that got deleted — carries the argument. Show real config, real commands, real output; never claim "simple" or "powerful" in the abstract.
-- **Configure nothing that can be derived — the site too.** Trellis's own principle applies to its website: every element earns its place from the content; no decorative scaffolding, no section that exists because landing pages have one.
+- **Derive before declaring — the site too.** Trellis's own principle applies to its website: every element earns its place from the content; no decorative scaffolding, no section that exists because landing pages have one.
 - **Calm over loud.** Precise typography, restrained motion, exact language. The visitor is a skeptical engineer; earn trust the way the tool does — by being correct and quiet about it.
 
 ## Accessibility & Inclusion

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ gleam package that also anchors the workspace. Only `members` is required:
 ```toml
 # gleam.toml at the repo root
 [tools.trellis]
-members = ["packages/*", "examples"]
+members = ["packages/*", "examples/*"]
 # Exclusions are globbed against member paths and scoped by task. `release`
 # covers changelog, versioning, tagging, and publishing.
-exclude = { docs = ["examples"], release = ["examples"] }
+exclude = { docs = ["examples/*"], release = ["examples/*"] }
 
 # Custom tasks for `trellis run <name>`. Built-in verbs (build, test, check,
 # format, docs, deps, clean) need no declaration.
@@ -144,8 +144,8 @@ explicitly. For larger maps, use a table:
 
 ```toml
 [tools.trellis.exclude]
-docs = ["examples", "packages/internal-*"]
-release = ["examples"]
+docs = ["examples/*", "packages/internal-*"]
+release = ["examples/*"]
 ```
 
 The special `release` key defines the package set used by changelog, version,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -103,10 +103,10 @@ workspace marker lives in the manifest format the ecosystem already uses
 ```toml
 # gleam.toml at the workspace root
 [tools.trellis]
-members = ["packages/lattice_*", "examples"]
+members = ["packages/lattice_*", "examples/*"]
 # Glob arrays matched against member paths and scoped by task. The special
 # release key covers changelog, versioning, tagging, and publishing.
-exclude = { docs = ["examples"], release = ["examples"] }
+exclude = { docs = ["examples/*"], release = ["examples/*"] }
 
 # Custom tasks, available to `trellis run <name>`. Built-in verbs (build, test,
 # check, format, docs, deps, clean) need no declaration.

--- a/src/config.rs
+++ b/src/config.rs
@@ -259,9 +259,9 @@ mod tests {
             version = "0.0.0"
 
             [tools.trellis]
-            members = ["packages/lattice_*", "examples"]
-            ignore-release = ["examples"]
-            exclude = { docs = ["examples"], release = ["packages/private-*"] }
+            members = ["packages/lattice_*", "examples/*"]
+            ignore-release = ["examples/*"]
+            exclude = { docs = ["examples/*"], release = ["packages/private-*"] }
 
             [tools.trellis.tasks.lint]
             command = "gleam run -m glinter"
@@ -282,8 +282,8 @@ mod tests {
         "###;
         let config = ConfigFile::from_gleam_toml(text).unwrap();
         assert_eq!(config.members.len(), 2);
-        assert_eq!(config.ignore_release, vec!["examples"]);
-        assert_eq!(config.exclude["docs"], vec!["examples"]);
+        assert_eq!(config.ignore_release, vec!["examples/*"]);
+        assert_eq!(config.exclude["docs"], vec!["examples/*"]);
         assert_eq!(config.exclude["release"], vec!["packages/private-*"]);
         assert!(config.tasks["lint"].needs_deps);
         assert_eq!(config.publish.retry.attempts, 5);

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -25,7 +25,7 @@ fn list_prints_members_in_topological_order() {
         .arg("list")
         .assert()
         .success()
-        .stdout("lat_core\nlat_mid\nlat_cli\nexamples\n");
+        .stdout("lat_core\nlat_mid\nlat_cli\npackage_a\n");
 }
 
 #[test]
@@ -62,8 +62,8 @@ fn list_json_includes_graph_facts() {
     assert_eq!(mid["releasable"], true);
     assert_eq!(mid["dependencies"], serde_json::json!(["lat_core"]));
     assert_eq!(mid["dependents"], serde_json::json!(["lat_cli"]));
-    let examples = items.iter().find(|i| i["name"] == "examples").unwrap();
-    assert_eq!(examples["releasable"], false);
+    let package_a = items.iter().find(|i| i["name"] == "package_a").unwrap();
+    assert_eq!(package_a["releasable"], false);
 }
 
 // ---- graph -----------------------------------------------------------
@@ -87,7 +87,7 @@ fn graph_json_lists_nodes_and_edges() {
     let graph: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(graph["nodes"].as_array().unwrap().len(), 4);
     // lat_mid->lat_core, lat_cli->lat_mid, lat_cli->lat_core (dev),
-    // examples->lat_cli
+    // package_a->lat_cli
     assert_eq!(graph["edges"].as_array().unwrap().len(), 4);
 }
 
@@ -124,14 +124,14 @@ fn run_custom_task_fans_out_with_prefixes() {
         .stdout(predicate::str::contains("lat_core"))
         // once for the echoed `$ ...` command line and once for its output
         .stdout(predicate::str::contains("hello-from-task").count(6))
-        .stdout(predicate::str::contains("examples").not())
+        .stdout(predicate::str::contains("package_a").not())
         .stdout(predicate::str::contains("ok"));
 }
 
 #[test]
 fn task_exclusions_apply_to_explicit_package_selection() {
     trellis(&fixture("basic"))
-        .args(["run", "hello", "examples"])
+        .args(["run", "hello", "package_a"])
         .assert()
         .success()
         .stdout("no packages selected\n");
@@ -147,7 +147,7 @@ fn built_in_task_can_be_excluded_without_overriding_its_command() {
         .stdout(predicate::str::contains("lat_core"))
         .stdout(predicate::str::contains("lat_mid"))
         .stdout(predicate::str::contains("lat_cli"))
-        .stdout(predicate::str::contains("examples").not());
+        .stdout(predicate::str::contains("package_a").not());
 }
 
 #[test]
@@ -404,7 +404,7 @@ fn ci_outputs_emits_key_value_lines() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "projects=[\"lat_core\",\"lat_mid\",\"lat_cli\",\"examples\"]",
+            "projects=[\"lat_core\",\"lat_mid\",\"lat_cli\",\"package_a\"]",
         ))
         .stdout(predicate::str::contains(
             "releasable=[\"lat_core\",\"lat_mid\",\"lat_cli\"]",
@@ -453,7 +453,7 @@ fn since_selects_changed_packages_and_dependents() {
         .args(["list", "--since", "main", "--with-dependents"])
         .assert()
         .success()
-        .stdout("lat_mid\nlat_cli\nexamples\n");
+        .stdout("lat_mid\nlat_cli\npackage_a\n");
 
     // Uncommitted changes count too.
     write(&root.join("packages/lat_core/src/wip.gleam"), "// wip\n");

--- a/tests/fixtures/basic/examples/gleam.toml
+++ b/tests/fixtures/basic/examples/gleam.toml
@@ -1,5 +1,0 @@
-name = "examples"
-version = "0.0.0"
-
-[dependencies]
-lat_cli = { path = "../packages/lat_cli" }

--- a/tests/fixtures/basic/examples/package-a/gleam.toml
+++ b/tests/fixtures/basic/examples/package-a/gleam.toml
@@ -1,0 +1,5 @@
+name = "package_a"
+version = "0.0.0"
+
+[dependencies]
+lat_cli = { path = "../../packages/lat_cli" }

--- a/tests/fixtures/basic/gleam.toml
+++ b/tests/fixtures/basic/gleam.toml
@@ -2,8 +2,8 @@
 # a regular package manifest; here it is config-only.
 
 [tools.trellis]
-members = ["packages/*", "examples"]
-exclude = { docs = ["examples"], hello = ["examples"], release = ["examples"] }
+members = ["packages/*", "examples/*"]
+exclude = { docs = ["examples/*"], hello = ["examples/*"], release = ["examples/*"] }
 
 [tools.trellis.tasks.hello]
 command = "echo hello-from-task"

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -127,7 +127,7 @@ fn new_fragment_writes_toml_and_validates_inputs() {
             "changelog",
             "new",
             "--package",
-            "examples",
+            "package_a",
             "--kind",
             "Added",
             "--body",
@@ -184,10 +184,10 @@ fn changelog_check_maps_diff_to_missing_fragments() {
     git(&["add", "."]);
     git(&["commit", "-q", "-m", "init"]);
     git(&["checkout", "-q", "-b", "feature"]);
-    // Change two releasable packages and examples; add a fragment for one.
+    // Change two releasable packages and the example package; add a fragment for one.
     write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
     write(&root.join("packages/lat_mid/src/new.gleam"), "// x\n");
-    write(&root.join("examples/src/new.gleam"), "// x\n");
+    write(&root.join("examples/package-a/src/new.gleam"), "// x\n");
     add_fragment(root, "lat_core", "Added", "something");
     git(&["add", "."]);
     git(&["commit", "-q", "-m", "change"]);
@@ -201,7 +201,7 @@ fn changelog_check_maps_diff_to_missing_fragments() {
     assert_eq!(payload["has-entries"], true);
     assert_eq!(payload["needs-entry"], true);
     let packages = payload["packages"].as_array().unwrap();
-    // examples changed too but is not releasable, so only two rows.
+    // The example package changed too but is not releasable, so only two rows.
     assert_eq!(packages.len(), 2);
     let core = packages.iter().find(|p| p["name"] == "lat_core").unwrap();
     assert_eq!(core["has-entry"], true);

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -201,7 +201,7 @@ fn tag_plan_lists_untagged_versions_and_create_tags_them() {
     let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let plan = plan.as_array().unwrap();
     let names: Vec<&str> = plan.iter().map(|p| p["name"].as_str().unwrap()).collect();
-    // examples is ignore-release; lat_core already tagged.
+    // package_a is ignore-release; lat_core already tagged.
     assert_eq!(names, vec!["lat_mid", "lat_cli"]);
     assert_eq!(plan[0]["tag"], "lat_mid-v0.5.0");
 
@@ -486,7 +486,7 @@ fn publish_all_untagged_goes_in_topological_order_and_is_idempotent() {
         "dependency must publish before dependent:\n{log}"
     );
     assert!(
-        !log.contains("examples"),
+        !log.contains("package_a"),
         "ignore-release members never publish"
     );
 }
@@ -571,7 +571,7 @@ fn publish_rejects_unreleasable_package() {
     let root = tmp.path();
     copy_fixture_to(root);
     trellis(root)
-        .args(["publish", "examples"])
+        .args(["publish", "package_a"])
         .assert()
         .failure()
         .stderr(predicate::str::contains("excluded from release"));

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -32,20 +32,7 @@ const github = "https://github.com/tylerbutler/trellis";
     <header class="site-header">
       <div class="shell">
         <a class="brand" href="/" aria-label="Trellis home">
-          <svg width="22" height="22" viewBox="0 0 22 22" fill="none" aria-hidden="true">
-            <path
-              d="M2 7.5 7.5 2M2 14.5 14.5 2M2 20 20 2M7.5 20 20 7.5M14.5 20 20 14.5"
-              stroke="oklch(0.8 0.128 80)"
-              stroke-width="1.5"
-              stroke-linecap="round"
-            />
-            <path
-              d="M7.5 2 20 14.5M2 7.5 14.5 20M14.5 2 2 14.5"
-              stroke="oklch(0.45 0.086 230)"
-              stroke-width="1.5"
-              stroke-linecap="round"
-            />
-          </svg>
+          <img src="/favicon.svg" width="22" height="22" alt="" aria-hidden="true" />
           trellis
         </a>
         <nav class="site-nav" aria-label="Site">

--- a/website/src/pages/docs/configuration.astro
+++ b/website/src/pages/docs/configuration.astro
@@ -44,15 +44,16 @@ lat_cli`;
 
 <Docs
   title="Configuration — Trellis docs"
-  description="A [tools.trellis] table in gleam.toml marks the workspace root. Only members is required; everything else is derived."
+  description="Trellis uses a [tools.trellis] table in gleam.toml to identify the workspace root. Only members is required."
 >
   <h1>Configuration</h1>
   <p>
-    A <code>[tools.trellis]</code> table in a <code>gleam.toml</code> marks the
-    workspace root — there is no separate config file. The root manifest may be
-    config-only, or a regular Gleam package that also anchors the workspace.
-    Only <code>members</code> is required; everything else trellis needs is
-    derived from the member manifests.
+    Trellis uses a <code>[tools.trellis]</code> table in a
+    <code>gleam.toml</code> to identify the workspace root, so it does not need a
+    separate config file. The root manifest may be config-only, or a regular
+    Gleam package that also anchors the workspace. Only
+    <code>members</code> is required; trellis derives the rest of its workspace
+    model from the member manifests.
   </p>
 
   <Code lang="toml" title="gleam.toml" code={rootConfig} />
@@ -66,9 +67,10 @@ lat_cli`;
   <div class="callout">
     <p>
       A <code>[tools.trellis]</code> table in a <em>member</em> manifest is a
-      <code>doctor</code> error — it would hijack root discovery, which walks
-      up from the current directory to the first manifest carrying the table,
-      the way <code>git</code> and <code>cargo</code> find their roots.
+      <code>doctor</code> error because it would change root discovery. Trellis
+      walks up from the current directory to the first manifest carrying the
+      table, similar to how <code>git</code> and <code>cargo</code> find their
+      roots.
     </p>
   </div>
 

--- a/website/src/pages/docs/configuration.astro
+++ b/website/src/pages/docs/configuration.astro
@@ -5,9 +5,9 @@ import Docs from "../../layouts/Docs.astro";
 const rootConfig = `# gleam.toml at the repo root
 [tools.trellis]
 members = ["packages/*", "examples"]
-# Matching members participate in task fan-out but are excluded from
-# changelog, versioning, tagging, and publishing.
-ignore-release = ["examples"]
+# Exclusions are globbed against member paths and scoped by task.
+# \`release\` covers changelog, versioning, tagging, and publishing.
+exclude = { docs = ["examples"], release = ["examples"] }
 
 # Custom tasks for \`trellis run <name>\`. Built-in verbs (build, test, check,
 # format, docs, deps, clean) need no declaration.
@@ -30,7 +30,11 @@ kinds = [
 
 const exclusionConfig = `[tools.trellis]
 members = ["packages/*", "examples", "benchmarks/*"]
-ignore-release = ["examples", "benchmarks/*"]`;
+exclude = { docs = ["examples", "benchmarks/*"], release = ["examples", "benchmarks/*"] }`;
+
+const exclusionTableConfig = `[tools.trellis.exclude]
+docs = ["examples", "benchmarks/*"]
+release = ["examples", "benchmarks/*"]`;
 
 const releasableOutput = `$ trellis list --releasable
 lat_core
@@ -87,12 +91,27 @@ lat_cli`;
         </td>
       </tr>
       <tr>
-        <td><code>ignore-release</code></td>
+        <td><code>exclude.&lt;task&gt;</code></td>
         <td>no</td>
         <td>
-          Members that run tasks but are excluded from changelog, versioning,
-          tagging, and publishing. <code>doctor</code> rejects a releasable
-          member that depends on an unreleasable one.
+          Member-path globs omitted from that built-in or custom task. The
+          exclusion still applies when a package is named explicitly.
+        </td>
+      </tr>
+      <tr>
+        <td><code>exclude.release</code></td>
+        <td>no</td>
+        <td>
+          The shared package set omitted from changelog, versioning, tagging,
+          publishing, and release CI.
+        </td>
+      </tr>
+      <tr>
+        <td><code>ignore-release</code></td>
+        <td>legacy</td>
+        <td>
+          Compatibility alias for release exclusions. It remains supported and
+          is combined with <code>exclude.release</code>.
         </td>
       </tr>
       <tr>
@@ -140,66 +159,87 @@ lat_cli`;
     </tbody>
   </table>
 
-  <h2 id="release-exclusions">Release exclusions</h2>
+  <h2 id="release-exclusions">Package exclusions</h2>
   <p>
-    Some workspace members need the normal development loop without becoming
-    published packages. Add their paths to <code>ignore-release</code>:
+    Trellis 0.2.0 added task-scoped package exclusions. Add a key for any
+    built-in or custom <code>trellis run</code> task whose package set differs
+    from the full workspace:
   </p>
 
   <Code lang="toml" title="gleam.toml" code={exclusionConfig} />
 
   <p>
-    The patterns are globs matched against member paths relative to the
-    workspace root, not package names. An excluded member stays in the
-    dependency graph and still participates in <code>run</code>,
-    <code>exec</code>, <code>list</code>, <code>graph</code>, and changed-package
-    selection.
+    Inline TOML is concise for a small map. The equivalent table form is easier
+    to scan as more tasks gain exclusions:
+  </p>
+
+  <Code lang="toml" title="gleam.toml" code={exclusionTableConfig} />
+
+  <p>
+    Patterns are globs matched against member paths relative to the workspace
+    root, not package names. A task exclusion applies after normal package
+    selection, so it still wins when a package is named explicitly or selected
+    through <code>--since</code>.
   </p>
 
   <table>
     <thead>
       <tr>
-        <th scope="col">Surface</th>
-        <th scope="col">Excluded member behavior</th>
+        <th scope="col">Key</th>
+        <th scope="col">What it excludes</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>Tasks and graph</td>
-        <td>Included normally, with dependencies and dependents intact.</td>
+        <td><code>docs</code></td>
+        <td>
+          Matching members from <code>trellis run docs</code>. Built-in tasks
+          can be filtered without overriding their commands.
+        </td>
       </tr>
       <tr>
-        <td>Changelog and versioning</td>
+        <td>Any custom task name</td>
         <td>
-          Omitted from checks and plans. Explicit changelog creation is
+          Matching members from that <code>trellis run &lt;name&gt;</code>
+          invocation.
+        </td>
+      </tr>
+      <tr>
+        <td><code>release</code></td>
+        <td>
+          Matching members from changelog, version, tag, publish, and release
+          CI operations. Explicit changelog creation and publishing are
           rejected.
-        </td>
-      </tr>
-      <tr>
-        <td>Tags, publishing, and release CI</td>
-        <td>
-          Omitted from generated release sets. Explicit publishing is rejected.
-        </td>
-      </tr>
-      <tr>
-        <td>Introspection</td>
-        <td>
-          <code>info</code> and JSON output expose
-          <code>releasable: false</code>; <code>list --releasable</code> returns
-          only the release set.
         </td>
       </tr>
     </tbody>
   </table>
 
+  <p>
+    Release-excluded members remain in the dependency graph and still
+    participate in <code>list</code>, <code>graph</code>, <code>exec</code>, and
+    every task that does not exclude them. <code>info</code> and JSON output
+    expose <code>releasable: false</code>; <code>list --releasable</code> returns
+    only the release set:
+  </p>
+
   <Code lang="console" code={releasableOutput} />
 
   <div class="callout">
     <p>
-      <code>trellis doctor</code> catches an exclusion glob that matches no
-      member and rejects a releasable package that path-depends on an excluded
-      one. A published package cannot depend on a workspace package that will
-      never exist on Hex.
+      The older <code>ignore-release</code> array remains supported and is
+      combined with <code>exclude.release</code>. Prefer
+      <code>exclude.release</code> in new configuration so every package-set
+      exception lives under the same task-scoped model.
+    </p>
+  </div>
+
+  <div class="callout">
+    <p>
+      <code>trellis doctor</code> catches every exclusion glob that matches no
+      member. For release exclusions, it also rejects a releasable package that
+      path-depends on an excluded one: a published package cannot depend on a
+      workspace package that will never exist on Hex.
     </p>
   </div>
 
@@ -225,8 +265,8 @@ lat_cli`;
   <h2>Verifying it</h2>
   <p>
     Run <code>trellis doctor</code> after any config change. It validates that
-    member globs resolve, the graph is acyclic, ignore-release globs match
-    members, the tag format produces unique tags, and locked versions match —
-    exiting non-zero on any error.
+    member globs resolve, the graph is acyclic, task exclusion globs match
+    members, release boundaries are safe, the tag format produces unique tags,
+    and locked versions match — exiting non-zero on any error.
   </p>
 </Docs>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -29,7 +29,7 @@ tag-format = "{name}-v{version}"`;
     <div class="shell hero-grid">
       <div class="hero-copy">
         <h1>
-          Workspace tooling for multi-package Gleam repositories.
+          Tools for Gleam monorepos.
           <em>Derived from gleam.toml.</em>
         </h1>
         <p class="lead">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -33,7 +33,7 @@ tag-format = "{name}-v{version}"`;
           <em>Derived from gleam.toml.</em>
         </h1>
         <p class="lead">
-          Trellis is one binary for task fan-out, dependency-graph
+          Trellis is one binary that provides task fan-out, dependency-graph
           introspection, changelogs, versioning, and publish orchestration —
           all derived from the <code>gleam.toml</code> files you already have.
         </p>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -9,8 +9,9 @@ const configSample = `# This table marks the workspace root.
 # Only \`members\` is required.
 [tools.trellis]
 members = ["packages/*", "examples"]
-# Keep examples in task fan-out, but out of releases.
-ignore-release = ["examples"]
+# Exclusions are scoped by task. \`release\` covers changelog,
+# versioning, tagging, publishing, and release CI.
+exclude = { docs = ["examples"], release = ["examples"] }
 
 [tools.trellis.tasks.lint]
 command = "gleam run -m glinter"
@@ -157,33 +158,33 @@ tag-format = "{name}-v{version}"`;
     </div>
   </section>
 
-  <!-- ============ RELEASE EXCLUSIONS ============ -->
+  <!-- ============ PACKAGE EXCLUSIONS ============ -->
   <section class="exclusions">
     <div class="shell exclusions-grid">
       <div class="section-head">
-        <h2>Run it here. Don’t release it.</h2>
+        <h2>One workspace. Different task sets.</h2>
         <p>
           Examples, benchmarks, and internal tools belong in the workspace:
-          they should build, test, and appear in the graph. They do not belong
-          in a changelog or on Hex.
+          they should build, test, and appear in the graph, but they may not
+          need generated docs or a release on Hex.
         </p>
         <p>
-          <code>ignore-release</code> draws that boundary with member-path
-          globs. Trellis applies it across changelogs, versioning, tags,
-          publishing, and release CI — then <code>doctor</code> checks that the
-          boundary is safe.
+          In 0.2.0, <code>exclude</code> gives each built-in or custom task its
+          own member-path globs. The special <code>release</code> key covers
+          changelogs, versioning, tags, publishing, and release CI.
         </p>
-        <a href="/docs/configuration/#release-exclusions">Configure release exclusions →</a>
+        <a href="/docs/configuration/#release-exclusions">Configure package exclusions →</a>
       </div>
 
       <div class="exclusion-proof">
-        <div class="release-ledger-scroll">
-          <table class="release-ledger">
+        <div class="exclusion-ledger-scroll">
+          <table class="exclusion-ledger">
             <thead>
               <tr>
                 <th scope="col">Member</th>
-                <th scope="col">Everyday commands</th>
-                <th scope="col">Release commands</th>
+                <th scope="col">build / test</th>
+                <th scope="col">docs</th>
+                <th scope="col">release</th>
               </tr>
             </thead>
             <tbody>
@@ -191,10 +192,12 @@ tag-format = "{name}-v{version}"`;
                 <td><code>packages/*</code></td>
                 <td><span class="state state-included">included</span></td>
                 <td><span class="state state-included">included</span></td>
+                <td><span class="state state-included">included</span></td>
               </tr>
               <tr>
                 <td><code>examples</code></td>
                 <td><span class="state state-included">included</span></td>
+                <td><span class="state state-excluded">excluded</span></td>
                 <td><span class="state state-excluded">excluded</span></td>
               </tr>
             </tbody>
@@ -208,7 +211,8 @@ tag-format = "{name}-v{version}"`;
 <span class="name">lat_cli</span></code></pre>
           <figcaption class="term-note">
             <code>examples</code> still appears in <code>trellis list</code>,
-            <code>graph</code>, and task fan-out. Only the release set changes.
+            <code>graph</code>, <code>exec</code>, and tasks that do not exclude
+            it. Only the configured task sets change.
           </figcaption>
         </figure>
       </div>
@@ -275,7 +279,7 @@ tag-format = "{name}-v{version}"`;
         <figcaption class="term-bar"><span class="prompt">$</span>trellis doctor</figcaption>
         <pre class="term-out"><code><span class="dim">checked:</span> member globs resolve and every member has a parseable gleam.toml
 <span class="dim">checked:</span> path dependencies stay inside the workspace; graph is acyclic
-<span class="dim">checked:</span> ignore-release globs match members; no releasable member depends on an unreleasable one
+<span class="dim">checked:</span> task exclusion globs match members; no releasable member depends on an unreleasable one
 <span class="dim">checked:</span> tag format produces a unique tag per releasable member
 <span class="dim">checked:</span> manifest.toml locked versions match workspace-internal gleam.toml versions
 <span class="dim">checked:</span> each releasable member's version is not behind its CHANGELOG
@@ -580,20 +584,20 @@ tag-format = "{name}-v{version}"`;
     min-width: 0;
   }
 
-  .release-ledger-scroll {
+  .exclusion-ledger-scroll {
     overflow-x: auto;
     border: 1px solid var(--line);
     border-radius: var(--radius-md);
   }
 
-  .release-ledger {
+  .exclusion-ledger {
     width: 100%;
-    min-width: 34rem;
+    min-width: 42rem;
     border-collapse: collapse;
     font-size: var(--text-small);
   }
 
-  .release-ledger th {
+  .exclusion-ledger th {
     text-align: left;
     font-family: var(--font-mono);
     font-size: var(--text-fine);
@@ -604,16 +608,16 @@ tag-format = "{name}-v{version}"`;
     background: var(--surface-2);
   }
 
-  .release-ledger td {
+  .exclusion-ledger td {
     padding: var(--sp-md);
     border-bottom: 1px solid var(--line-soft);
   }
 
-  .release-ledger tbody tr:last-child td {
+  .exclusion-ledger tbody tr:last-child td {
     border-bottom: none;
   }
 
-  .release-ledger td:first-child {
+  .exclusion-ledger td:first-child {
     color: var(--brass);
   }
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -21,19 +21,19 @@ tag-format = "{name}-v{version}"`;
 ---
 
 <Base
-  title="Trellis — the missing Gleam workspace"
-  description="One binary gives Gleam monorepos task fan-out, dependency-graph introspection, changelogs, versioning, and publish orchestration — all derived from gleam.toml."
+  title="Trellis — a Gleam workspace manager"
+  description="Trellis is a single binary for task fan-out, dependency-graph introspection, changelogs, versioning, and publish orchestration in multi-package Gleam repositories."
 >
   <!-- ============ HERO ============ -->
   <section class="hero">
     <div class="shell hero-grid">
       <div class="hero-copy">
         <h1>
-          Gleam has no workspace concept.
-          <em>Trellis is it.</em>
+          Workspace tooling for multi-package Gleam repositories.
+          <em>Derived from gleam.toml.</em>
         </h1>
         <p class="lead">
-          One binary gives a Gleam monorepo task fan-out, dependency-graph
+          Trellis is one binary for task fan-out, dependency-graph
           introspection, changelogs, versioning, and publish orchestration —
           all derived from the <code>gleam.toml</code> files you already have.
         </p>
@@ -57,7 +57,7 @@ tag-format = "{name}-v{version}"`;
 <span class="name">examples</span> <span class="dim">(0.0.0)</span>
 <span class="dim">  └─</span> lat_cli</code></pre>
         <figcaption class="term-note">
-          Real output. The graph is computed from path dependencies — never declared.
+          Real output. Trellis computes the graph from path dependencies.
         </figcaption>
       </figure>
     </div>
@@ -67,11 +67,11 @@ tag-format = "{name}-v{version}"`;
   <section class="glue">
     <div class="shell">
       <div class="section-head">
-        <h2>You're maintaining glue by hand.</h2>
+        <h2>A real repository before trellis.</h2>
         <p>
-          Without workspaces, every multi-package Gleam repo rebuilds the same
-          machinery out of bash loops, YAML blocks, and duplicated config.
-          This ledger is from a real workspace, before trellis:
+          Multi-package repositories can accumulate workspace glue in bash
+          loops, YAML blocks, and duplicated config. This ledger comes from one
+          Gleam repository before it adopted trellis:
         </p>
       </div>
       <div class="ledger-scroll">
@@ -80,7 +80,7 @@ tag-format = "{name}-v{version}"`;
             <tr>
               <th scope="col">Where it lives</th>
               <th scope="col">What's maintained by hand</th>
-              <th scope="col">How it fails</th>
+              <th scope="col">What can drift</th>
             </tr>
           </thead>
           <tbody>
@@ -113,8 +113,8 @@ tag-format = "{name}-v{version}"`;
         </table>
       </div>
       <p class="ledger-coda">
-        Every row in that table is <strong>derivable</strong> from one file
-        format the ecosystem already uses.
+        Trellis derives the information behind each row from
+        <code>gleam.toml</code>, a file format the ecosystem already uses.
       </p>
     </div>
   </section>
@@ -124,8 +124,8 @@ tag-format = "{name}-v{version}"`;
     <div class="shell">
       <blockquote class="doctrine">
         <p>
-          Configure nothing that can be derived.<br />
-          Verify anything that must be duplicated.
+          Trellis derives what it can.<br />
+          It verifies what must remain explicit.
         </p>
       </blockquote>
       <div class="derived-grid">
@@ -164,9 +164,9 @@ tag-format = "{name}-v{version}"`;
       <div class="section-head">
         <h2>One workspace. Different task sets.</h2>
         <p>
-          Examples, benchmarks, and internal tools belong in the workspace:
-          they should build, test, and appear in the graph, but they may not
-          need generated docs or a release on Hex.
+          Examples, benchmarks, and internal tools can remain workspace members
+          for builds, tests, and graphing without needing generated docs or a
+          release on Hex.
         </p>
         <p>
           In 0.2.0, <code>exclude</code> gives each built-in or custom task its
@@ -223,7 +223,7 @@ tag-format = "{name}-v{version}"`;
   <section class="lifecycle">
     <div class="shell">
       <div class="section-head">
-        <h2>One binary, the whole lifecycle.</h2>
+        <h2>One binary across the lifecycle.</h2>
         <p>
           The same tool runs locally and in CI. Commands work from anywhere in
           the workspace — the root is found by walking up, like
@@ -267,12 +267,11 @@ tag-format = "{name}-v{version}"`;
   <section class="drift">
     <div class="shell drift-stack">
       <div class="section-head">
-        <h2>It fails loudly on drift.</h2>
+        <h2>Checks for drift.</h2>
         <p>
           Some things can't be derived — locked versions, changelogs, tags,
-          toolchain pins. For those, <code>trellis doctor</code> verifies every
-          invariant that used to be enforced by hope, and exits non-zero the
-          moment one breaks.
+          toolchain pins. For those, <code>trellis doctor</code> checks the
+          invariants that remain explicit and exits non-zero when one breaks.
         </p>
       </div>
       <figure class="term">
@@ -295,11 +294,11 @@ tag-format = "{name}-v{version}"`;
   <section class="install" id="install">
     <div class="shell">
       <div class="section-head">
-        <h2>Install it in a second.</h2>
+        <h2>Install a prebuilt binary.</h2>
         <p>
-          One prebuilt binary — the same distribution model as
-          <code>just</code> and <code>ratchet</code>. Zero runtime
-          dependencies, SLSA build provenance, installs in CI in about a second.
+          Trellis has no runtime dependencies and includes SLSA build
+          provenance. Its shell installer typically completes in about a second
+          in CI.
         </p>
       </div>
       <dl class="channels">

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -188,7 +188,7 @@ kbd {
   letter-spacing: 0.01em;
 }
 
-.brand svg {
+.brand img {
   display: block;
 }
 


### PR DESCRIPTION
## Summary

- update the homepage and configuration reference for v0.2.0 task-scoped exclusions
- document the special `release` key and legacy `ignore-release` compatibility
- use the canonical favicon SVG for the shared site header logo

## Testing

- `pnpm --dir website build`
