### PR TITLE
feat: parse git dependencies and skip non-package glob matches

### DIFF
--- a/.changes/unreleased/Added-20260712-gitdeps.yaml
+++ b/.changes/unreleased/Added-20260712-gitdeps.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Parse git dependencies (`{ git = "...", ref = "..." }`) in member manifests as external requirements instead of failing with "neither a version nor a path".
+time: 2026-07-12T00:00:00.000000000-08:00

--- a/.changes/unreleased/Changed-20260712-globskip.yaml
+++ b/.changes/unreleased/Changed-20260712-globskip.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Wildcard member globs now skip directories without a gleam.toml (e.g. node_modules alongside packages); literal member paths still require one.
+time: 2026-07-12T00:00:01.000000000-08:00

--- a/src/gleam.rs
+++ b/src/gleam.rs
@@ -31,6 +31,10 @@ pub enum Requirement {
     Hex(String),
     /// A path dependency, relative to the package directory.
     Path(String),
+    /// A git dependency, e.g. `{ git = "https://...", ref = "..." }`.
+    /// External to the workspace, like a Hex dependency, but not
+    /// publishable to Hex as a runtime requirement.
+    Git(String),
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,6 +61,7 @@ enum RawDep {
     Detailed {
         path: Option<String>,
         version: Option<String>,
+        git: Option<String>,
     },
 }
 
@@ -81,8 +86,11 @@ impl GleamManifest {
                         version: Some(version),
                         ..
                     } => Requirement::Hex(version.clone()),
+                    RawDep::Detailed { git: Some(git), .. } => Requirement::Git(git.clone()),
                     RawDep::Detailed { .. } => {
-                        anyhow::bail!("dependency `{name}` has neither a version nor a path")
+                        anyhow::bail!(
+                            "dependency `{name}` has neither a version, a path, nor a git source"
+                        )
                     }
                 };
                 dependencies.push(Dependency {
@@ -111,7 +119,7 @@ impl GleamManifest {
             .iter()
             .filter_map(|dep| match &dep.requirement {
                 Requirement::Path(path) => Some((dep.name.as_str(), path.as_str(), dep.dev)),
-                Requirement::Hex(_) => None,
+                Requirement::Hex(_) | Requirement::Git(_) => None,
             })
     }
 }
@@ -182,6 +190,36 @@ mod tests {
                 ("lattice_testing", "../lattice_testing", true),
             ]
         );
+    }
+
+    #[test]
+    fn parses_git_deps_as_external() {
+        let manifest = GleamManifest::parse(
+            r#"
+            name = "beryl_mist"
+            version = "0.0.1"
+
+            [dependencies]
+            beryl = { path = "../beryl" }
+
+            [dev-dependencies]
+            aquamarine = { git = "https://github.com/tylerbutler/aquamarine.git", ref = "main" }
+            "#,
+        )
+        .unwrap();
+        let git_dep = manifest
+            .dependencies
+            .iter()
+            .find(|dep| dep.name == "aquamarine")
+            .unwrap();
+        assert_eq!(
+            git_dep.requirement,
+            Requirement::Git("https://github.com/tylerbutler/aquamarine.git".to_string())
+        );
+        assert!(git_dep.dev);
+        // Git deps are external: they never join the path-dependency graph.
+        let paths: Vec<_> = manifest.path_deps().collect();
+        assert_eq!(paths, vec![("beryl", "../beryl", false)]);
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -436,12 +436,20 @@ fn expand_member_globs(
             diagnostics.error(format!("member glob `{pattern}` is not valid UTF-8"));
             continue;
         };
+        // A literal member path is a promise that a package lives there, so a
+        // missing gleam.toml stays a hard error downstream. A wildcard pattern
+        // sweeps directories that merely live alongside packages (node_modules,
+        // asset dirs), so matches without a gleam.toml are skipped.
+        let is_wildcard = pattern.contains(['*', '?', '[']);
         let mut matched = 0usize;
         match glob::glob(full) {
             Ok(paths) => {
                 for entry in paths {
                     match entry {
                         Ok(path) if path.is_dir() => {
+                            if is_wildcard && !path.join(GLEAM_TOML).is_file() {
+                                continue;
+                            }
                             matched += 1;
                             dirs.insert(normalize_path(&path));
                         }
@@ -457,7 +465,7 @@ fn expand_member_globs(
             }
         }
         if matched == 0 {
-            diagnostics.error(format!("member glob `{pattern}` matches no directories"));
+            diagnostics.error(format!("member glob `{pattern}` matches no packages"));
         }
     }
     dirs.into_iter().collect()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -376,8 +376,28 @@ fn strict_load_fails_on_broken_workspace_but_names_doctor() {
         .arg("list")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("matches no directories"))
+        .stderr(predicate::str::contains("matches no packages"))
         .stderr(predicate::str::contains("trellis doctor"));
+}
+
+#[test]
+fn member_glob_skips_directories_without_gleam_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"pkgs/*\"]\n",
+    );
+    write(
+        &root.join("pkgs/a/gleam.toml"),
+        "name = \"a\"\nversion = \"0.1.0\"\n",
+    );
+    // Non-package clutter that a wildcard sweeps up (e.g. node_modules).
+    std::fs::create_dir_all(root.join("pkgs/node_modules")).unwrap();
+    let output = trellis(root).arg("list").assert().success();
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout).to_string();
+    assert!(stdout.contains("a"));
+    assert!(!stdout.contains("node_modules"));
 }
 
 // ---- ci --------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two workspace-loading fixes found while converting [beryl](https://github.com/tylerbutler/beryl) to a trellis monorepo:

- **Git dependencies parse as external requirements.** `{ git = "...", ref = "..." }` deps (supported by Gleam for dev/test helpers not on Hex) previously failed manifest parsing with *"dependency has neither a version nor a path"*, which dropped the whole package from the workspace graph and cascaded into bogus "path dependency is not a workspace member" errors for everything depending on it. They now parse as `Requirement::Git`, treated like Hex deps for graph purposes (never workspace members).

- **Wildcard member globs skip directories without a gleam.toml.** `members = ["examples/*"]` swept up non-package directories like a pnpm workspace's `node_modules` and errored. Wildcard matches without a manifest are now skipped; literal member paths still hard-error when the manifest is missing, since naming a path is a promise a package lives there. The empty-glob diagnostic now reads "matches no packages".

## Testing
- New unit test: git deps parse as `Requirement::Git` and stay out of `path_deps()`.
- New CLI test: `pkgs/node_modules` (no gleam.toml) is skipped by `pkgs/*`.
- `cargo test` (92 tests), `cargo clippy -- -D warnings`, `cargo fmt` all clean.
- Verified end-to-end against the beryl workspace (packages/* + examples/* with git dev-deps): `trellis doctor` passes.