### PR TITLE
feat: add live progress for parallel tasks

### DIFF
--- a/.changes/unreleased/Added-20260721-172539.yaml
+++ b/.changes/unreleased/Added-20260721-172539.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Interactive task runs now show live per-package progress rows with stable, hash-derived package colors while logs scroll above them; pipes and CI retain plain prefixed output.
+time: 2026-07-21T17:25:39.932763-07:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +366,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -622,6 +640,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,6 +772,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "potential_utf"
@@ -1180,6 +1216,7 @@ dependencies = [
  "glob",
  "globset",
  "ignore",
+ "indicatif",
  "minijinja",
  "predicates",
  "semver",
@@ -1198,6 +1235,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ clap-markdown = "0.1.5"
 glob = "0.3.3"
 globset = "0.4.18"
 ignore = "0.4.31"
+indicatif = { version = "0.18.6", default-features = false, features = ["unicode-width"] }
 minijinja = "2.21.0"
 semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -171,7 +171,10 @@ trellis exec [pkgs...] [--since <ref>] [--serial] [--keep-going] -- <command...>
 
 Scheduling is graph-parallel by default: a package runs as soon as its
 workspace dependencies have finished, up to `--jobs N` at once. Output is
-streamed with a `pkg ▏` prefix and a summary table names any failures.
+streamed with a `pkg ▏` prefix and a summary table names any failures. In an
+interactive terminal, active packages remain visible as live progress rows and
+package names use stable, hash-derived colors. Pipes and CI receive plain text
+without terminal control sequences.
 `--target all` runs the task once per compile target. `--serial` runs one
 package at a time in dependency order.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -213,8 +213,10 @@ trellis exec [pkgs...] -- <command...>
   (task names may not start with `@`).
 - Scheduling is **graph-parallel by default**: a package runs as soon as its
   workspace deps have finished, up to `--jobs N`. Output is streamed with a
-  `pkg ▏` prefix, followed by a summary table. The justfile's serial loops become
-  the `--serial` fallback.
+  `pkg ▏` prefix. Interactive terminals keep active packages in live progress
+  rows and use stable, hash-derived colors for package names; pipes and CI keep
+  the plain prefixed stream. A summary table follows. The justfile's serial
+  loops become the `--serial` fallback.
 - `--target all` runs the task once per target, replacing the `*-js` recipe
   duplication (`test-js`, `build-strict-js`, …).
 - Compound flows stay in just as one-liners, e.g.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,16 +1,21 @@
 //! Graph-parallel task scheduler: a package's job starts as soon as every
 //! selected package it (transitively) depends on has finished, up to
-//! `--jobs N` at once. Output is streamed with a `pkg ▏` prefix and a summary
-//! table is printed at the end.
+//! `--jobs N` at once. Interactive output keeps active jobs in live progress
+//! rows while logs scroll above; non-interactive output stays as a plain
+//! `pkg ▏`-prefixed stream. A summary table is printed at the end.
 
 use crate::workspace::Workspace;
 use anyhow::Result;
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, IsTerminal};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use std::sync::mpsc;
+use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
+
+const NAME_COLOR_CODES: &[u8] = &[31, 32, 33, 34, 35, 36, 91, 92, 93, 94, 95, 96];
+const SPINNER_TICKS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 #[derive(Debug, Clone)]
 pub struct CommandSpec {
@@ -66,6 +71,103 @@ pub struct RunOptions {
     pub keep_going: bool,
 }
 
+#[derive(Clone)]
+struct Output {
+    progress: Option<Arc<MultiProgress>>,
+    colors: bool,
+}
+
+impl Output {
+    fn new() -> Self {
+        let live =
+            std::io::stdout().is_terminal() && std::env::var("TERM").as_deref() != Ok("dumb");
+        Self {
+            progress: live
+                .then(|| Arc::new(MultiProgress::with_draw_target(ProgressDrawTarget::stdout()))),
+            colors: live
+                && std::env::var_os("NO_COLOR").is_none()
+                && std::env::var("CLICOLOR").as_deref() != Ok("0"),
+        }
+    }
+
+    fn start_job(&self, name: &str) -> JobDisplay {
+        let progress = self.progress.as_ref().map(|multi| {
+            let progress = multi.add(ProgressBar::new_spinner());
+            progress.set_style(
+                ProgressStyle::with_template(
+                    "{spinner:.cyan} {prefix}  {msg}  [{elapsed_precise}]",
+                )
+                .expect("progress template is valid")
+                .tick_strings(SPINNER_TICKS),
+            );
+            progress.set_prefix(self.format_name(name, name));
+            progress.set_message("starting");
+            progress.enable_steady_tick(Duration::from_millis(80));
+            progress
+        });
+        JobDisplay {
+            progress,
+            colors: self.colors,
+        }
+    }
+
+    fn emit(&self, name: &str, width: usize, line: &str) {
+        let padded = format!("{name:width$}");
+        let name = self.format_name(name, &padded);
+        self.println(format!("{name} ▏ {line}"));
+    }
+
+    fn println(&self, line: String) {
+        if let Some(progress) = &self.progress {
+            progress
+                .println(line)
+                .expect("failed to write progress output");
+        } else {
+            println!("{line}");
+        }
+    }
+
+    fn format_name(&self, name: &str, display: &str) -> String {
+        colorize_name(name, display, self.colors)
+    }
+
+    fn clear_live(&self) {
+        if let Some(progress) = &self.progress {
+            progress.clear().expect("failed to clear progress output");
+        }
+    }
+}
+
+#[derive(Clone)]
+struct JobDisplay {
+    progress: Option<ProgressBar>,
+    colors: bool,
+}
+
+impl JobDisplay {
+    fn set_command(&self, command: &str) {
+        if let Some(progress) = &self.progress {
+            progress.set_message(format!("$ {command}"));
+        }
+    }
+
+    fn finish(&self, status: &JobStatus, duration: Duration) {
+        let Some(progress) = &self.progress else {
+            return;
+        };
+        progress.set_style(
+            ProgressStyle::with_template("{prefix}  {msg}").expect("progress template is valid"),
+        );
+        let (symbol, label, color) = match status {
+            JobStatus::Success => ("✓", "ok", 32),
+            JobStatus::Failed(_) => ("✗", "FAILED", 31),
+            JobStatus::Skipped => ("-", "skipped", 33),
+        };
+        let status = colorize_text(&format!("{symbol} {label}"), color, self.colors);
+        progress.finish_with_message(format!("{status}  {:.1}s", duration.as_secs_f64()));
+    }
+}
+
 /// Run jobs respecting workspace dependency order among the selected members.
 /// Ordering constraints follow *transitive* deps, so order is preserved even
 /// when intermediate packages aren't part of the selection.
@@ -84,6 +186,7 @@ pub fn run_jobs(
         .map(|job| workspace.members[job.member].name.len())
         .max()
         .unwrap_or(0);
+    let output = Output::new();
 
     let selected: HashMap<usize, usize> = jobs
         .iter()
@@ -111,6 +214,8 @@ pub fn run_jobs(
     let (sender, receiver) = mpsc::channel::<JobResult>();
     let mut running = 0usize;
     let mut halted = false;
+    // Keep finished bars alive so later log lines do not erase their rows.
+    let mut live_displays = Vec::new();
 
     std::thread::scope(|scope| -> Result<()> {
         loop {
@@ -121,9 +226,13 @@ pub fn run_jobs(
                 let job = &jobs[job_idx];
                 let name = workspace.members[job.member].name.clone();
                 let sender = sender.clone();
+                let output = output.clone();
+                let display = output.start_job(&name);
+                live_displays.push(display.clone());
                 running += 1;
                 scope.spawn(move || {
-                    let status = execute_job(job, &name, prefix_width);
+                    let status = execute_job(job, &name, prefix_width, &output, &display);
+                    display.finish(&status.0, status.1);
                     let _ = sender.send(JobResult {
                         member: job_idx, // job index in-flight; remapped below
                         status: status.0,
@@ -167,24 +276,33 @@ pub fn run_jobs(
         })
         .collect();
 
-    print_summary(workspace, &results);
+    output.clear_live();
+    print_summary(workspace, &results, &output);
     Ok(results)
 }
 
-fn execute_job(job: &Job, name: &str, width: usize) -> (JobStatus, Duration) {
+fn execute_job(
+    job: &Job,
+    name: &str,
+    width: usize,
+    output: &Output,
+    display: &JobDisplay,
+) -> (JobStatus, Duration) {
     let started = Instant::now();
     for spec in &job.commands {
-        emit(name, width, &format!("$ {}", spec.display()));
-        match run_streaming(spec, name, width) {
+        let command = spec.display();
+        display.set_command(&command);
+        output.emit(name, width, &format!("$ {command}"));
+        match run_streaming(spec, name, width, output) {
             Ok(true) => {}
             Ok(false) => {
                 return (
-                    JobStatus::Failed(format!("`{}` failed", spec.display())),
+                    JobStatus::Failed(format!("`{command}` failed")),
                     started.elapsed(),
                 );
             }
             Err(err) => {
-                emit(name, width, &format!("error: {err:#}"));
+                output.emit(name, width, &format!("error: {err:#}"));
                 return (JobStatus::Failed(format!("{err:#}")), started.elapsed());
             }
         }
@@ -193,7 +311,7 @@ fn execute_job(job: &Job, name: &str, width: usize) -> (JobStatus, Duration) {
 }
 
 /// Run one command, streaming stdout and stderr lines with the `pkg ▏` prefix.
-fn run_streaming(spec: &CommandSpec, name: &str, width: usize) -> Result<bool> {
+fn run_streaming(spec: &CommandSpec, name: &str, width: usize, output: &Output) -> Result<bool> {
     let mut child = Command::new(&spec.program)
         .args(&spec.args)
         .current_dir(&spec.cwd)
@@ -210,9 +328,10 @@ fn run_streaming(spec: &CommandSpec, name: &str, width: usize) -> Result<bool> {
             Box::new(stdout) as Box<dyn std::io::Read + Send>,
             Box::new(stderr),
         ] {
+            let output = output.clone();
             scope.spawn(move || {
                 for line in BufReader::new(pipe).lines().map_while(Result::ok) {
-                    emit(name, width, &line);
+                    output.emit(name, width, &line);
                 }
             });
         }
@@ -220,11 +339,30 @@ fn run_streaming(spec: &CommandSpec, name: &str, width: usize) -> Result<bool> {
     Ok(child.wait()?.success())
 }
 
-fn emit(name: &str, width: usize, line: &str) {
-    println!("{name:width$} ▏ {line}");
+fn stable_name_hash(name: &str) -> u64 {
+    name.bytes().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+    })
 }
 
-fn print_summary(workspace: &Workspace, results: &[JobResult]) {
+fn colorize_name(name: &str, display: &str, enabled: bool) -> String {
+    colorize_text(display, name_color_code(name), enabled)
+}
+
+fn name_color_code(name: &str) -> u8 {
+    let index = stable_name_hash(name) as usize % NAME_COLOR_CODES.len();
+    NAME_COLOR_CODES[index]
+}
+
+fn colorize_text(text: &str, color: u8, enabled: bool) -> String {
+    if enabled {
+        format!("\x1b[1;{color}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}
+
+fn print_summary(workspace: &Workspace, results: &[JobResult], output: &Output) {
     let width = results
         .iter()
         .map(|r| workspace.members[r.member].name.len())
@@ -235,6 +373,8 @@ fn print_summary(workspace: &Workspace, results: &[JobResult]) {
     println!("{:width$}  {:8}  time", "package", "status");
     for result in results {
         let name = &workspace.members[result.member].name;
+        let padded_name = format!("{name:width$}");
+        let display_name = output.format_name(name, &padded_name);
         let (status, detail) = match &result.status {
             JobStatus::Success => ("ok", String::new()),
             JobStatus::Failed(reason) => ("FAILED", format!("  {reason}")),
@@ -245,11 +385,28 @@ fn print_summary(workspace: &Workspace, results: &[JobResult]) {
         } else {
             format!("{:.1}s", result.duration.as_secs_f64())
         };
-        println!("{name:width$}  {status:8}  {time}{detail}");
+        println!("{display_name}  {status:8}  {time}{detail}");
     }
 }
 
 /// True when every job succeeded (skipped counts as failure for exit codes).
 pub fn all_succeeded(results: &[JobResult]) -> bool {
     results.iter().all(|r| r.status == JobStatus::Success)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn package_name_colors_are_stable_and_hash_based() {
+        assert_eq!(name_color_code("lat_core"), 35);
+        assert_eq!(name_color_code("lat_core"), name_color_code("lat_core"));
+        assert_ne!(name_color_code("lat_core"), name_color_code("lat_mid"));
+    }
+
+    #[test]
+    fn package_name_colors_can_be_disabled() {
+        assert_eq!(colorize_name("lat_core", "lat_core", false), "lat_core");
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -125,6 +125,7 @@ fn run_custom_task_fans_out_with_prefixes() {
         // once for the echoed `$ ...` command line and once for its output
         .stdout(predicate::str::contains("hello-from-task").count(6))
         .stdout(predicate::str::contains("package_a").not())
+        .stdout(predicate::str::contains("\x1b[").not())
         .stdout(predicate::str::contains("ok"));
 }
 


### PR DESCRIPTION
## Summary

- add live `indicatif` progress rows for concurrently running packages
- keep subprocess logs scrolling above progress while preserving plain output for pipes and CI
- color package labels deterministically from their names and document the new behavior

## Testing

- `cargo test --quiet`
- `cargo clippy --all-targets --all-features --quiet -- -D warnings`
