### PR TITLE
feat: notify when a newer trellis release is available

### DIFF
--- a/.changes/unreleased/update-check.yaml
+++ b/.changes/unreleased/update-check.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Interactive commands now print a notice when a newer trellis has been published to crates.io. The check is cached for a day, runs only in a terminal, and is skipped in CI or when `DO_NOT_TRACK` / `TRELLIS_NO_UPDATE_CHECK` is set.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-update-check"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08be75869b99ec3d11258cbaa9ffe7bdab0ec339ce3303a1763c9a74a2655eca"
+dependencies = [
+ "semver",
+ "serde_json",
+ "ureq",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1080,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tiny-update-check",
  "toml",
  "toml_edit",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ minijinja = "2.21.0"
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+# Pure-Rust rustls (via the ureq we already depend on) instead of the default
+# native-tls, so release binaries stay OpenSSL-free per the zero-runtime-deps promise.
+tiny-update-check = { version = "1.1.3", default-features = false, features = ["rustls", "do-not-track"] }
 toml = "1.1.2"
 toml_edit = "0.25.12"
 ureq = { version = "3.3.0", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ Prebuilt archives for every target are on the
 specific version in CI by replacing `latest/download` with
 `download/v0.1.0` in the installer URL.
 
+### Update checks
+
+Interactive commands print a one-line notice to stderr when a newer trellis
+has been published to crates.io. The check is best-effort — cached for a day,
+capped at a short timeout, and silent on any error — so it never slows a
+command or changes its exit status. It runs only when stderr is a terminal, so
+scripts and structured output are never touched. It is additionally skipped in
+CI and when `DO_NOT_TRACK` or `TRELLIS_NO_UPDATE_CHECK` is set in the
+environment.
+
 ## Configuration
 
 A `[tools.trellis]` table in a `gleam.toml` marks the workspace root — no

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod lockfile;
 mod rewrite;
 mod runner;
 mod tools;
+mod update_check;
 mod workspace;
 
 use anyhow::Result;
@@ -293,7 +294,15 @@ enum CiCommand {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    match dispatch(cli) {
+    // Machine-consumed commands never get the interactive update notice, and it
+    // only prints when the command itself succeeded, so it never clutters error
+    // output or corrupts structured stdout.
+    let notify_update = !matches!(cli.command, Command::MarkdownHelp | Command::Ci { .. });
+    let result = dispatch(cli);
+    if notify_update && result.is_ok() {
+        update_check::notify();
+    }
+    match result {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
         Err(err) => {

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -45,7 +45,9 @@ fn notice_enabled(stderr_is_terminal: bool, env: impl Fn(&str) -> Option<String>
 /// Print a notice to stderr if a newer trellis has been published. Best-effort:
 /// returns quietly on any error or when suppressed.
 pub fn notify() {
-    if !notice_enabled(std::io::stderr().is_terminal(), |key| std::env::var(key).ok()) {
+    if !notice_enabled(std::io::stderr().is_terminal(), |key| {
+        std::env::var(key).ok()
+    }) {
         return;
     }
 
@@ -97,6 +99,9 @@ mod tests {
 
     #[test]
     fn suppressed_by_opt_out_env() {
-        assert!(!notice_enabled(true, env_from(&[("TRELLIS_NO_UPDATE_CHECK", "1")])));
+        assert!(!notice_enabled(
+            true,
+            env_from(&[("TRELLIS_NO_UPDATE_CHECK", "1")])
+        ));
     }
 }

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,102 @@
+//! Best-effort "a newer trellis is available" notice.
+//!
+//! The check hits crates.io for the published crate (`trellis-gleam`; the
+//! installed binary is `trellis`), caches the result for a day, and prints a
+//! notice to stderr when a newer version exists. It never blocks a command's
+//! own output and never turns a failure into an error — any problem (offline,
+//! slow network, unparseable response) is swallowed silently.
+//!
+//! It only runs for interactive humans: suppressed when stderr isn't a
+//! terminal, in CI, when `DO_NOT_TRACK` is set (handled by the crate), or when
+//! `TRELLIS_NO_UPDATE_CHECK` is set.
+
+use std::io::IsTerminal;
+use std::time::Duration;
+
+/// crates.io crate name. The binary is `trellis`, but the crate publishes as
+/// `trellis-gleam` (see Cargo.toml), so the version lives under that name.
+const CRATE_NAME: &str = "trellis-gleam";
+
+/// Where to point people once an update exists — the install docs cover every
+/// distribution channel (binary, Homebrew, mise), so it beats a bare
+/// `cargo install` line.
+const RELEASES_URL: &str = "https://github.com/tylerbutler/trellis/releases/latest";
+
+/// Cap the first-of-the-day network call so a slow crates.io can't hang the
+/// CLI. On a timeout the crate returns an error, we swallow it, and the next
+/// invocation simply tries again.
+const CHECK_TIMEOUT: Duration = Duration::from_millis(800);
+
+/// Decide whether an interactive update notice should even be attempted, given
+/// the terminal state and an environment lookup. Pure so it can be tested
+/// without touching the real environment. `DO_NOT_TRACK` is intentionally not
+/// checked here — the crate honors it internally and returns no update.
+fn notice_enabled(stderr_is_terminal: bool, env: impl Fn(&str) -> Option<String>) -> bool {
+    if !stderr_is_terminal {
+        return false;
+    }
+    // Empty values still count as "set" — `CI=` in a workflow means CI.
+    if env("CI").is_some() || env("TRELLIS_NO_UPDATE_CHECK").is_some() {
+        return false;
+    }
+    true
+}
+
+/// Print a notice to stderr if a newer trellis has been published. Best-effort:
+/// returns quietly on any error or when suppressed.
+pub fn notify() {
+    if !notice_enabled(std::io::stderr().is_terminal(), |key| std::env::var(key).ok()) {
+        return;
+    }
+
+    let checker = tiny_update_check::UpdateChecker::new(CRATE_NAME, env!("CARGO_PKG_VERSION"))
+        .timeout(CHECK_TIMEOUT);
+
+    if let Ok(Some(info)) = checker.check() {
+        eprintln!();
+        eprintln!(
+            "A new release of trellis is available: {} → {}",
+            info.current, info.latest
+        );
+        eprintln!("{RELEASES_URL}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key| map.get(key).cloned()
+    }
+
+    #[test]
+    fn enabled_for_interactive_terminal_without_ci() {
+        assert!(notice_enabled(true, env_from(&[])));
+    }
+
+    #[test]
+    fn suppressed_when_not_a_terminal() {
+        assert!(!notice_enabled(false, env_from(&[])));
+    }
+
+    #[test]
+    fn suppressed_in_ci() {
+        assert!(!notice_enabled(true, env_from(&[("CI", "true")])));
+    }
+
+    #[test]
+    fn suppressed_when_ci_is_set_but_empty() {
+        assert!(!notice_enabled(true, env_from(&[("CI", "")])));
+    }
+
+    #[test]
+    fn suppressed_by_opt_out_env() {
+        assert!(!notice_enabled(true, env_from(&[("TRELLIS_NO_UPDATE_CHECK", "1")])));
+    }
+}


### PR DESCRIPTION
## What

Integrates [`tiny-update-check`](https://github.com/tylerbutler/tiny-update-check) so interactive commands print a one-line notice to stderr when a newer trellis has been published to crates.io (the `trellis-gleam` crate).

```
A new release of trellis is available: 0.4.1 → 0.5.0
https://github.com/tylerbutler/trellis/releases/latest
```

## Design

- **Best-effort, never intrusive.** The check is cached for a day, capped at an 800ms timeout, and swallows every error — it can't slow a command or change its exit status. The notice prints only after the command *succeeds*.
- **Terminal-only.** Runs only when stderr is a terminal, so scripts, pipes, and structured (JSON / CI) output are never touched. `MarkdownHelp` and `ci` subcommands are excluded outright.
- **Opt-out.** Skipped in CI and when `DO_NOT_TRACK` or `TRELLIS_NO_UPDATE_CHECK` is set.
- **OpenSSL-free.** Uses the `rustls` feature routed through the `ureq` trellis already depends on (default `native-tls` is disabled), so release binaries keep the zero-runtime-deps promise. Net lockfile change: one crate.

## Changes

- `Cargo.toml` — add `tiny-update-check = "1.1.3"` (`rustls` + `do-not-track`, defaults off)
- `src/update_check.rs` (new) — `notify()` plus a pure `notice_enabled()` gate with 5 unit tests
- `src/main.rs` — call `notify()` after a successful dispatch, excluding machine-consumed commands
- `README.md` — new "Update checks" subsection documenting the behavior and opt-outs
- changelog fragment (`Added`)

## Verification

- `cargo build` clean, `cargo clippy --all-targets` clean
- Full suite passes (41 + integration), including the 5 new gating tests