### PR TITLE
feat: configless workspaces and git-based member auto-discovery

### DIFF
--- a/.changes/unreleased/Added-20260718-configless-discovery.yaml
+++ b/.changes/unreleased/Added-20260718-configless-discovery.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Configless workspaces and member auto-discovery: `members` in `[tools.trellis]` is now optional — when omitted, every non-gitignored `gleam.toml` in the repository (outside `build/`) marks a member, and with no `[tools.trellis]` table anywhere the git repository root becomes the workspace root with an entirely defaulted configuration. A new reserved `exclude` key, `@members`, removes directories from workspace membership entirely (e.g. committed test fixtures), in both auto-discovered and explicit-members modes. `doctor` announces inferred roots and auto-discovered member counts.'
+time: 2026-07-18T00:00:00.000000000-00:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,10 +233,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
 
 [[package]]
 name = "difflib"
@@ -310,6 +376,12 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -472,6 +544,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +673,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -776,6 +863,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +1010,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -1021,6 +1116,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "ureq",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -1096,6 +1192,43 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vergen"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ lto = "thin"
 
 [dependencies]
 anyhow = "1.0.103"
-clap = { version = "4.6.1", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive", "string"] }
 clap-markdown = "0.1.5"
 glob = "0.3.3"
 globset = "0.4.18"
@@ -44,3 +44,6 @@ ureq = { version = "3.3.0", features = ["json"] }
 assert_cmd = "2.2.2"
 predicates = "3.1.4"
 tempfile = "3.27.0"
+
+[build-dependencies]
+vergen-gitcl = "9.1.0"

--- a/README.md
+++ b/README.md
@@ -76,17 +76,27 @@ specific version in CI by replacing `latest/download` with
 
 ## Configuration
 
-A `[tools.trellis]` table in a `gleam.toml` marks the workspace root — no
-separate config file. The root manifest may be config-only, or a regular
-gleam package that also anchors the workspace. Only `members` is required:
+Configuration is optional. With no configuration at all, the git repository
+root is the workspace root and every non-gitignored `gleam.toml` (outside
+`build/`) marks a member — a fresh Gleam monorepo, or a single-package repo,
+works with zero setup.
+
+When you need to configure something, a `[tools.trellis]` table in a
+`gleam.toml` marks the workspace root — no separate config file. The root
+manifest may be config-only, or a regular gleam package that also anchors the
+workspace. Every key is optional, including `members`: omit it to keep
+auto-discovering members from git while configuring everything else:
 
 ```toml
 # gleam.toml at the repo root
 [tools.trellis]
+# Optional: pin membership to explicit globs instead of auto-discovery.
 members = ["packages/*", "examples/*"]
 # Exclusions are globbed against member paths and scoped by task. The
 # reserved `@release` key covers changelog, versioning, tagging, and
-# publishing; the `@` prefix keeps it from ever colliding with a task name.
+# publishing; `@members` removes directories from membership entirely
+# (e.g. committed test fixtures that auto-discovery would sweep in); the
+# `@` prefix keeps them from ever colliding with a task name.
 exclude = { docs = ["examples/*"], "@release" = ["examples/*"] }
 
 # Custom tasks for `trellis run <name>`. Built-in verbs (build, test, check,
@@ -108,7 +118,9 @@ error (it would hijack root discovery).
 
 Every command works from anywhere inside the workspace (the root is found by
 walking up to the first `gleam.toml` with a `[tools.trellis]` table, like
-`git` or `cargo` — member manifests along the way are skipped).
+`git` or `cargo` — member manifests along the way are skipped). Without a
+`[tools.trellis]` table anywhere, the git repository root is the workspace
+root and members are auto-discovered.
 
 ### Introspection
 
@@ -151,9 +163,10 @@ docs = ["examples/*", "packages/internal-*"]
 ```
 
 The reserved `@release` key defines the package set used by changelog,
-version, tag, and publish commands. Special keys use a `@` prefix so they
-can never collide with a task name — trellis rejects any task named with
-that prefix.
+version, tag, and publish commands, and `@members` removes directories from
+workspace membership entirely (in both auto-discovered and explicit-members
+modes). Special keys use a `@` prefix so they can never collide with a task
+name — trellis rejects any task named with that prefix.
 
 ### Changelog & versioning
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+//! Embeds `VERGEN_GIT_*` env vars so dev builds can report the commit they
+//! were built from. The default emitter degrades to placeholder values when
+//! git metadata is unavailable (e.g. a crates.io tarball), so builds never
+//! fail on missing git.
+
+use vergen_gitcl::{Emitter, GitclBuilder};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let gitcl = GitclBuilder::default()
+        .describe(true, true, None)
+        .sha(true)
+        .dirty(true)
+        .build()?;
+    Emitter::default().add_instructions(&gitcl)?.emit()?;
+    Ok(())
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -85,9 +85,20 @@ starts by loading the **workspace model**:
    first `gleam.toml` with a `[tools.trellis]` table (so commands work from
    inside a package, like `git` or `cargo` — member manifests along the way
    are skipped, and a `[tools.trellis]` table in a member manifest is a
-   doctor error because it would hijack this walk).
+   doctor error because it would hijack this walk). When no manifest up the
+   tree has the table, trellis runs configless: the enclosing git repository
+   root becomes the workspace root with an entirely defaulted configuration.
+   An unparseable ancestor manifest blocks this fallback — it may be the
+   intended root hiding behind a syntax error, and guessing would silently
+   change discovery modes.
 2. Expand `members` globs into package directories; parse each `gleam.toml` for
-   `name`, `version`, and dependencies.
+   `name`, `version`, and dependencies. When `members` is omitted (or there is
+   no config at all), members are auto-discovered instead: every non-gitignored
+   `gleam.toml` in the repository — tracked or untracked, outside `build/` —
+   marks a member, and the reserved `@members` exclusion key removes
+   directories from membership entirely (committed test fixtures, say, which
+   gitignore cannot hide). A config-only root manifest (no `name`) is never
+   itself a member.
 3. Build the dependency graph from path dependencies between members. Reject cycles
    and path deps that point outside the workspace with a clear error.
 4. Compute the topological order once; every other command consumes it.
@@ -97,8 +108,13 @@ starts by loading the **workspace model**:
 The `[tools.trellis]` table of the root `gleam.toml` is the single source of
 configured truth, and stays small. There is no separate config file: the
 workspace marker lives in the manifest format the ecosystem already uses
-(the root manifest may be config-only or also a regular package). Schema
-(everything except `members` optional, with the defaults shown):
+(the root manifest may be config-only or also a regular package). The table
+itself is optional — configuration is a graduated ladder: no config at all
+(git-inferred root, auto-discovered members), a table without `members`
+(auto-discovery plus exclusions, tasks, and release settings), or explicit
+`members` globs pinning the set down. Schema (everything optional, with the
+defaults shown; omitting `members` auto-discovers, an explicitly empty list
+is an error):
 
 ```toml
 # gleam.toml at the workspace root

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -58,6 +58,10 @@ struct Report {
     warnings: Vec<String>,
     fixes: Vec<Fix>,
     members: usize,
+    /// No [tools.trellis] anywhere; the root was inferred from git.
+    configless: bool,
+    /// `members` is not configured; the member list came from git.
+    auto_members: bool,
 }
 
 impl Report {
@@ -84,6 +88,8 @@ fn inspect(root: &Path) -> Result<Report> {
 
     if let Some(workspace) = &workspace {
         report.members = workspace.members.len();
+        report.configless = workspace.configless;
+        report.auto_members = workspace.config.members.is_none();
         check_exclusions(workspace, &mut report);
         check_tag_collisions(workspace, &mut report);
         check_lockfiles(workspace, &mut report);
@@ -145,6 +151,20 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
 }
 
 fn print_findings(report: &Report) {
+    // Auto-discovery leaves no file saying "this is the workspace", so doctor
+    // states the inference instead of leaving it invisible.
+    if report.configless {
+        println!(
+            "note: no [tools.trellis] configuration found; workspace root inferred from git, \
+             {} member(s) auto-discovered",
+            report.members
+        );
+    } else if report.auto_members {
+        println!(
+            "note: `members` is not configured; {} member(s) auto-discovered from git",
+            report.members
+        );
+    }
     for warning in &report.warnings {
         println!("warning: {warning}");
     }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -67,27 +67,48 @@ pub fn run(workspace: &Workspace, options: &NewOptions) -> Result<()> {
         format!("{parent}/{name}")
     };
 
-    // A directory no members glob matches would be silently invisible to
-    // every other command — exactly the drift trellis exists to prevent.
-    let matched = workspace.config.members.iter().any(|pattern| {
-        glob::Pattern::new(pattern)
-            .map(|p| {
-                p.matches_with(
-                    &rel_path,
-                    glob::MatchOptions {
-                        require_literal_separator: true,
-                        ..Default::default()
-                    },
-                )
-            })
-            .unwrap_or(false)
-    });
-    if !matched {
-        bail!(
-            "`{rel_path}` does not match any members glob in [tools.trellis] ({}); \
-             pass a different --path or add a glob first",
-            workspace.config.members.join(", ")
-        );
+    // A directory that discovery won't pick up would be silently invisible to
+    // every other command — exactly the drift trellis exists to prevent. With
+    // explicit `members`, a glob must match; with auto-discovery, any
+    // gleam.toml is found, so only an `@members` exclusion can hide it.
+    if let Some(member_globs) = &workspace.config.members {
+        let matched = member_globs.iter().any(|pattern| {
+            glob::Pattern::new(pattern)
+                .map(|p| {
+                    p.matches_with(
+                        &rel_path,
+                        glob::MatchOptions {
+                            require_literal_separator: true,
+                            ..Default::default()
+                        },
+                    )
+                })
+                .unwrap_or(false)
+        });
+        if !matched {
+            bail!(
+                "`{rel_path}` does not match any members glob in [tools.trellis] ({}); \
+                 pass a different --path or add a glob first",
+                member_globs.join(", ")
+            );
+        }
+    } else if let Some(patterns) = workspace
+        .config
+        .exclude
+        .get(crate::config::MEMBERS_EXCLUDE_KEY)
+    {
+        let excluded = patterns.iter().any(|pattern| {
+            glob::Pattern::new(pattern)
+                .map(|p| p.matches(&rel_path))
+                .unwrap_or(false)
+        });
+        if excluded {
+            bail!(
+                "`{rel_path}` matches an `{}` exclusion glob, so the new package would be \
+                 invisible to trellis; pass a different --path or adjust the exclusion",
+                crate::config::MEMBERS_EXCLUDE_KEY
+            );
+        }
     }
 
     let dir = crate::workspace::normalize_path(&workspace.root.join(&rel_path));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,17 @@
 //! Schema for the `[tools.trellis]` table of the workspace root's
 //! `gleam.toml` — the single source of configured (not derived) workspace
 //! facts, living in the manifest format the ecosystem already uses.
-//! Everything except `members` is optional.
+//! Everything is optional: when `members` is omitted, workspace members are
+//! auto-discovered from git (every non-ignored `gleam.toml`), and when the
+//! whole table is absent trellis runs configless with the same discovery.
 
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::path::Path;
 
-/// Prefix reserved for special `exclude` keys (currently just
-/// [`RELEASE_EXCLUDE_KEY`]) so they can never collide with a task name —
+/// Prefix reserved for special `exclude` keys ([`RELEASE_EXCLUDE_KEY`] and
+/// [`MEMBERS_EXCLUDE_KEY`]) so they can never collide with a task name —
 /// built-in verbs and `[tools.trellis.tasks]` entries may not start with it.
 pub const RESERVED_PREFIX: &str = "@";
 
@@ -17,11 +19,21 @@ pub const RESERVED_PREFIX: &str = "@";
 /// tagging, and publishing, rather than from a single task.
 pub const RELEASE_EXCLUDE_KEY: &str = "@release";
 
+/// The `exclude` key whose globs remove directories from workspace membership
+/// entirely — they are never parsed, graphed, or touched by any command.
+/// Applies to explicit `members` globs and to auto-discovered members alike.
+pub const MEMBERS_EXCLUDE_KEY: &str = "@members";
+
+/// All special `exclude` keys, for validation and error messages.
+pub const RESERVED_EXCLUDE_KEYS: [&str; 2] = [RELEASE_EXCLUDE_KEY, MEMBERS_EXCLUDE_KEY];
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct ConfigFile {
     /// Glob array matched against directories relative to the workspace root.
-    pub members: Vec<String>,
+    /// When omitted, members are auto-discovered: every non-gitignored
+    /// `gleam.toml` in the repository (outside `build/`) marks a member.
+    pub members: Option<Vec<String>>,
     /// Per-task glob arrays matched against member paths. Keys are task names
     /// (built-in verbs or `[tools.trellis.tasks]` entries), except the
     /// reserved [`RELEASE_EXCLUDE_KEY`] (`@release`), whose globs exclude
@@ -249,10 +261,28 @@ impl ConfigFile {
         Ok(config)
     }
 
-    /// Reject task names that could collide with a reserved `exclude` key
-    /// (currently just `@release`), and any `exclude` key that misuses the
-    /// reserved prefix without being one.
+    /// The synthesized configuration for a workspace with no `[tools.trellis]`
+    /// table anywhere: members auto-discovered, everything else defaulted.
+    pub fn configless() -> Self {
+        Self {
+            members: None,
+            exclude: BTreeMap::new(),
+            tasks: BTreeMap::new(),
+            publish: PublishConfig::default(),
+            changelog: ChangelogConfig::default(),
+        }
+    }
+
+    /// Reject an explicitly empty `members` list (omit it to auto-discover),
+    /// task names that could collide with a reserved `exclude` key, and any
+    /// `exclude` key that misuses the reserved prefix without being one.
     fn validate(&self) -> Result<()> {
+        if self.members.as_ref().is_some_and(Vec::is_empty) {
+            bail!(
+                "`members` is empty; remove the key entirely to auto-discover members, \
+                 or list at least one glob"
+            );
+        }
         for name in self.tasks.keys() {
             if name.starts_with(RESERVED_PREFIX) {
                 bail!(
@@ -262,9 +292,12 @@ impl ConfigFile {
             }
         }
         for key in self.exclude.keys() {
-            if key.starts_with(RESERVED_PREFIX) && key != RELEASE_EXCLUDE_KEY {
+            if key.starts_with(RESERVED_PREFIX) && !RESERVED_EXCLUDE_KEYS.contains(&key.as_str()) {
                 bail!(
-                    "unknown reserved `exclude` key `{key}`; did you mean `{RELEASE_EXCLUDE_KEY}`?"
+                    "unknown reserved `exclude` key `{key}`; the special keys are {}",
+                    RESERVED_EXCLUDE_KEYS
+                        .map(|reserved| format!("`{reserved}`"))
+                        .join(" and ")
                 );
             }
         }
@@ -313,7 +346,7 @@ mod tests {
             ]
         "###;
         let config = ConfigFile::from_gleam_toml(text).unwrap();
-        assert_eq!(config.members.len(), 2);
+        assert_eq!(config.members.as_deref().unwrap().len(), 2);
         assert_eq!(config.exclude["docs"], vec!["examples/*"]);
         assert_eq!(
             config.exclude[RELEASE_EXCLUDE_KEY],
@@ -350,6 +383,34 @@ mod tests {
             config.changelog.version_format,
             "## v{{ version }} - {{ date }}"
         );
+    }
+
+    #[test]
+    fn omitted_members_means_auto_discovery() {
+        let config = ConfigFile::from_gleam_toml(
+            "[tools.trellis]\nexclude = { \"@members\" = [\"tests/fixtures/*\"] }",
+        )
+        .unwrap();
+        assert!(config.members.is_none());
+        assert_eq!(
+            config.exclude[MEMBERS_EXCLUDE_KEY],
+            vec!["tests/fixtures/*"]
+        );
+    }
+
+    #[test]
+    fn empty_members_is_a_clear_error() {
+        let err = ConfigFile::from_gleam_toml("[tools.trellis]\nmembers = []").unwrap_err();
+        assert!(err.to_string().contains("auto-discover"), "{err:#}");
+    }
+
+    #[test]
+    fn configless_config_has_defaults_and_no_members() {
+        let config = ConfigFile::configless();
+        assert!(config.members.is_none());
+        assert!(config.exclude.is_empty());
+        assert!(config.tasks.is_empty());
+        assert_eq!(config.format_tag("core", "1.2.3"), "core-v1.2.3");
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,5 @@
-//! Git integration for `--since <ref>`: map changed files to the workspace
-//! members that own them.
+//! Git integration: map changed files to the workspace members that own them
+//! (`--since <ref>`), and enumerate manifests for member auto-discovery.
 
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
@@ -87,6 +87,41 @@ fn owning_member(workspace: &Workspace, file: &Path) -> Option<usize> {
         .filter(|(_, member)| file.starts_with(&member.path))
         .max_by_key(|(_, member)| member.path.components().count())
         .map(|(idx, _)| idx)
+}
+
+/// The git repository root containing `dir`, if any. `None` means `dir` is
+/// not inside a work tree (or git itself is unavailable).
+pub fn repo_root(dir: &Path) -> Option<PathBuf> {
+    git_stdout(dir, &["rev-parse", "--show-toplevel"])
+        .ok()
+        .map(|out| PathBuf::from(out.trim()))
+}
+
+/// Every non-gitignored `gleam.toml` under `cwd` — tracked and untracked
+/// alike, so freshly created packages are discovered before their first
+/// commit. Paths are relative to `cwd`.
+pub fn ls_gleam_manifests(cwd: &Path) -> Result<Vec<String>> {
+    // A plain pathspec wildcard matches across `/`, so `*gleam.toml` finds
+    // manifests at any depth; the basename filter drops accidental matches
+    // like `mygleam.toml`.
+    let text = git_stdout(
+        cwd,
+        &[
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "*gleam.toml",
+        ],
+    )?;
+    Ok(lines(&text)
+        .filter(|path| {
+            Path::new(path)
+                .file_name()
+                .is_some_and(|name| name == "gleam.toml")
+        })
+        .collect())
 }
 
 /// `-c user.name=... -c user.email=...` args to prepend to a git command that

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,13 +18,28 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use workspace::Workspace;
 
+/// Crate version, with `git describe` output appended for builds that aren't
+/// a clean release tag. "VERGEN_IDEMPOTENT_OUTPUT" is the placeholder build.rs
+/// emits when git metadata is unavailable (e.g. a crates.io tarball).
+fn version() -> String {
+    let base = env!("CARGO_PKG_VERSION");
+    match option_env!("VERGEN_GIT_DESCRIBE") {
+        Some(describe)
+            if describe != "VERGEN_IDEMPOTENT_OUTPUT" && describe != format!("v{base}") =>
+        {
+            format!("{base} ({describe})")
+        }
+        _ => base.to_string(),
+    }
+}
+
 /// A workspace CLI for Gleam monorepos: task fan-out, introspection, and
 /// release orchestration derived entirely from gleam.toml files — the
 /// workspace root's [tools.trellis] table and each member's manifest.
 /// Configure nothing that can be derived; verify anything that must be
 /// duplicated.
 #[derive(Parser)]
-#[command(name = "trellis", version, about, max_term_width = 100)]
+#[command(name = "trellis", version = version(), about, max_term_width = 100)]
 struct Cli {
     /// Run as if started in this directory.
     #[arg(short = 'C', long = "directory", global = true, value_name = "DIR")]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -133,9 +133,12 @@ impl Workspace {
         // configuration, its absence (or a missing manifest — a configless
         // git-root workspace) means everything is defaulted and discovered.
         let manifest_path = root.join(GLEAM_TOML);
-        let configless = match std::fs::read_to_string(&manifest_path) {
+        let (configless, root_is_package) = match std::fs::read_to_string(&manifest_path) {
             Ok(text) => match toml::from_str::<toml::Value>(&text) {
-                Ok(document) => !crate::config::has_trellis_table(&document),
+                Ok(document) => (
+                    !crate::config::has_trellis_table(&document),
+                    document.get("name").is_some(),
+                ),
                 Err(err) => {
                     diagnostics.error(format!(
                         "failed to parse {}: {err}",
@@ -144,7 +147,7 @@ impl Workspace {
                     return Ok((None, diagnostics));
                 }
             },
-            Err(_) => true,
+            Err(_) => (true, false),
         };
         let config = if configless {
             ConfigFile::configless()
@@ -162,6 +165,11 @@ impl Workspace {
             Some(globs) => expand_member_globs(root, globs, &mut diagnostics),
             None => discover_member_dirs(root, &mut diagnostics),
         };
+        // A config-only root manifest ([tools.trellis] without a `name`) is
+        // configuration, not a package — discovery must not sweep it in.
+        if config.members.is_none() && !root_is_package {
+            member_dirs.retain(|dir| dir != root);
+        }
 
         // Parse each member manifest; unparseable members are reported and dropped.
         for (task, patterns) in &config.exclude {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -32,6 +32,9 @@ impl Member {
 pub struct Workspace {
     pub root: PathBuf,
     pub config: ConfigFile,
+    /// True when no `[tools.trellis]` table exists anywhere: the root was
+    /// inferred from git and the configuration is entirely defaulted.
+    pub configless: bool,
     /// Members in topological order (dependencies before dependents).
     pub members: Vec<Member>,
     /// Direct workspace dependencies, indexed like `members`.
@@ -62,6 +65,12 @@ impl Workspace {
     /// `[tools.trellis]` table — the workspace root marker. Member manifests
     /// (gleam.toml without the table) are skipped, so commands work from
     /// inside a package, like `git` or `cargo`.
+    ///
+    /// When no manifest anywhere up the tree has the table, trellis runs
+    /// configless: the enclosing git repository root becomes the workspace
+    /// root and members are auto-discovered from git. An unparseable ancestor
+    /// manifest blocks the fallback — it may be the intended root hiding
+    /// behind a syntax error, and guessing would silently change modes.
     pub fn find_root(start: &Path) -> Result<PathBuf> {
         let start = start
             .canonicalize()
@@ -80,21 +89,26 @@ impl Workspace {
                 Err(_) => unparseable.push(manifest),
             }
         }
-        let mut message = format!(
-            "no {GLEAM_TOML} with a [tools.trellis] table found in {} or any parent directory",
-            start.display()
-        );
         if !unparseable.is_empty() {
-            message.push_str(&format!(
-                " (note: {} could not be parsed and may be the missing workspace root)",
+            bail!(
+                "no {GLEAM_TOML} with a [tools.trellis] table found in {} or any parent \
+                 directory, and {} could not be parsed and may be the intended workspace root",
+                start.display(),
                 unparseable
                     .iter()
                     .map(|p| p.display().to_string())
                     .collect::<Vec<_>>()
                     .join(", ")
-            ));
+            );
         }
-        bail!(message)
+        if let Some(root) = crate::git::repo_root(&start) {
+            return Ok(root);
+        }
+        bail!(
+            "no {GLEAM_TOML} with a [tools.trellis] table found in {} or any parent directory, \
+             and it is not inside a git repository (configless mode discovers members from git)",
+            start.display()
+        )
     }
 
     /// Strict load: any diagnostic error is fatal.
@@ -115,21 +129,59 @@ impl Workspace {
     /// coherent model exists (unreadable config or a dependency cycle).
     pub fn load_with_diagnostics(root: &Path) -> Result<(Option<Self>, Diagnostics)> {
         let mut diagnostics = Diagnostics::default();
-        let config = match ConfigFile::load(&root.join(GLEAM_TOML)) {
-            Ok(config) => config,
-            Err(err) => {
-                diagnostics.error(format!("{err:#}"));
-                return Ok((None, diagnostics));
+        // The root's gleam.toml decides the mode: a [tools.trellis] table is
+        // configuration, its absence (or a missing manifest — a configless
+        // git-root workspace) means everything is defaulted and discovered.
+        let manifest_path = root.join(GLEAM_TOML);
+        let configless = match std::fs::read_to_string(&manifest_path) {
+            Ok(text) => match toml::from_str::<toml::Value>(&text) {
+                Ok(document) => !crate::config::has_trellis_table(&document),
+                Err(err) => {
+                    diagnostics.error(format!(
+                        "failed to parse {}: {err}",
+                        manifest_path.display()
+                    ));
+                    return Ok((None, diagnostics));
+                }
+            },
+            Err(_) => true,
+        };
+        let config = if configless {
+            ConfigFile::configless()
+        } else {
+            match ConfigFile::load(&manifest_path) {
+                Ok(config) => config,
+                Err(err) => {
+                    diagnostics.error(format!("{err:#}"));
+                    return Ok((None, diagnostics));
+                }
             }
         };
 
-        let member_dirs = expand_member_globs(root, &config.members, &mut diagnostics);
+        let mut member_dirs = match &config.members {
+            Some(globs) => expand_member_globs(root, globs, &mut diagnostics),
+            None => discover_member_dirs(root, &mut diagnostics),
+        };
 
         // Parse each member manifest; unparseable members are reported and dropped.
         for (task, patterns) in &config.exclude {
             if let Err(err) = build_globset(patterns) {
                 diagnostics.error(format!("invalid `{task}` exclusion glob: {err:#}"));
             }
+        }
+
+        // `@members` removes directories from membership entirely, before
+        // their manifests are even parsed.
+        if let Some(patterns) = config.exclude.get(crate::config::MEMBERS_EXCLUDE_KEY)
+            && let Ok(excludes) = build_globset(patterns)
+        {
+            member_dirs.retain(|dir| !excludes.is_match(rel_path_string(root, dir)));
+        }
+        if member_dirs.is_empty() && diagnostics.errors.is_empty() {
+            diagnostics.error(format!(
+                "no workspace members left after `{}` exclusions",
+                crate::config::MEMBERS_EXCLUDE_KEY
+            ));
         }
 
         let release_exclusions = config
@@ -155,10 +207,19 @@ impl Workspace {
                     // A member manifest with its own [tools.trellis] would
                     // hijack root discovery for commands run inside it.
                     if manifest.has_trellis_config && dir != root {
-                        diagnostics.error(format!(
-                            "member `{rel_path}` has a [tools.trellis] table; only the workspace \
-                             root's gleam.toml may have one"
-                        ));
+                        if configless {
+                            diagnostics.error(format!(
+                                "`{rel_path}/gleam.toml` has a [tools.trellis] table but the \
+                                 workspace root was inferred as `{}`; run trellis from \
+                                 `{rel_path}`, or move the table to the repository root",
+                                root.display()
+                            ));
+                        } else {
+                            diagnostics.error(format!(
+                                "member `{rel_path}` has a [tools.trellis] table; only the \
+                                 workspace root's gleam.toml may have one"
+                            ));
+                        }
                     }
                     let releasable = release_excludes
                         .as_ref()
@@ -266,6 +327,7 @@ impl Workspace {
         let workspace = Workspace {
             root: root.to_path_buf(),
             config,
+            configless,
             members,
             deps,
             dependents,
@@ -470,6 +532,38 @@ fn expand_member_globs(
     dirs.into_iter().collect()
 }
 
+/// Auto-discovery: every directory owning a non-gitignored `gleam.toml` is a
+/// member. Gleam's `build/` tree is skipped unconditionally — it holds a
+/// manifest for every downloaded dependency, and while it is conventionally
+/// gitignored, membership must not hinge on that.
+fn discover_member_dirs(root: &Path, diagnostics: &mut Diagnostics) -> Vec<PathBuf> {
+    let manifests = match crate::git::ls_gleam_manifests(root) {
+        Ok(manifests) => manifests,
+        Err(err) => {
+            diagnostics.error(format!("cannot auto-discover members: {err:#}"));
+            return Vec::new();
+        }
+    };
+    let mut dirs = BTreeSet::new();
+    for manifest in &manifests {
+        let path = Path::new(manifest);
+        if path.components().any(|c| c.as_os_str() == "build") {
+            continue;
+        }
+        let dir = path.parent().unwrap_or(Path::new(""));
+        dirs.insert(normalize_path(&root.join(dir)));
+    }
+    if dirs.is_empty() {
+        diagnostics.error(format!(
+            "no members to auto-discover: no gleam.toml found under {} \
+             (gitignored paths are not searched); add packages, or configure \
+             `members` in a [tools.trellis] table",
+            root.display()
+        ));
+    }
+    dirs.into_iter().collect()
+}
+
 fn build_globset(patterns: &[String]) -> Result<globset::GlobSet> {
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in patterns {
@@ -498,10 +592,18 @@ pub fn normalize_path(path: &Path) -> PathBuf {
 
 fn rel_path_string(root: &Path, path: &Path) -> String {
     let rel = path.strip_prefix(root).unwrap_or(path);
-    rel.components()
+    let joined = rel
+        .components()
         .map(|c| c.as_os_str().to_string_lossy())
         .collect::<Vec<_>>()
-        .join("/")
+        .join("/");
+    // The root itself can be a member (a single-package repo under
+    // auto-discovery); "." keeps `{rel_path}/...` displays working.
+    if joined.is_empty() {
+        ".".to_string()
+    } else {
+        joined
+    }
 }
 
 #[cfg(test)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -624,6 +624,33 @@ fn since_selects_changed_packages_and_dependents() {
         .stdout("lat_core\nlat_mid\n");
 }
 
+// ---- version ---------------------------------------------------------
+
+#[test]
+fn version_appends_git_describe_on_dev_builds() {
+    let output = Command::cargo_bin("trellis")
+        .unwrap()
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let base = env!("CARGO_PKG_VERSION");
+
+    // Integration tests share the package's build-script env, so the same
+    // VERGEN_GIT_DESCRIBE the binary embedded is visible here.
+    match option_env!("VERGEN_GIT_DESCRIBE") {
+        // "VERGEN_IDEMPOTENT_OUTPUT" is vergen's fallback when git info is
+        // unavailable (e.g. building from a crates.io tarball).
+        Some(describe)
+            if describe != "VERGEN_IDEMPOTENT_OUTPUT" && describe != format!("v{base}") =>
+        {
+            assert_eq!(stdout.trim(), format!("trellis {base} ({describe})"));
+        }
+        _ => assert_eq!(stdout.trim(), format!("trellis {base}")),
+    }
+}
+
 fn copy_dir(from: &Path, to: &Path) {
     for entry in walk(from) {
         let rel = entry.strip_prefix(from).unwrap();

--- a/tests/configless.rs
+++ b/tests/configless.rs
@@ -1,0 +1,270 @@
+//! End-to-end tests for member auto-discovery: fully configless workspaces
+//! (no [tools.trellis] anywhere, root inferred from git), configured
+//! workspaces without `members`, and the `@members` exclusion key.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+fn trellis(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("trellis").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn git_init(root: &Path) {
+    let status = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(root)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "git init failed");
+}
+
+/// Two packages with a path dependency between them, no config anywhere.
+fn scaffold_two_packages(root: &Path) {
+    write(
+        &root.join("packages/core/gleam.toml"),
+        "name = \"core\"\nversion = \"1.0.0\"\n",
+    );
+    write(
+        &root.join("packages/cli/gleam.toml"),
+        "name = \"cli\"\nversion = \"0.1.0\"\n\n[dependencies]\ncore = { path = \"../core\" }\n",
+    );
+}
+
+// ---- fully configless (rung 1) ----------------------------------------
+
+#[test]
+fn configless_list_discovers_members_from_the_git_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+
+    // Nothing is committed: discovery must see untracked packages too.
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core\ncli\n");
+}
+
+#[test]
+fn configless_works_from_inside_a_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+
+    trellis(&root.join("packages/cli"))
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core\ncli\n");
+}
+
+#[test]
+fn configless_single_package_repo_has_the_root_as_member() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    write(
+        &root.join("gleam.toml"),
+        "name = \"solo\"\nversion = \"2.0.0\"\n",
+    );
+
+    let output = trellis(root).args(["list", "--json"]).output().unwrap();
+    assert!(output.status.success());
+    let items: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = items.as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["name"], "solo");
+    assert_eq!(items[0]["path"], ".");
+}
+
+#[test]
+fn configless_skips_gitignored_paths_and_build() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+    write(&root.join(".gitignore"), "vendor/\n");
+    write(
+        &root.join("vendor/dep/gleam.toml"),
+        "name = \"vendored\"\nversion = \"0.0.1\"\n",
+    );
+    // Gleam's build tree holds a manifest per downloaded dependency; it must
+    // never become a member even if it is not gitignored.
+    write(
+        &root.join("build/packages/wibble/gleam.toml"),
+        "name = \"wibble\"\nversion = \"0.9.0\"\n",
+    );
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core\ncli\n");
+}
+
+#[test]
+fn configless_doctor_announces_the_inference() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .stdout(predicate::str::contains(
+            "note: no [tools.trellis] configuration found; workspace root inferred from git, \
+             2 member(s) auto-discovered",
+        ));
+}
+
+#[test]
+fn configless_errors_on_a_stray_trellis_table() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+    write(
+        &root.join("nested/gleam.toml"),
+        "name = \"nested\"\nversion = \"0.1.0\"\n\n[tools.trellis]\n",
+    );
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("workspace root was inferred as"))
+        .stderr(predicate::str::contains("run trellis from `nested`"));
+}
+
+#[test]
+fn no_config_outside_a_git_repo_is_an_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    scaffold_two_packages(root);
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("not inside a git repository"));
+}
+
+#[test]
+fn unparseable_ancestor_manifest_blocks_the_configless_fallback() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+    write(&root.join("gleam.toml"), "name = \"broken\nversion=\n");
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("could not be parsed"));
+}
+
+// ---- configured but members omitted (rung 2) ---------------------------
+
+#[test]
+fn table_without_members_auto_discovers_and_keeps_exclusions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+    write(
+        &root.join("examples/demo/gleam.toml"),
+        "name = \"demo\"\nversion = \"0.0.1\"\n",
+    );
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nexclude = { \"@release\" = [\"examples/*\"] }\n",
+    );
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core\ncli\ndemo\n");
+    trellis(root)
+        .args(["list", "--releasable"])
+        .assert()
+        .success()
+        .stdout("core\ncli\n");
+}
+
+#[test]
+fn at_members_excludes_directories_from_membership() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+    // A committed fixture package: gitignore cannot exclude it, @members can.
+    write(
+        &root.join("tests/fixtures/sample/gleam.toml"),
+        "name = \"sample_fixture\"\nversion = \"0.0.1\"\n",
+    );
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nexclude = { \"@members\" = [\"tests/**\"] }\n",
+    );
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core\ncli\n");
+}
+
+#[test]
+fn at_members_also_filters_explicit_member_globs() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    scaffold_two_packages(root);
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\
+         exclude = { \"@members\" = [\"packages/cli\"] }\n",
+    );
+
+    // No git needed: explicit members never touch discovery.
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core\n");
+}
+
+#[test]
+fn new_package_is_discovered_without_a_members_glob() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    git_init(root);
+    scaffold_two_packages(root);
+
+    trellis(root)
+        .args(["new", "extra"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("created packages/extra/"));
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("extra\n"));
+}

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -1,23 +1,32 @@
 ---
 title: Configuration
-description: Trellis uses a [tools.trellis] table in gleam.toml to identify the workspace root. Only members is required.
+description: Trellis works with zero configuration; a [tools.trellis] table in gleam.toml identifies the workspace root when you need to configure anything.
 ---
 
 import Callout from "../../../components/Callout.astro";
 
-Trellis uses a `[tools.trellis]` table in a `gleam.toml` to identify the
-workspace root, so it does not need a separate config file. The root manifest
-may be config-only, or a regular Gleam package that also anchors the
-workspace. Only `members` is required; trellis derives the rest of its
-workspace model from the member manifests.
+Configuration is optional. With no configuration at all, the git repository
+root is the workspace root and every non-gitignored `gleam.toml` (outside
+`build/`) marks a member — a fresh Gleam monorepo, or a single-package repo,
+works with zero setup.
+
+When you need to configure something, trellis uses a `[tools.trellis]` table
+in a `gleam.toml` to identify the workspace root, so it does not need a
+separate config file. The root manifest may be config-only, or a regular
+Gleam package that also anchors the workspace. Every key is optional,
+including `members` — omit it to keep auto-discovering members from git while
+configuring everything else; trellis derives the rest of its workspace model
+from the member manifests.
 
 ```toml title="gleam.toml" wrap
 # gleam.toml at the repo root
 [tools.trellis]
+# Optional: pin membership to explicit globs instead of auto-discovery.
 members = ["packages/*", "examples/*"]
 # Exclusions are globbed against member paths and scoped by task. The
 # reserved `@release` key covers changelog, versioning, tagging, and
-# publishing; its `@` prefix keeps it from ever colliding with a task name.
+# publishing; `@members` removes directories from membership entirely; the
+# `@` prefix keeps them from ever colliding with a task name.
 exclude = { docs = ["examples/*"], "@release" = ["examples/*"] }
 
 # Custom tasks for `trellis run <name>`. Built-in verbs (build, test, check,
@@ -47,9 +56,10 @@ their roots.
 
 | Key | Required | What it does |
 | --- | --- | --- |
-| `members` | yes | Globs expanded into package directories. New packages join every command the moment their directory matches. |
+| `members` | no | Globs expanded into package directories. New packages join every command the moment their directory matches. When omitted, members are auto-discovered: every non-gitignored `gleam.toml` in the repository (outside `build/`) marks a member. An explicitly empty list is an error. |
 | `exclude.<task>` | no | Member-path globs omitted from that built-in or custom task. The exclusion still applies when a package is named explicitly. |
 | `exclude.@release` | no | The shared package set omitted from changelog, versioning, tagging, publishing, and release CI. The `@` prefix is reserved for special keys like this one, so it can never collide with a task name — task names may not start with `@`. |
+| `exclude.@members` | no | Directories removed from workspace membership entirely — never parsed, graphed, or touched by any command. Useful for committed test fixtures that auto-discovery would otherwise sweep in; also filters explicit `members` globs. |
 | `tasks.<name>` | no | Custom tasks for `trellis run`. A task with a built-in's name (`build`, `test`, …) overrides it. `needs-deps = true` downloads dependencies first. |
 | `publish.tag-format` | no | Template for per-member git tags. Default: `{name}-v{version}`. |
 | `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial-delay, multiplier }`. |
@@ -87,6 +97,7 @@ through `--since`.
 | `docs` | Matching members from `trellis run docs`. Built-in tasks can be filtered without overriding their commands. |
 | Any custom task name | Matching members from that `trellis run <name>` invocation. |
 | `@release` | Matching members from changelog, version, tag, publish, and release CI operations. Explicit changelog creation and publishing are rejected. |
+| `@members` | Matching directories from workspace membership itself — they are invisible to every command, as if they held no `gleam.toml` at all. |
 
 Release-excluded members remain in the dependency graph and still participate
 in `list`, `graph`, `exec`, and every task that does not exclude them. `info`

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -30,8 +30,9 @@ The jobs themselves are independent. Every capability is a plain command,
 and nothing requires the piece above it, so you can adopt trellis a layer at
 a time:
 
-- **Just the task runner.** `run`, `exec`, `list`, and `graph` need only the
-  `members` glob. Keep your existing changelog tool and CI untouched.
+- **Just the task runner.** `run`, `exec`, `list`, and `graph` need no
+  configuration at all — members are auto-discovered from git. Keep your
+  existing changelog tool and CI untouched.
 - **Add changelogs and versioning.** Fragments, `version plan`, and
   `version apply` manage bumps and changelogs without trellis owning your
   release workflow — or any CI at all.
@@ -48,8 +49,9 @@ surrounds it.
 
 1. [Install trellis](/docs/installation/) — a single prebuilt binary; shell
    installer, Homebrew, mise/asdf, or cargo.
-2. [Configure the workspace](/docs/configuration/) — one `[tools.trellis]`
-   table in `gleam.toml`; only `members` is required.
+2. [Configure the workspace](/docs/configuration/) if you need to — with no
+   configuration, members are auto-discovered from git; one optional
+   `[tools.trellis]` table in `gleam.toml` covers everything else.
 3. Run `trellis doctor` to verify the setup, then
    [run tasks](/docs/task-running/) across the workspace.
 


### PR DESCRIPTION
Makes configuration fully optional via a graduated discovery ladder:

1. **No `[tools.trellis]` anywhere** — `Workspace::find_root` falls back to the git repository root and members are auto-discovered, so any Gleam repo (monorepo or single-package) works with zero setup.
2. **Table present, `members` omitted** — `members` is now `Option`; when omitted, discovery stays automatic while exclusions, tasks, and publish/changelog settings remain configurable. An explicitly empty list is an error pointing at the omission alternative.
3. **Explicit `members` globs** — unchanged.

## Changes

- **`src/git.rs`**: new `repo_root` and `ls_gleam_manifests` (`git ls-files --cached --others --exclude-standard`), giving discovery exact gitignore semantics and picking up untracked packages before their first commit.
- **`src/workspace.rs`**: configless root fallback in `find_root` — an unparseable ancestor `gleam.toml` blocks it rather than silently changing modes; `load_with_diagnostics` detects the mode from the root manifest, synthesizes a default config when configless, and chooses glob expansion vs. `discover_member_dirs` (which unconditionally skips Gleam's `build/` tree, since it holds a manifest per downloaded dependency). A config-only root manifest (no `name`) is kept out of membership; a root that *is* a package becomes a member with `rel_path: "."`. A stray `[tools.trellis]` table found during discovery errors with a pointer to that directory.
- **`src/config.rs`**: new reserved `@members` exclude key removing directories from membership entirely (e.g. committed test fixtures that gitignore cannot hide); applies to both discovery modes. `ConfigFile::configless()` constructor; reserved-key validation generalized over `@release`/`@members`.
- **`src/commands/doctor.rs`**: announces inferred roots and auto-discovered member counts, since configless mode leaves no file marking the workspace.
- **`src/commands/new.rs`**: the members-glob check applies only with explicit `members`; under auto-discovery it instead rejects a destination an `@members` glob would hide, preserving the "no invisible packages" guarantee.
- Docs (README, DESIGN.md, website) updated for the ladder; changie fragment included.