### PR TITLE
docs: correct installer asset name to trellis-gleam-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ provenance attestations.
 **Shell installer** (Linux and macOS):
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/latest/download/trellis-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/latest/download/trellis-gleam-installer.sh | sh
 ```
 
 **PowerShell installer** (Windows):
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/tylerbutler/trellis/releases/latest/download/trellis-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/tylerbutler/trellis/releases/latest/download/trellis-gleam-installer.ps1 | iex"
 ```
 
 **Homebrew:**

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -24,7 +24,7 @@ Pin the version so CI doesn't move under you (see
   code={`- name: Install trellis
   run: |
     curl --proto '=https' --tlsv1.2 -LsSf \\
-      https://github.com/tylerbutler/trellis/releases/download/v${TRELLIS_VERSION}/trellis-installer.sh | sh
+      https://github.com/tylerbutler/trellis/releases/download/v${TRELLIS_VERSION}/trellis-gleam-installer.sh | sh
     # the installer adds its install dir to $GITHUB_PATH automatically`}
 />
 

--- a/website/src/content/docs/docs/installation.mdx
+++ b/website/src/content/docs/docs/installation.mdx
@@ -18,7 +18,7 @@ attestations attached to every release.
 On Linux and macOS:
 
 ```sh
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/latest/download/trellis-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/latest/download/trellis-gleam-installer.sh | sh
 ```
 
 ## PowerShell installer
@@ -26,7 +26,7 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/rel
 On Windows:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/tylerbutler/trellis/releases/latest/download/trellis-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/tylerbutler/trellis/releases/latest/download/trellis-gleam-installer.ps1 | iex"
 ```
 
 ## Homebrew
@@ -62,7 +62,7 @@ The installer URLs above resolve `latest`. To pin a specific version, replace
 
 <Code
   lang="sh"
-  code={`curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/download/v${TRELLIS_VERSION}/trellis-installer.sh | sh`}
+  code={`curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/download/v${TRELLIS_VERSION}/trellis-gleam-installer.sh | sh`}
 />
 
 Prebuilt archives for every target are on the

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,7 +4,7 @@ import Base from "../layouts/Base.astro";
 import { TRELLIS_VERSION } from "../lib/version";
 
 const installCmd =
-  "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/latest/download/trellis-installer.sh | sh";
+  "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/tylerbutler/trellis/releases/latest/download/trellis-gleam-installer.sh | sh";
 
 const miseCmd = `mise use "github:tylerbutler/trellis@${TRELLIS_VERSION}"`;
 


### PR DESCRIPTION
The install docs (README, installation.mdx, ci.mdx, landing page) point at `trellis-installer.sh`, but cargo-dist names release assets after the crate: `trellis-gleam-installer.sh` / `.ps1`. The documented curl commands 404 against v0.3.0 (verified; the corrected URL installs a working `trellis` 0.3.0 binary).