### PR TITLE
fix: respect git ignores in member globs

### DIFF
--- a/.changes/unreleased/issue-21.yaml
+++ b/.changes/unreleased/issue-21.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Recursive member globs now respect repository Git ignore rules, preventing ignored build artifacts and vendored dependencies from being discovered as workspace members.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +515,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -776,6 +817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1062,7 @@ dependencies = [
  "clap-markdown",
  "glob",
  "globset",
+ "ignore",
  "minijinja",
  "predicates",
  "semver",
@@ -1113,6 +1164,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1186,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ clap = { version = "4.6.1", features = ["derive"] }
 clap-markdown = "0.1.5"
 glob = "0.3.3"
 globset = "0.4.18"
+ignore = "0.4.31"
 minijinja = "2.21.0"
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ members define the graph; cycles and path deps escaping the workspace are
 rejected, and a `[tools.trellis]` table in a *member* manifest is a doctor
 error (it would hijack root discovery).
 
+Member entries containing `*`, `?`, or `[` are wildcard patterns. In a Git
+repository, wildcard discovery honors repository `.gitignore` files at every
+level and `.git/info/exclude`. It does not read global `core.excludesFile`
+rules, generic `.ignore` files, or automatically exclude hidden paths, so
+results do not depend on machine-local Git configuration. Outside a Git
+repository, Git ignore rules do not apply. Traversal follows symlinks but never
+enters `.git`, and only matching directories with a `gleam.toml` become members.
+
+Entries without wildcard metacharacters are resolved directly, so an explicit
+literal path remains included even when Git ignores it. `[tools.trellis.exclude]`
+is a separate post-discovery filter: task and `@release` exclusions do not
+control traversal.
+
 ## Commands
 
 Every command works from anywhere inside the workspace (the root is found by

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -86,8 +86,10 @@ starts by loading the **workspace model**:
    inside a package, like `git` or `cargo` — member manifests along the way
    are skipped, and a `[tools.trellis]` table in a member manifest is a
    doctor error because it would hijack this walk).
-2. Expand `members` globs into package directories; parse each `gleam.toml` for
-   `name`, `version`, and dependencies.
+2. Expand `members` into package directories. Literal entries resolve directly;
+   wildcard entries use repository-aware traversal and retain only directories
+   containing `gleam.toml`. Parse each manifest for `name`, `version`, and
+   dependencies.
 3. Build the dependency graph from path dependencies between members. Reject cycles
    and path deps that point outside the workspace with a clear error.
 4. Compute the topological order once; every other command consumes it.
@@ -146,6 +148,15 @@ kinds = [
   { label = "Security", bump = "patch" },
 ]
 ```
+
+Wildcard discovery honors repository `.gitignore` files at every level and
+`.git/info/exclude`, but only when the workspace is in a Git repository. It
+deliberately ignores global `core.excludesFile` rules for reproducibility and
+generic `.ignore` files; hidden paths are traversed, symlinks are followed, and
+the `.git` directory itself is skipped. Literal member entries (those without
+`*`, `?`, or `[`) bypass ignore status and are resolved directly.
+`[tools.trellis.exclude]` is separate: task and `@release` exclusions filter
+the discovered member set afterward and never prune traversal.
 
 Notably absent, because derived: package lists, dependency order, per-package
 changelog wiring, version-file maps, path-dep rewrite maps, tag→package

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -429,6 +429,8 @@ fn expand_member_globs(
     diagnostics: &mut Diagnostics,
 ) -> Vec<PathBuf> {
     let mut dirs = BTreeSet::new();
+    let mut wildcard_patterns = Vec::new();
+
     for pattern in patterns {
         let full = root.join(pattern);
         let Some(full) = full.to_str() else {
@@ -440,33 +442,68 @@ fn expand_member_globs(
         // sweeps directories that merely live alongside packages (node_modules,
         // asset dirs), so matches without a gleam.toml are skipped.
         let is_wildcard = pattern.contains(['*', '?', '[']);
-        let mut matched = 0usize;
-        match glob::glob(full) {
-            Ok(paths) => {
-                for entry in paths {
-                    match entry {
-                        Ok(path) if path.is_dir() => {
-                            if is_wildcard && !path.join(GLEAM_TOML).is_file() {
-                                continue;
-                            }
-                            matched += 1;
-                            dirs.insert(normalize_path(&path));
+        if is_wildcard {
+            match glob::Pattern::new(full) {
+                Ok(matcher) => wildcard_patterns.push((pattern, matcher, 0usize)),
+                Err(err) => diagnostics.error(format!("invalid member glob `{pattern}`: {err}")),
+            }
+            continue;
+        }
+
+        let path = Path::new(full);
+        if path.is_dir() {
+            dirs.insert(normalize_path(path));
+        } else {
+            diagnostics.error(format!("member glob `{pattern}` matches no packages"));
+        }
+    }
+
+    if !wildcard_patterns.is_empty() {
+        let mut builder = ignore::WalkBuilder::new(root);
+        builder
+            .hidden(false)
+            .ignore(false)
+            .git_ignore(true)
+            .git_exclude(true)
+            .git_global(false)
+            .parents(true)
+            .require_git(true)
+            .follow_links(true)
+            .filter_entry(|entry| entry.depth() == 0 || entry.file_name() != ".git");
+
+        let match_options = glob::MatchOptions {
+            require_literal_separator: true,
+            ..Default::default()
+        };
+        for entry in builder.build() {
+            match entry {
+                Ok(entry)
+                    if entry
+                        .file_type()
+                        .is_some_and(|file_type| file_type.is_dir())
+                        && entry.path().join(GLEAM_TOML).is_file() =>
+                {
+                    for (_, matcher, matched) in &mut wildcard_patterns {
+                        if matcher.matches_path_with(entry.path(), match_options) {
+                            *matched += 1;
+                            dirs.insert(normalize_path(entry.path()));
                         }
-                        Ok(_) => {} // files can't be members
-                        Err(err) => diagnostics
-                            .warning(format!("while expanding member glob `{pattern}`: {err}")),
                     }
                 }
-            }
-            Err(err) => {
-                diagnostics.error(format!("invalid member glob `{pattern}`: {err}"));
-                continue;
+                Ok(_) => {}
+                Err(err) => {
+                    diagnostics.warning(format!("while expanding member globs: {err}"));
+                }
             }
         }
+    }
+
+    for (pattern, _, matched) in wildcard_patterns {
         if matched == 0 {
             diagnostics.error(format!("member glob `{pattern}` matches no packages"));
         }
     }
+
     dirs.into_iter().collect()
 }
 

--- a/tests/member_discovery.rs
+++ b/tests/member_discovery.rs
@@ -1,0 +1,109 @@
+//! End-to-end tests for workspace member discovery.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+
+fn trellis(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("trellis").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn write_package(root: &Path, path: &str, name: &str) {
+    write(
+        &root.join(path).join("gleam.toml"),
+        &format!("name = \"{name}\"\nversion = \"0.1.0\"\n"),
+    );
+}
+
+fn init_git(root: &Path) {
+    let status = std::process::Command::new("git")
+        .args(["init", "--quiet"])
+        .current_dir(root)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn recursive_member_glob_respects_repository_git_ignores() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    init_git(root);
+
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"examples/**\"]\n",
+    );
+    write(&root.join(".gitignore"), "build/\n");
+    write(&root.join(".git/info/exclude"), "scratch/\n");
+    write(
+        &root.join("examples/collab_docs/.gitignore"),
+        "generated/\n",
+    );
+
+    write_package(root, "examples/chatrooms", "chatrooms");
+    write_package(root, "examples/collab_docs/client", "collab_docs_client");
+    write_package(root, "examples/scratch", "scratch");
+    write_package(root, "examples/collab_docs/generated", "generated");
+
+    // These duplicate vendored packages reproduce issue #21 when build/
+    // directories are traversed.
+    write_package(root, "examples/chatrooms/build/packages/vendor", "vendor");
+    write_package(root, "examples/collab_docs/build/packages/vendor", "vendor");
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("chatrooms\ncollab_docs_client\n");
+}
+
+#[test]
+fn literal_member_path_includes_an_ignored_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    init_git(root);
+
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"generated/package\"]\n",
+    );
+    write(&root.join(".gitignore"), "generated/\n");
+    write_package(root, "generated/package", "generated_package");
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("generated_package\n");
+}
+
+#[test]
+fn wildcard_with_only_ignored_packages_reports_no_matches() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    init_git(root);
+
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"generated/**\"]\n",
+    );
+    write(&root.join(".gitignore"), "generated/\n");
+    write_package(root, "generated/package", "generated_package");
+
+    trellis(root)
+        .arg("list")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "member glob `generated/**` matches no packages",
+        ));
+}

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -34,6 +34,28 @@ Each member is a directory with its own `gleam.toml`. Path dependencies
 between members define the graph; cycles and path deps that escape the
 workspace are rejected with a clear error.
 
+## Member discovery
+
+`members` accepts paths relative to the workspace root. An entry containing
+`*`, `?`, or `[` is a wildcard member pattern; any other entry is literal.
+
+```toml title="gleam.toml"
+[tools.trellis]
+members = ["packages/core", "examples/**"]
+```
+
+In a Git repository, wildcard discovery honors nested `.gitignore` files and
+`.git/info/exclude`. It does not honor global `core.excludesFile`, generic
+`.ignore` files, or automatically hide dot paths. Outside a Git repository, Git
+ignore rules do not apply.
+
+Wildcard traversal follows symlinks but does not enter `.git`. Only matching
+directories that contain a `gleam.toml` become members. Literal entries bypass
+ignore status and are resolved directly, even when Git ignores the path.
+
+`[tools.trellis.exclude]` is a separate post-discovery filter. It can remove
+members from task or release package sets, but it never prunes traversal.
+
 <Callout>
 
 A `[tools.trellis]` table in a *member* manifest is a `doctor` error because
@@ -47,7 +69,7 @@ their roots.
 
 | Key | Required | What it does |
 | --- | --- | --- |
-| `members` | yes | Globs expanded into package directories. New packages join every command the moment their directory matches. |
+| `members` | yes | Literal directories and wildcard patterns relative to the workspace root. Entries containing `*`, `?`, or `[` use wildcard discovery; only matching directories with a `gleam.toml` become members. |
 | `exclude.<task>` | no | Member-path globs omitted from that built-in or custom task. The exclusion still applies when a package is named explicitly. |
 | `exclude.@release` | no | The shared package set omitted from changelog, versioning, tagging, publishing, and release CI. The `@` prefix is reserved for special keys like this one, so it can never collide with a task name — task names may not start with `@`. |
 | `tasks.<name>` | no | Custom tasks for `trellis run`. A task with a built-in's name (`build`, `test`, …) overrides it. `needs-deps = true` downloads dependencies first. |


### PR DESCRIPTION
## Summary
- use the `ignore` crate for Git-aware wildcard member discovery
- preserve explicit literal members and existing exclusion semantics
- document behavior in the README, design docs, and website
- add regression coverage for `.gitignore` and `.git/info/exclude`

Closes #21