### PR TITLE
fix(release): use lowercase release: type in PR title

### DIFF
--- a/.changes/unreleased/Fixed-20260716-release-pr-title.yaml
+++ b/.changes/unreleased/Fixed-20260716-release-pr-title.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Release PR title now uses a lowercase `release:` type so it passes conventional-commit / commitlint PR-title checks (matching the release commit message).
+time: 2026-07-16T00:00:00.000000000-00:00

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -67,7 +67,7 @@ fn build_release_commit_and_pr(
         .map(|entry| format!("{} v{}", entry.name, entry.next))
         .collect::<Vec<_>>()
         .join(", ");
-    let title = format!("Release: {summary}");
+    let title = format!("release: {summary}");
 
     git_stdout(root, &["add", "-A"])?;
     let mut commit_args = crate::git::identity_fallback_args(root);

--- a/tests/new_and_release.rs
+++ b/tests/new_and_release.rs
@@ -265,7 +265,7 @@ fn release_pr_creates_then_updates_the_pull_request() {
     // including the changelog section the native engine just rendered.
     let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
     assert!(log.contains("pr create --base main --head release/pending"));
-    assert!(log.contains("--title Release: lat_core v1.3.0"));
+    assert!(log.contains("--title release: lat_core v1.3.0"));
     assert!(log.contains("| lat_core | 1.2.0 | 1.3.0 | 1 |"));
     assert!(
         log.contains("- pending change"),
@@ -323,7 +323,7 @@ fn release_pr_creates_then_updates_the_pull_request() {
         .success()
         .stdout(predicate::str::contains("updated release PR #42"));
     let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert!(log.contains("pr edit 42 --title Release: lat_core v"));
+    assert!(log.contains("pr edit 42 --title release: lat_core v"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

`trellis release pr` stamps a lowercase `release:` type on the release **commit** message but a capitalized `Release:` on the **PR title** (`src/commands/release.rs:70`). The capitalized title fails conventional-commit / commitlint PR-title checks:

```
✖  type must be lower-case [type-case]
✖  type must be one of [feat, fix, docs, ...] [type-enum]
```

This surfaced on a downstream repo (beryl) whose PR-title check rejects every trellis-generated release PR.

## Fix

Use `release:` (lowercase) for the PR title too, matching the release commit message. One-line change plus the two test assertions that pinned the old title.

## Testing

`cargo test --test new_and_release` → 8 passed.