### PR TITLE
docs(website): explain trellis is opinionated but modular

### DIFF
--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -14,6 +14,32 @@ from manifests that already exist; the things that can't be derived — locked
 versions, changelogs, tags, toolchain pins — are checked by
 `trellis doctor`, which exits non-zero when an invariant breaks.
 
+## Opinionated, but modular
+
+Trellis has one way of doing each job: change fragments are TOML files in
+`.changes/unreleased/`, every releasable package gets its own git tag, and
+version bumps are derived from fragment kinds. Those opinions are what make
+derivation and verification possible — there's no plugin system to configure
+around them.
+
+The jobs themselves are independent. Every capability is a plain command,
+and nothing requires the piece above it, so you can adopt trellis a layer at
+a time:
+
+- **Just the task runner.** `run`, `exec`, `list`, and `graph` need only the
+  `members` glob. Keep your existing changelog tool and CI untouched.
+- **Add changelogs and versioning.** Fragments, `version plan`, and
+  `version apply` manage bumps and changelogs without trellis owning your
+  release workflow — or any CI at all.
+- **Add publishing.** `tag` and `publish` push to Hex in dependency order,
+  from your own scripts or workflows.
+- **The full pipeline.** `ci`, `changelog check`, and `release pr` turn
+  GitHub Actions workflows into thin triggers around trellis commands.
+
+Commands that feed automation emit structured JSON (`--json`,
+`trellis ci`), so any single piece slots into whatever tooling already
+surrounds it.
+
 ## Getting started
 
 1. [Install trellis](/docs/installation/) — a single prebuilt binary; shell

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -66,6 +66,47 @@ tag-format = "{name}-v{version}"`;
     </div>
   </section>
 
+  <!-- ============ OPINIONATED, BUT MODULAR ============ -->
+  <section class="adopt">
+    <div class="shell">
+      <div class="section-head">
+        <h2>Opinionated, but modular.</h2>
+        <p>
+          Trellis has one way of doing each job — TOML change fragments, a
+          tag per package, bumps derived from fragment kinds. But the jobs
+          are independent: nothing requires the piece above it, so you adopt
+          a layer at a time and keep whatever already works.
+        </p>
+      </div>
+      <ol class="adopt-paths">
+        <li>
+          <h3>Just the task runner</h3>
+          <p>
+            <code>run</code>, <code>exec</code>, <code>list</code>, and{" "}
+            <code>graph</code> need only the <code>members</code> glob. Your
+            changelog tool and CI stay untouched.
+          </p>
+        </li>
+        <li>
+          <h3>Add releases</h3>
+          <p>
+            Fragments, <code>version</code>, <code>tag</code>, and{" "}
+            <code>publish</code> manage changelogs, bumps, and Hex — from
+            your own scripts, or no CI at all.
+          </p>
+        </li>
+        <li>
+          <h3>The full pipeline</h3>
+          <p>
+            <code>ci</code>, <code>changelog check</code>, and{" "}
+            <code>release pr</code> turn GitHub Actions workflows into thin
+            triggers around trellis commands.
+          </p>
+        </li>
+      </ol>
+    </div>
+  </section>
+
   <!-- ============ THE GLUE ============ -->
   <section class="glue">
     <div class="shell">
@@ -708,6 +749,49 @@ tag-format = "{name}-v{version}"`;
     margin: 0;
     color: var(--muted);
     font-size: var(--text-small);
+  }
+
+  /* ---- opinionated, but modular ---- */
+  .adopt-paths {
+    list-style: none;
+    padding: 0;
+    margin-top: var(--sp-2xl);
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
+    gap: var(--sp-xl);
+    counter-reset: adopt;
+  }
+
+  .adopt-paths li {
+    counter-increment: adopt;
+    padding-top: var(--sp-sm);
+    border-top: 1px solid var(--line);
+  }
+
+  .adopt-paths h3 {
+    display: flex;
+    align-items: baseline;
+    gap: var(--sp-md);
+    font-size: var(--text-h3);
+  }
+
+  .adopt-paths h3::before {
+    content: counter(adopt);
+    font-family: var(--font-mono);
+    font-size: var(--text-small);
+    font-weight: 640;
+    color: var(--brass);
+  }
+
+  .adopt-paths p {
+    margin-top: var(--sp-sm);
+    color: var(--muted);
+    font-size: var(--text-small);
+  }
+
+  .adopt-paths code {
+    color: var(--ink-soft);
+    font-size: 0.9em;
   }
 
   /* ---- drift / doctor ---- */


### PR DESCRIPTION
## What

Adds an "Opinionated, but modular" message to the website in two places:

- **Landing page** (`src/pages/index.astro`) — a new section directly after the hero. Headline plus three numbered adoption paths: *Just the task runner* → *Add releases* → *The full pipeline*. Reuses the site's existing visual language (numbered columns, brass accents, mono code).
- **Docs overview** (`src/content/docs/docs/index.mdx`) — a matching subsection spelling out the same idea in more detail.

## Why

The core pitch: trellis is **opinionated** (one way to do each job — TOML change fragments, a tag per package, bumps derived from fragment kinds), and those fixed conventions are exactly what make derivation and verification possible. But the capabilities are **modular** — nothing requires the layer above it, so you can adopt trellis a piece at a time and keep whatever already works (e.g. use it purely as a task runner without its changelog or CI features).

## Verification

- `pnpm build` passes (9 pages).
- Verified the new landing-page section renders correctly in the browser and matches the existing design.