### PR TITLE
feat: add moving series tags for pre-1.0 releases

### DIFF
--- a/.changes/unreleased/Added-20260724-series-tags.yaml
+++ b/.changes/unreleased/Added-20260724-series-tags.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Packages can now move a series tag alongside (or instead of) their immutable per-version tag. `tag-mode` picks the lifecycle for the workspace and `tag-mode-overrides` picks it per package; the series is derived from the version — `0.Y` while the major is 0, `X` after — so releasing 0.0.1, 0.0.2, 0.0.3 keeps moving one `pkg-v0.0` tag.
+time: 2026-07-24T09:00:00.000000-07:00

--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ needs-deps = true            # run `gleam deps download` first if not cached
 
 [tools.trellis.publish]
 tag-format = "{name}-v{version}"
+# A moving tag per release series, for consumers who pin a series instead of
+# chasing patch tags. {series} is derived from the version: `0.Y` while the
+# major is 0, `X` after. `tag-mode` is exact (default), series, or both.
+series-tag-format = "{name}-v{series}"
+tag-mode = "exact"
+tag-mode-overrides = { both = ["packages/lat_cli"] }
 ```
 
 Each member is a directory with a `gleam.toml`. Path dependencies between
@@ -260,10 +266,18 @@ already open, updates — the PR via the `gh` CLI. The body carries the bump
 table and each package's new CHANGELOG section. Requires a clean working
 tree; a no-op when there are no fragments.
 
-`tag plan` lists releasable packages whose `gleam.toml` version has no
-`{name}-v{version}` tag yet; `tag create` creates the missing tags in
-topological order, optionally pushing them and creating GitHub Releases (via
-the `gh` CLI) with the matching CHANGELOG section as the body.
+`tag plan` lists the tags the current versions call for and don't have yet;
+`tag create` reconciles them in topological order, optionally pushing them and
+creating GitHub Releases (via the `gh` CLI) with the matching CHANGELOG
+section as the body.
+
+A package tags in one of two lifecycles, per `tag-mode`. Exact tags
+(`{name}-v{version}`) are immutable — created once, never rewritten. Series
+tags (`{name}-v{series}`) move: each release force-moves the tag to the
+release commit and force-pushes it. Because a moving tag names no particular
+version, it never carries a GitHub Release and `publish --tag` refuses it;
+`ci tag-package` still resolves it, and a `series`-only workspace publishes
+with `--all-untagged`.
 
 `publish` runs, per package and in dependency order: an idempotency check
 against the Hex API (already-published versions are skipped, so re-running a

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -133,7 +133,15 @@ command = "gleam run -m glinter"
 needs-deps = true            # run `gleam deps download` first if not cached
 
 [tools.trellis.publish]
-tag-format = "{name}-v{version}"      # lattice_core-v1.1.0
+tag-format = "{name}-v{version}"          # lattice_core-v1.1.0
+# The moving series tag, re-pointed at each release in the series. {series} is
+# derived from the version — `0.Y` while the major is 0, `X` after — and never
+# configured. Omit {name} for one repository-wide tag.
+series-tag-format = "{name}-v{series}"    # lattice_core-v1, lattice_cli-v0.4
+# Which tags a release creates: exact (default), series, or both. The
+# overrides map picks it per member, as globs matched against member paths.
+tag-mode = "exact"
+tag-mode-overrides = { both = ["packages/lattice_cli"] }
 # How a path dep is rewritten to a Hex requirement at publish time, from the
 # dependency's current version X.Y.Z:
 #   minor  → ">= X.Y.Z and < (X+1).0.0"   (default)
@@ -267,6 +275,18 @@ trellis lockfile refresh [--package <pkg>]
   `gleam.toml` version against existing `{name}-v{version}` tags, create missing
   tags in topological order, optionally create GitHub Releases with the matching
   CHANGELOG section as the body.
+- A member may instead (or also) carry a **series tag** — `{name}-v{series}`,
+  where the series is derived from the version: `0.Y` while the major is 0,
+  `X` after. It is the one ref trellis rewrites: each release in the series
+  force-moves it to the release commit and force-pushes it, so consumers can
+  pin a series rather than chase patch tags. Divergence between local and
+  origin is the normal state for a moving tag, so the divergence check that
+  guards exact tags does not apply. Three consequences fall out of a tag that
+  names no particular version: it never carries a GitHub Release (which would
+  silently retarget), `publish --tag` refuses it (`ci tag-package` still
+  resolves it, so CI can route on it), and a `series`-only workspace releases
+  through `--all-untagged` rather than a tag-push trigger. `tag-mode` sets the
+  lifecycle for the workspace; `tag-mode-overrides` sets it per member.
 - `publish` performs, per package:
   1. **Idempotency check** — query Hex once; skip if this exact version is already
      published (makes re-runs of a partially failed release safe).
@@ -321,7 +341,13 @@ Checks, each of which is an unenforced invariant in lattice today:
 6. Every task exclusion glob matches at least one member (catches typos), and
    no releasable member path-depends on a release-excluded member — a published
    package cannot require a project that will never exist on Hex.
-7. Tag-format collisions (two members whose names would produce ambiguous tags).
+7. Tag-format collisions (two members whose names would produce ambiguous tags),
+   for series tags as well as exact ones — except a `series-tag-format` without
+   `{name}`, which warns instead once the workspace has more than one series
+   member, since sharing one repository-wide tag is the point and costs only
+   the ability to resolve it back to a single package. That warning keys on the
+   format, not on today's versions: with no `{name}` to substitute, every
+   series tag matches every member whatever they are versioned at.
 
 `doctor` is the CI tripwire for the duplication that can't be eliminated. Today,
 publish.yml's `replace-path-deps` being one package short would only be discovered

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -219,10 +219,12 @@ pub fn render_section(
     date: &str,
     fragments: &[&Fragment],
 ) -> Result<String> {
+    // Empty for a prerelease, which belongs to no series.
+    let series = crate::config::series_of(version).unwrap_or_default();
     let mut out = render(
         &config.version_format,
         "version-format",
-        minijinja::context! { name, version, date, tag },
+        minijinja::context! { name, version, date, tag, series },
     )?;
     out.push('\n');
     for kind in &config.kinds {

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -3,6 +3,7 @@
 //! lines suitable for `$GITHUB_OUTPUT`; `tag-package` resolves a pushed tag
 //! ($GITHUB_REF_NAME) to the package it belongs to.
 
+use super::tag::ResolvedTag;
 use crate::workspace::{SelectionFilter, Workspace};
 use anyhow::Result;
 use serde_json::json;
@@ -10,18 +11,28 @@ use serde_json::json;
 /// Resolve a tag to its package for shell substitution, e.g.
 /// `trellis lockfile refresh --package "$(trellis ci tag-package "$GITHUB_REF_NAME")"`.
 pub fn tag_package(workspace: &Workspace, tag: &str, json_output: bool) -> Result<()> {
-    let (idx, tag_version) = super::tag::resolve_tag(workspace, tag)?;
-    let member = &workspace.members[idx];
+    let resolved = super::tag::resolve_tag(workspace, tag)?;
+    let member = &workspace.members[resolved.member()];
     if json_output {
-        println!(
-            "{}",
-            serde_json::to_string(&json!({
+        // A series tag identifies the package but no version, so it reports
+        // the series it names instead of `tag-version`.
+        let payload = match &resolved {
+            ResolvedTag::Exact { version, .. } => json!({
                 "name": member.name,
                 "path": member.rel_path,
                 "version": member.version(),
-                "tag-version": tag_version,
-            }))?
-        );
+                "tag-kind": "exact",
+                "tag-version": version,
+            }),
+            ResolvedTag::Series { series, .. } => json!({
+                "name": member.name,
+                "path": member.rel_path,
+                "version": member.version(),
+                "tag-kind": "series",
+                "tag-series": series,
+            }),
+        };
+        println!("{}", serde_json::to_string(&payload)?);
     } else {
         println!("{}", member.name);
     }
@@ -67,13 +78,30 @@ pub fn outputs(workspace: &Workspace) -> Result<()> {
     let tags: Vec<String> = workspace
         .members
         .iter()
-        .filter(|m| m.releasable)
+        .filter(|m| m.releasable && m.tag_mode.includes_exact())
         .map(|m| workspace.config.format_tag(&m.name, m.version()))
         .collect();
+    // Deduplicated: a repository-wide series tag is one tag, however many
+    // members move it.
+    let mut series_tags: Vec<String> = Vec::new();
+    for member in workspace
+        .members
+        .iter()
+        .filter(|m| m.releasable && m.tag_mode.includes_series())
+    {
+        if let Some(tag) = workspace
+            .config
+            .format_series_tag(&member.name, member.version())
+            && !series_tags.contains(&tag)
+        {
+            series_tags.push(tag);
+        }
+    }
 
     println!("projects={}", serde_json::to_string(&all)?);
     println!("releasable={}", serde_json::to_string(&releasable)?);
     println!("version-files={}", serde_json::to_string(&version_files)?);
     println!("tags={}", serde_json::to_string(&tags)?);
+    println!("series-tags={}", serde_json::to_string(&series_tags)?);
     Ok(())
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -251,7 +251,24 @@ fn check_tool_versions(workspace: &Workspace, report: &mut Report) {
 fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     for (task, patterns) in &workspace.config.exclude {
         for pattern in patterns {
-            check_exclusion_pattern(workspace, task, pattern, report);
+            check_member_glob(
+                workspace,
+                &format!("`{task}` exclusion glob"),
+                pattern,
+                report,
+            );
+        }
+    }
+    // Same typo trap, one table over: a tag-mode override that matches nothing
+    // silently leaves its packages on the workspace default.
+    for (mode, patterns) in &workspace.config.publish.tag_mode_overrides {
+        for pattern in patterns {
+            check_member_glob(
+                workspace,
+                &format!("`tag-mode-overrides.{mode}` glob"),
+                pattern,
+                report,
+            );
         }
     }
 
@@ -272,7 +289,7 @@ fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     }
 }
 
-fn check_exclusion_pattern(workspace: &Workspace, task: &str, pattern: &str, report: &mut Report) {
+fn check_member_glob(workspace: &Workspace, label: &str, pattern: &str, report: &mut Report) {
     let matches = globset::Glob::new(pattern)
         .ok()
         .map(|glob| glob.compile_matcher())
@@ -284,22 +301,80 @@ fn check_exclusion_pattern(workspace: &Workspace, task: &str, pattern: &str, rep
         });
     match matches {
         Some(true) => {}
-        Some(false) => report.error(format!(
-            "`{task}` exclusion glob `{pattern}` matches no member (typo?)"
-        )),
-        None => report.error(format!("`{task}` exclusion glob `{pattern}` is invalid")),
+        Some(false) => report.error(format!("{label} `{pattern}` matches no member (typo?)")),
+        None => report.error(format!("{label} `{pattern}` is invalid")),
     }
 }
 
-/// Check 7: no two releasable members produce the same tag.
+/// Check 7: no two releasable members produce the same tag, for series tags as
+/// well as exact ones.
+///
+/// A `series-tag-format` without `{name}` is the exception: sharing one
+/// repository-wide tag is the point, so it warns rather than errors. The
+/// warning is keyed on the format and the member count, not on today's
+/// versions — `resolve_tag` substitutes `{name}` per member, so with no
+/// `{name}` to substitute *every* series tag matches every member regardless
+/// of what they're versioned at. Warning only on a version collision would go
+/// quiet on exactly the configurations `trellis ci tag-package` still fails on.
 fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     let mut seen: std::collections::HashMap<String, &str> = std::collections::HashMap::new();
     for member in workspace.members.iter().filter(|m| m.releasable) {
-        let tag = workspace.config.format_tag(&member.name, member.version());
-        if let Some(other) = seen.insert(tag.clone(), &member.name) {
+        if member.tag_mode.includes_exact() {
+            let tag = workspace.config.format_tag(&member.name, member.version());
+            if let Some(other) = seen.insert(tag.clone(), &member.name) {
+                report.error(format!(
+                    "tag collision: `{other}` and `{}` both produce tag `{tag}`",
+                    member.name
+                ));
+            }
+        }
+    }
+
+    let series_members: Vec<&str> = workspace
+        .members
+        .iter()
+        .filter(|m| m.releasable && m.tag_mode.includes_series())
+        .map(|m| m.name.as_str())
+        .collect();
+    let names = |members: &[&str]| {
+        members
+            .iter()
+            .map(|name| format!("`{name}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    if workspace.config.series_tag_is_repo_wide() {
+        if series_members.len() > 1 {
+            report.warning(format!(
+                "`series-tag-format` `{}` has no {{name}}, so one repository-wide series tag \
+                 covers {}; `trellis ci tag-package` cannot resolve such a tag to one package",
+                workspace.config.publish.series_tag_format,
+                names(&series_members)
+            ));
+        }
+        return;
+    }
+
+    let mut sharing: std::collections::BTreeMap<String, Vec<&str>> =
+        std::collections::BTreeMap::new();
+    for member in workspace
+        .members
+        .iter()
+        .filter(|m| m.releasable && m.tag_mode.includes_series())
+    {
+        if let Some(tag) = workspace
+            .config
+            .format_series_tag(&member.name, member.version())
+        {
+            sharing.entry(tag).or_default().push(&member.name);
+        }
+    }
+    for (tag, members) in sharing {
+        if members.len() > 1 {
             report.error(format!(
-                "tag collision: `{other}` and `{}` both produce tag `{tag}`",
-                member.name
+                "series tag collision: {} all produce tag `{tag}`",
+                names(&members)
             ));
         }
     }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -21,10 +21,21 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
     println!("version:    {}", member.version());
     println!("path:       {}", member.rel_path);
     println!("releasable: {}", member.releasable);
-    println!(
-        "tag:        {}",
-        workspace.config.format_tag(&member.name, member.version())
-    );
+    // Only the tags this member's mode actually produces — a series-only
+    // package has no per-version tag to report.
+    if member.tag_mode.includes_exact() {
+        println!(
+            "tag:        {}",
+            workspace.config.format_tag(&member.name, member.version())
+        );
+    }
+    if member.tag_mode.includes_series()
+        && let Some(tag) = workspace
+            .config
+            .format_series_tag(&member.name, member.version())
+    {
+        println!("series tag: {tag}");
+    }
     let format_names = |indices: &[usize]| -> String {
         if indices.is_empty() {
             "(none)".to_string()

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -43,19 +43,37 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
             }
             vec![idx]
         }
-        Selector::Tag(tag) => {
-            let (idx, tag_version) = super::tag::resolve_tag(workspace, tag)?;
-            let member = &workspace.members[idx];
-            if tag_version != member.version() {
+        Selector::Tag(tag) => match super::tag::resolve_tag(workspace, tag)? {
+            super::tag::ResolvedTag::Exact {
+                member: idx,
+                version: tag_version,
+            } => {
+                let member = &workspace.members[idx];
+                if tag_version != member.version() {
+                    bail!(
+                        "tag `{tag}` says version {tag_version} but {}/gleam.toml says {} — \
+                         refusing to publish a version that doesn't match its tag",
+                        member.rel_path,
+                        member.version()
+                    );
+                }
+                vec![idx]
+            }
+            // A moving tag names a series, not a release; publishing off one
+            // would ship whatever the working tree happens to say today.
+            super::tag::ResolvedTag::Series {
+                member: idx,
+                series,
+            } => {
+                let member = &workspace.members[idx];
                 bail!(
-                    "tag `{tag}` says version {tag_version} but {}/gleam.toml says {} — \
-                     refusing to publish a version that doesn't match its tag",
-                    member.rel_path,
-                    member.version()
+                    "tag `{tag}` is the moving v{series} series tag for `{}` and names no \
+                     specific version — publish with `--package {}` or `--all-untagged`",
+                    member.name,
+                    member.name
                 );
             }
-            vec![idx]
-        }
+        },
         // Member indices are already topological; publish order follows.
         Selector::AllUntagged => (0..workspace.members.len())
             .filter(|&idx| workspace.members[idx].releasable)

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -1,56 +1,167 @@
 //! `trellis tag` — compare each releasable member's gleam.toml version
-//! against existing `{name}-v{version}` tags; create the missing ones in
-//! topological order, optionally with GitHub Releases carrying the matching
-//! CHANGELOG section.
+//! against existing tags and reconcile the difference, in topological order.
+//!
+//! A member tags in one of two lifecycles, chosen by `tag-mode`: immutable
+//! `{name}-v{version}` tags, created once and never touched again, and moving
+//! `{name}-v{series}` tags, force-moved to the release commit every time that
+//! series releases. Only the immutable ones can carry a GitHub Release — a
+//! release bound to a moving tag would silently retarget.
 
 use crate::tools;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
 use serde_json::json;
+use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
-/// Releasable members (topo order) whose current version has no tag yet.
-fn missing_tags(workspace: &Workspace) -> Result<Vec<(usize, String)>> {
+/// Which tag lifecycle a planned tag belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TagKind {
+    /// An immutable `tag-format` tag naming one version.
+    Exact,
+    /// A moving `series-tag-format` tag naming a release series.
+    Series,
+}
+
+impl TagKind {
+    fn key(self) -> &'static str {
+        match self {
+            TagKind::Exact => "exact",
+            TagKind::Series => "series",
+        }
+    }
+}
+
+/// The work `tag create` would do for a planned tag, from local state alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TagAction {
+    /// The tag does not exist locally.
+    Create,
+    /// A series tag exists locally but points somewhere other than HEAD.
+    Move,
+    /// The tag already points where it should; only the remote may need work.
+    UpToDate,
+}
+
+impl TagAction {
+    fn key(self) -> &'static str {
+        match self {
+            TagAction::Create => "create",
+            TagAction::Move => "move",
+            TagAction::UpToDate => "up-to-date",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PlannedTag {
+    /// Index into `workspace.members`.
+    pub member: usize,
+    pub tag: String,
+    pub kind: TagKind,
+    pub action: TagAction,
+}
+
+/// Every tag the current versions call for, in topological order, each with
+/// the work it needs. A repository-wide series tag (a `series-tag-format`
+/// without `{name}`) is claimed by the first member that would produce it, so
+/// it is moved once rather than once per package.
+fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
     let existing = git_stdout(&workspace.root, &["tag", "--list"])?;
-    let existing: std::collections::HashSet<&str> = existing
+    let existing: HashSet<&str> = existing
         .lines()
         .map(str::trim)
         .filter(|l| !l.is_empty())
         .collect();
-    Ok(workspace
+    // Unborn in a repository with no commits, where nothing can be tagged yet.
+    let head = commit_of(&workspace.root, "HEAD")?;
+
+    let mut planned: Vec<PlannedTag> = Vec::new();
+    let mut claimed: HashSet<String> = HashSet::new();
+    for (member, index) in workspace
         .members
         .iter()
-        .enumerate()
-        .filter(|(_, member)| member.releasable)
-        .filter_map(|(idx, member)| {
+        .zip(0..)
+        .filter(|(member, _)| member.releasable)
+    {
+        if member.tag_mode.includes_exact() {
             let tag = workspace.config.format_tag(&member.name, member.version());
-            (!existing.contains(tag.as_str())).then_some((idx, tag))
-        })
-        .collect())
+            let action = if existing.contains(tag.as_str()) {
+                TagAction::UpToDate
+            } else {
+                TagAction::Create
+            };
+            if claimed.insert(tag.clone()) {
+                planned.push(PlannedTag {
+                    member: index,
+                    tag,
+                    kind: TagKind::Exact,
+                    action,
+                });
+            }
+        }
+        // A prerelease belongs to no series, and so moves no tag.
+        if member.tag_mode.includes_series()
+            && let Some(tag) = workspace
+                .config
+                .format_series_tag(&member.name, member.version())
+        {
+            let action = if !existing.contains(tag.as_str()) {
+                TagAction::Create
+            } else if head.is_some() && commit_of(&workspace.root, &tag)? == head {
+                TagAction::UpToDate
+            } else {
+                TagAction::Move
+            };
+            if claimed.insert(tag.clone()) {
+                planned.push(PlannedTag {
+                    member: index,
+                    tag,
+                    kind: TagKind::Series,
+                    action,
+                });
+            }
+        }
+    }
+    Ok(planned)
 }
 
 pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
-    let missing = missing_tags(workspace)?;
+    let pending: Vec<PlannedTag> = plan_tags(workspace)?
+        .into_iter()
+        .filter(|planned| planned.action != TagAction::UpToDate)
+        .collect();
     if json {
-        let items: Vec<_> = missing
+        let items: Vec<_> = pending
             .iter()
-            .map(|(idx, tag)| {
-                let member = &workspace.members[*idx];
+            .map(|planned| {
+                let member = &workspace.members[planned.member];
                 json!({
                     "name": member.name,
                     "version": member.version(),
-                    "tag": tag,
+                    "tag": planned.tag,
+                    "kind": planned.kind.key(),
+                    "action": planned.action.key(),
                 })
             })
             .collect();
         println!("{}", serde_json::to_string_pretty(&items)?);
-    } else if missing.is_empty() {
+    } else if pending.is_empty() {
         println!("every releasable package version is already tagged");
     } else {
-        for (idx, tag) in &missing {
-            let member = &workspace.members[*idx];
-            println!("{}: {} needs tag {tag}", member.name, member.version());
+        for planned in &pending {
+            let member = &workspace.members[planned.member];
+            let verb = match planned.action {
+                TagAction::Move => "moves tag",
+                _ => "needs tag",
+            };
+            println!(
+                "{}: {} {verb} {}",
+                member.name,
+                member.version(),
+                planned.tag
+            );
         }
     }
     Ok(())
@@ -63,85 +174,136 @@ pub struct CreateOptions {
 
 pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
     let push = options.push || options.github_release;
-    let targets = if push {
-        workspace
-            .members
-            .iter()
-            .enumerate()
-            .filter(|(_, member)| member.releasable)
-            .map(|(idx, member)| {
-                (
-                    idx,
-                    workspace.config.format_tag(&member.name, member.version()),
-                )
-            })
-            .collect()
-    } else {
-        missing_tags(workspace)?
-    };
+    let planned = plan_tags(workspace)?;
+    // Without a remote to reconcile, a tag that already points where it
+    // should is nothing to do; with one, it may still be missing from origin.
+    let targets: Vec<&PlannedTag> = planned
+        .iter()
+        .filter(|planned| push || planned.action != TagAction::UpToDate)
+        .collect();
     if targets.is_empty() {
         println!("every releasable package version is already tagged");
         return Ok(());
     }
 
-    for (idx, tag) in &targets {
-        let member = &workspace.members[*idx];
-        let local_oid = local_tag_oid(&workspace.root, tag)?;
-        let remote_oid = if push {
-            remote_tag_oid(&workspace.root, tag)?
+    for planned in targets {
+        match planned.kind {
+            TagKind::Exact => create_exact_tag(workspace, planned, options, push)?,
+            TagKind::Series => move_series_tag(workspace, planned, push)?,
+        }
+    }
+    Ok(())
+}
+
+/// An immutable tag: created once, fetched when origin already has it, and
+/// never rewritten. Local and remote disagreeing about what it names is a
+/// history problem trellis refuses to paper over.
+fn create_exact_tag(
+    workspace: &Workspace,
+    planned: &PlannedTag,
+    options: &CreateOptions,
+    push: bool,
+) -> Result<()> {
+    let member = &workspace.members[planned.member];
+    let tag = &planned.tag;
+    let local_oid = local_tag_oid(&workspace.root, tag)?;
+    let remote_oid = if push {
+        remote_tag_oid(&workspace.root, tag)?
+    } else {
+        None
+    };
+    if let (Some(local), Some(remote)) = (&local_oid, &remote_oid)
+        && local != remote
+    {
+        bail!("tag `{tag}` points to different objects locally ({local}) and on origin ({remote})");
+    }
+    if local_oid.is_none() {
+        if remote_oid.is_some() {
+            git_stdout(&workspace.root, &["fetch", "origin", "tag", tag])?;
+            println!("fetched {tag}");
         } else {
-            None
-        };
-        if let (Some(local), Some(remote)) = (&local_oid, &remote_oid)
-            && local != remote
-        {
-            bail!(
-                "tag `{tag}` points to different objects locally ({local}) and on origin ({remote})"
-            );
+            let mut args = crate::git::identity_fallback_args(&workspace.root);
+            args.extend([
+                "tag".into(),
+                "-a".into(),
+                tag.clone(),
+                "-m".into(),
+                format!("{} {}", member.name, member.version()),
+            ]);
+            let args: Vec<&str> = args.iter().map(String::as_str).collect();
+            git_stdout(&workspace.root, &args)?;
+            println!("tagged {tag}");
         }
-        if local_oid.is_none() {
-            if remote_oid.is_some() {
-                git_stdout(&workspace.root, &["fetch", "origin", "tag", tag])?;
-                println!("fetched {tag}");
-            } else {
-                let mut args = crate::git::identity_fallback_args(&workspace.root);
-                args.extend([
-                    "tag".into(),
-                    "-a".into(),
-                    tag.clone(),
-                    "-m".into(),
-                    format!("{} {}", member.name, member.version()),
-                ]);
-                let args: Vec<&str> = args.iter().map(String::as_str).collect();
-                git_stdout(&workspace.root, &args)?;
-                println!("tagged {tag}");
+    }
+    if push && remote_oid.is_none() {
+        git_stdout(&workspace.root, &["push", "origin", tag])
+            .with_context(|| format!("failed to push tag {tag}"))?;
+        println!("pushed {tag}");
+    }
+    if options.github_release {
+        if github_release_exists(&workspace.root, tag)? {
+            println!("GitHub release {tag} already exists; skipping");
+        } else {
+            let notes = release_notes(workspace, planned.member);
+            let gh = tools::gh_bin();
+            let output = Command::new(&gh)
+                .args(["release", "create", tag, "--title", tag, "--notes", &notes])
+                .current_dir(&workspace.root)
+                .output()
+                .with_context(|| format!("failed to run `{gh}` — is the GitHub CLI installed?"))?;
+            if !output.status.success() {
+                bail!(
+                    "`{gh} release create {tag}` failed: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                );
             }
+            println!("created GitHub release {tag}");
         }
-        if push && remote_oid.is_none() {
-            git_stdout(&workspace.root, &["push", "origin", tag])
+    }
+    Ok(())
+}
+
+/// A series tag is the one ref trellis rewrites: it is force-moved to the
+/// release commit and force-pushed. Local and remote pointing at different
+/// objects is the normal state between releases, not an error, and no GitHub
+/// Release is ever attached — it would silently retarget on the next move.
+fn move_series_tag(workspace: &Workspace, planned: &PlannedTag, push: bool) -> Result<()> {
+    let member = &workspace.members[planned.member];
+    let tag = &planned.tag;
+    let remote_oid = if push {
+        remote_tag_oid(&workspace.root, tag)?
+    } else {
+        None
+    };
+    if planned.action != TagAction::UpToDate {
+        let mut args = crate::git::identity_fallback_args(&workspace.root);
+        args.extend([
+            "tag".into(),
+            "-f".into(),
+            "-a".into(),
+            tag.clone(),
+            "-m".into(),
+            format!("{} {}", member.name, member.version()),
+        ]);
+        let args: Vec<&str> = args.iter().map(String::as_str).collect();
+        git_stdout(&workspace.root, &args)?;
+        if planned.action == TagAction::Create {
+            println!("tagged {tag}");
+        } else {
+            println!("moved {tag}");
+        }
+    }
+    if push {
+        // Re-read after any move: a re-tag writes a fresh annotated object, so
+        // this also catches "already where it belongs, but origin disagrees".
+        let local_oid = local_tag_oid(&workspace.root, tag)?;
+        if local_oid != remote_oid {
+            git_stdout(&workspace.root, &["push", "--force", "origin", tag])
                 .with_context(|| format!("failed to push tag {tag}"))?;
-            println!("pushed {tag}");
-        }
-        if options.github_release {
-            if github_release_exists(&workspace.root, tag)? {
-                println!("GitHub release {tag} already exists; skipping");
+            if remote_oid.is_none() {
+                println!("pushed {tag}");
             } else {
-                let notes = release_notes(workspace, *idx);
-                let gh = tools::gh_bin();
-                let output = Command::new(&gh)
-                    .args(["release", "create", tag, "--title", tag, "--notes", &notes])
-                    .current_dir(&workspace.root)
-                    .output()
-                    .with_context(|| {
-                        format!("failed to run `{gh}` — is the GitHub CLI installed?")
-                    })?;
-                if !output.status.success() {
-                    bail!(
-                        "`{gh} release create {tag}` failed: {}",
-                        String::from_utf8_lossy(&output.stderr).trim()
-                    );
-                }
-                println!("created GitHub release {tag}");
+                println!("force-pushed {tag}");
             }
         }
     }
@@ -149,9 +311,19 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
 }
 
 fn local_tag_oid(root: &Path, tag: &str) -> Result<Option<String>> {
-    let reference = format!("refs/tags/{tag}");
+    rev_parse(root, &format!("refs/tags/{tag}"), tag)
+}
+
+/// The commit a revision points at, peeling annotated tags — the comparison a
+/// series tag needs, since re-tagging the same commit still writes a fresh tag
+/// object. `None` when the revision doesn't exist, including an unborn HEAD.
+fn commit_of(root: &Path, revision: &str) -> Result<Option<String>> {
+    rev_parse(root, &format!("{revision}^{{commit}}"), revision)
+}
+
+fn rev_parse(root: &Path, reference: &str, subject: &str) -> Result<Option<String>> {
     let output = Command::new("git")
-        .args(["rev-parse", "--verify", "--quiet", &reference])
+        .args(["rev-parse", "--verify", "--quiet", reference])
         .current_dir(root)
         .output()
         .context("failed to run git")?;
@@ -164,7 +336,7 @@ fn local_tag_oid(root: &Path, tag: &str) -> Result<Option<String>> {
             .map(Some)
             .context("git rev-parse returned no object ID"),
         Some(1) => Ok(None),
-        _ => bail!("git rev-parse failed while checking tag `{tag}`"),
+        _ => bail!("git rev-parse failed while checking `{subject}`"),
     }
 }
 
@@ -252,46 +424,127 @@ fn heading_version(heading: &str) -> Option<semver::Version> {
     semver::Version::parse(token).ok()
 }
 
-/// Resolve a tag like `lat_core-v1.2.0` to a releasable member and the
-/// version the tag claims (which may differ from gleam.toml — the caller
-/// decides whether that's fatal). Prefers the longest package-name match so
-/// `lat_core_extra-v1.0.0` never resolves to `lat_core`.
-pub fn resolve_tag(workspace: &Workspace, tag: &str) -> Result<(usize, String)> {
-    let Some((prefix_tpl, suffix_tpl)) =
-        workspace.config.publish.tag_format.split_once("{version}")
-    else {
-        bail!(
-            "tag-format `{}` has no {{version}} placeholder",
-            workspace.config.publish.tag_format
-        );
-    };
+/// A pushed tag resolved back to the package it names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedTag {
+    /// An immutable tag, carrying the version it claims — which may differ
+    /// from gleam.toml; the caller decides whether that's fatal.
+    Exact { member: usize, version: String },
+    /// A moving series tag, carrying the series it names. It identifies a
+    /// package but no particular version.
+    Series { member: usize, series: String },
+}
 
-    let mut best: Option<(usize, String)> = None;
-    for (idx, member) in workspace.members.iter().enumerate() {
-        if !member.releasable {
-            continue;
+impl ResolvedTag {
+    pub fn member(&self) -> usize {
+        match self {
+            ResolvedTag::Exact { member, .. } | ResolvedTag::Series { member, .. } => *member,
         }
-        let prefix = prefix_tpl.replace("{name}", &member.name);
-        let suffix = suffix_tpl.replace("{name}", &member.name);
+    }
+}
+
+/// Resolve a tag like `lat_core-v1.2.0` or `lat_core-v0.3` to the releasable
+/// member it belongs to. Exact tags are tried first; a candidate only counts
+/// if what the template captured is actually a version (or, for series tags, a
+/// series), so `lat_core-v0.3` doesn't resolve as version "0.3".
+pub fn resolve_tag(workspace: &Workspace, tag: &str) -> Result<ResolvedTag> {
+    let exact = match_tag_template(
+        &candidates(workspace, |mode| mode.includes_exact()),
+        tag,
+        &workspace.config.publish.tag_format,
+        "{version}",
+        |captured| semver::Version::parse(captured).is_ok(),
+    )?;
+    if let Some((member, version)) = exact.into_iter().next() {
+        return Ok(ResolvedTag::Exact { member, version });
+    }
+
+    let series = match_tag_template(
+        &candidates(workspace, |mode| mode.includes_series()),
+        tag,
+        &workspace.config.publish.series_tag_format,
+        "{series}",
+        is_series,
+    )?;
+    if series.len() > 1 && workspace.config.series_tag_is_repo_wide() {
+        bail!(
+            "tag `{tag}` is a repository-wide series tag shared by {}; it names no single package",
+            series
+                .iter()
+                .map(|(member, _)| format!("`{}`", workspace.members[*member].name))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    if let Some((member, series)) = series.into_iter().next() {
+        return Ok(ResolvedTag::Series { member, series });
+    }
+
+    bail!(
+        "tag `{tag}` does not match any releasable package (tag format: {}, series tag format: {})",
+        workspace.config.publish.tag_format,
+        workspace.config.publish.series_tag_format
+    )
+}
+
+/// Releasable members whose tag mode passes `wanted`, as `match_tag_template`
+/// candidates.
+fn candidates(
+    workspace: &Workspace,
+    wanted: impl Fn(crate::config::TagMode) -> bool,
+) -> Vec<(usize, &str)> {
+    workspace
+        .members
+        .iter()
+        .zip(0..)
+        .filter(|(member, _)| member.releasable && wanted(member.tag_mode))
+        .map(|(member, index)| (index, member.name.as_str()))
+        .collect()
+}
+
+/// Match `tag` against `template` once per candidate, with `{name}`
+/// substituted, and return what `placeholder` captured. Longest package name
+/// first, so `lat_core_extra-v1.0.0` never resolves to `lat_core`.
+fn match_tag_template(
+    candidates: &[(usize, &str)],
+    tag: &str,
+    template: &str,
+    placeholder: &str,
+    accept: impl Fn(&str) -> bool,
+) -> Result<Vec<(usize, String)>> {
+    let Some((prefix_template, suffix_template)) = template.split_once(placeholder) else {
+        bail!("tag format `{template}` has no {placeholder} placeholder");
+    };
+    let mut matches: Vec<(usize, &str, String)> = Vec::new();
+    for (index, name) in candidates {
+        let prefix = prefix_template.replace("{name}", name);
+        let suffix = suffix_template.replace("{name}", name);
         if tag.len() > prefix.len() + suffix.len()
             && tag.starts_with(&prefix)
             && tag.ends_with(&suffix)
         {
-            let version = tag[prefix.len()..tag.len() - suffix.len()].to_string();
-            let longer = best
-                .as_ref()
-                .is_none_or(|(other, _)| member.name.len() > workspace.members[*other].name.len());
-            if longer {
-                best = Some((idx, version));
+            let captured = &tag[prefix.len()..tag.len() - suffix.len()];
+            if accept(captured) {
+                matches.push((*index, name, captured.to_string()));
             }
         }
     }
-    best.with_context(|| {
-        format!(
-            "tag `{tag}` does not match any releasable package (tag format: {})",
-            workspace.config.publish.tag_format
-        )
-    })
+    matches.sort_by_key(|(_, name, _)| std::cmp::Reverse(name.len()));
+    Ok(matches
+        .into_iter()
+        .map(|(index, _, captured)| (index, captured))
+        .collect())
+}
+
+/// A series is `X` or `0.Y` — one or two all-numeric parts. Requiring the
+/// shape is what keeps the two tag formats from claiming each other's tags
+/// when they share a prefix, as the defaults do.
+fn is_series(token: &str) -> bool {
+    let parts: Vec<&str> = token.split('.').collect();
+    (1..=2).contains(&parts.len())
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
 fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
@@ -312,7 +565,66 @@ fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::changelog_section;
+    use super::{changelog_section, is_series, match_tag_template};
+
+    fn packages() -> Vec<(usize, &'static str)> {
+        vec![(0, "lat_core"), (1, "lat_core_extra")]
+    }
+
+    fn versions(tag: &str) -> Vec<(usize, String)> {
+        match_tag_template(&packages(), tag, "{name}-v{version}", "{version}", |c| {
+            semver::Version::parse(c).is_ok()
+        })
+        .unwrap()
+    }
+
+    fn series(tag: &str) -> Vec<(usize, String)> {
+        match_tag_template(&packages(), tag, "{name}-v{series}", "{series}", is_series).unwrap()
+    }
+
+    #[test]
+    fn longest_package_name_matches_first() {
+        assert_eq!(
+            versions("lat_core_extra-v1.0.0"),
+            vec![(1, "1.0.0".to_string())]
+        );
+        assert_eq!(versions("lat_core-v1.2.0"), vec![(0, "1.2.0".to_string())]);
+    }
+
+    #[test]
+    fn the_two_tag_formats_do_not_claim_each_others_tags() {
+        // `lat_core-v0.3` fits the exact template too, but "0.3" is not a
+        // version — so only the series template matches it, and vice versa.
+        assert!(versions("lat_core-v0.3").is_empty());
+        assert_eq!(series("lat_core-v0.3"), vec![(0, "0.3".to_string())]);
+        assert!(series("lat_core-v1.2.0").is_empty());
+        assert_eq!(series("lat_core-v2"), vec![(0, "2".to_string())]);
+    }
+
+    #[test]
+    fn a_repo_wide_series_tag_matches_every_candidate() {
+        let matches =
+            match_tag_template(&packages(), "v0.0", "v{series}", "{series}", is_series).unwrap();
+        assert_eq!(matches.len(), 2, "ambiguous by construction: {matches:?}");
+    }
+
+    #[test]
+    fn unmatched_and_malformed_templates() {
+        assert!(versions("some-other-tag").is_empty());
+        let err = match_tag_template(&packages(), "v1", "{name}-latest", "{version}", |_| true)
+            .unwrap_err();
+        assert!(err.to_string().contains("{version}"), "{err:#}");
+    }
+
+    #[test]
+    fn series_tokens_are_one_or_two_numbers() {
+        assert!(is_series("0") && is_series("0.0") && is_series("12") && is_series("0.12"));
+        assert!(!is_series("1.2.3"));
+        assert!(!is_series("0.0-rc"));
+        assert!(!is_series(""));
+        assert!(!is_series("0."));
+        assert!(!is_series("v1"));
+    }
 
     #[test]
     fn extracts_the_matching_section_only() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,18 @@ pub struct PublishConfig {
     /// Tag naming scheme; `{name}` and `{version}` are substituted.
     #[serde(default = "default_tag_format")]
     pub tag_format: String,
+    /// Naming scheme for the moving series tag; `{name}` and `{series}` are
+    /// substituted. Omit `{name}` for a single repository-wide series tag.
+    #[serde(default = "default_series_tag_format")]
+    pub series_tag_format: String,
+    /// Which tags a release creates, for members without an override.
+    #[serde(default)]
+    pub tag_mode: TagMode,
+    /// Per-member overrides of [`PublishConfig::tag_mode`], keyed by mode name
+    /// ([`TagMode::key`]); values are globs matched against member paths. A
+    /// member matching globs under two different modes is an error.
+    #[serde(default)]
+    pub tag_mode_overrides: BTreeMap<String, Vec<String>>,
     /// How a path dep is rewritten to a Hex requirement at publish time.
     #[serde(default)]
     pub path_dep_requirement: PathDepRequirement,
@@ -85,6 +97,9 @@ impl Default for PublishConfig {
     fn default() -> Self {
         Self {
             tag_format: default_tag_format(),
+            series_tag_format: default_series_tag_format(),
+            tag_mode: TagMode::default(),
+            tag_mode_overrides: BTreeMap::new(),
             path_dep_requirement: PathDepRequirement::default(),
             retry: RetryConfig::default(),
         }
@@ -93,6 +108,66 @@ impl Default for PublishConfig {
 
 fn default_tag_format() -> String {
     "{name}-v{version}".to_string()
+}
+
+fn default_series_tag_format() -> String {
+    "{name}-v{series}".to_string()
+}
+
+/// Which git tags a release creates for a member.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TagMode {
+    /// Immutable per-version tags only (`{name}-v1.2.0`).
+    #[default]
+    Exact,
+    /// Moving series tags only (`{name}-v0.0`, re-pointed at each release).
+    Series,
+    /// Both an immutable per-version tag and a moving series tag.
+    Both,
+}
+
+impl TagMode {
+    /// Every mode, in the order error messages list them.
+    pub const ALL: [TagMode; 3] = [TagMode::Exact, TagMode::Series, TagMode::Both];
+
+    /// The configuration key naming this mode.
+    pub fn key(self) -> &'static str {
+        match self {
+            TagMode::Exact => "exact",
+            TagMode::Series => "series",
+            TagMode::Both => "both",
+        }
+    }
+
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|mode| mode.key() == key)
+    }
+
+    /// True when releases create an immutable `tag-format` tag.
+    pub fn includes_exact(self) -> bool {
+        matches!(self, TagMode::Exact | TagMode::Both)
+    }
+
+    /// True when releases move a `series-tag-format` tag.
+    pub fn includes_series(self) -> bool {
+        matches!(self, TagMode::Series | TagMode::Both)
+    }
+}
+
+/// The moving series a version belongs to: `0.Y` while the major is 0 (where
+/// every minor bump is a breaking change), `X` afterward. Prereleases belong
+/// to no series — a release candidate must never move the tag consumers pin.
+pub fn series_of(version: &str) -> Option<String> {
+    let version = semver::Version::parse(version).ok()?;
+    if !version.pre.is_empty() {
+        return None;
+    }
+    Some(if version.major == 0 {
+        format!("0.{}", version.minor)
+    } else {
+        version.major.to_string()
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -301,6 +376,22 @@ impl ConfigFile {
                 );
             }
         }
+        for key in self.publish.tag_mode_overrides.keys() {
+            if TagMode::from_key(key).is_none() {
+                bail!(
+                    "unknown `tag-mode-overrides` key `{key}`; the tag modes are {}",
+                    TagMode::ALL
+                        .map(|mode| format!("`{}`", mode.key()))
+                        .join(", ")
+                );
+            }
+        }
+        if !self.publish.series_tag_format.contains("{series}") {
+            bail!(
+                "`series-tag-format` `{}` has no {{series}} placeholder",
+                self.publish.series_tag_format
+            );
+        }
         Ok(())
     }
 
@@ -309,6 +400,23 @@ impl ConfigFile {
             .tag_format
             .replace("{name}", name)
             .replace("{version}", version)
+    }
+
+    /// The moving tag for `version`'s series, or `None` when the version has
+    /// no series (a prerelease, or an unparseable version).
+    pub fn format_series_tag(&self, name: &str, version: &str) -> Option<String> {
+        series_of(version).map(|series| {
+            self.publish
+                .series_tag_format
+                .replace("{name}", name)
+                .replace("{series}", &series)
+        })
+    }
+
+    /// True when the series tag is repository-wide — one tag shared by every
+    /// series-mode member rather than one per package.
+    pub fn series_tag_is_repo_wide(&self) -> bool {
+        !self.publish.series_tag_format.contains("{name}")
     }
 }
 
@@ -445,6 +553,101 @@ mod tests {
         assert!(!has_trellis_table(&without));
         let not_table: toml::Value = toml::from_str("[tools]\ntrellis = true").unwrap();
         assert!(!has_trellis_table(&not_table));
+    }
+
+    #[test]
+    fn series_is_derived_from_the_version() {
+        // Pre-1.0 packages get a major.minor series; 1.0 and later get the
+        // major alone.
+        assert_eq!(series_of("0.0.1").as_deref(), Some("0.0"));
+        assert_eq!(series_of("0.0.17").as_deref(), Some("0.0"));
+        assert_eq!(series_of("0.1.0").as_deref(), Some("0.1"));
+        assert_eq!(series_of("0.12.3").as_deref(), Some("0.12"));
+        assert_eq!(series_of("1.2.3").as_deref(), Some("1"));
+        assert_eq!(series_of("10.0.0").as_deref(), Some("10"));
+        // A prerelease belongs to no series, and so never moves a tag.
+        assert_eq!(series_of("0.0.1-rc.1"), None);
+        assert_eq!(series_of("1.0.0-beta"), None);
+        // Build metadata is not a prerelease.
+        assert_eq!(series_of("1.0.0+build.5").as_deref(), Some("1"));
+        assert_eq!(series_of("not-a-version"), None);
+    }
+
+    #[test]
+    fn formats_series_tags() {
+        let config =
+            ConfigFile::from_gleam_toml("[tools.trellis]\nmembers = [\"packages/*\"]").unwrap();
+        assert_eq!(config.publish.series_tag_format, "{name}-v{series}");
+        assert_eq!(
+            config.format_series_tag("core", "0.0.3").as_deref(),
+            Some("core-v0.0")
+        );
+        assert_eq!(config.format_series_tag("core", "0.0.3-rc.1"), None);
+
+        let repo_wide = ConfigFile::from_gleam_toml(
+            "[tools.trellis]\n[tools.trellis.publish]\nseries-tag-format = \"v{series}\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            repo_wide.format_series_tag("core", "0.0.3").as_deref(),
+            Some("v0.0")
+        );
+    }
+
+    #[test]
+    fn parses_tag_modes_and_overrides() {
+        let config = ConfigFile::from_gleam_toml(
+            r###"
+            [tools.trellis]
+            members = ["packages/*"]
+
+            [tools.trellis.publish]
+            tag-mode = "series"
+            tag-mode-overrides = { both = ["packages/lat_*"], exact = ["packages/old"] }
+        "###,
+        )
+        .unwrap();
+        assert_eq!(config.publish.tag_mode, TagMode::Series);
+        assert_eq!(
+            config.publish.tag_mode_overrides["both"],
+            vec!["packages/lat_*"]
+        );
+        assert_eq!(
+            config.publish.tag_mode_overrides["exact"],
+            vec!["packages/old"]
+        );
+    }
+
+    #[test]
+    fn tag_mode_defaults_to_exact_only() {
+        let config =
+            ConfigFile::from_gleam_toml("[tools.trellis]\nmembers = [\"packages/*\"]").unwrap();
+        assert_eq!(config.publish.tag_mode, TagMode::Exact);
+        assert!(config.publish.tag_mode_overrides.is_empty());
+        assert!(config.publish.tag_mode.includes_exact());
+        assert!(!config.publish.tag_mode.includes_series());
+        assert!(TagMode::Both.includes_exact() && TagMode::Both.includes_series());
+        assert!(TagMode::Series.includes_series() && !TagMode::Series.includes_exact());
+    }
+
+    #[test]
+    fn unknown_tag_mode_override_key_is_a_clear_error() {
+        let err = ConfigFile::from_gleam_toml(
+            "[tools.trellis]\n[tools.trellis.publish]\ntag-mode-overrides = { seires = [\"x\"] }\n",
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("seires"), "{message}");
+        assert!(message.contains("series"), "{message}");
+    }
+
+    #[test]
+    fn series_tag_format_must_carry_the_series_placeholder() {
+        let err = ConfigFile::from_gleam_toml(
+            "[tools.trellis]\n[tools.trellis.publish]\nseries-tag-format = \"{name}-latest\"\n",
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("{series}"), "{err:#}");
     }
 
     #[test]

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -2,7 +2,7 @@
 //! dependency graph. Every command starts here; the topological order is
 //! computed once and consumed everywhere.
 
-use crate::config::ConfigFile;
+use crate::config::{ConfigFile, TagMode};
 use crate::gleam::GleamManifest;
 use anyhow::{Context, Result, bail};
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -20,6 +20,9 @@ pub struct Member {
     pub manifest: GleamManifest,
     /// False when the member matches an `@release` exclusion glob.
     pub releasable: bool,
+    /// Which tags a release creates for this member: the workspace
+    /// `tag-mode`, unless a `tag-mode-overrides` glob claims it.
+    pub tag_mode: TagMode,
 }
 
 impl Member {
@@ -202,6 +205,21 @@ impl Workspace {
                 diagnostics.error(format!("invalid release exclusion glob: {err:#}"));
             })
             .ok();
+        // Unknown mode keys are already rejected by `ConfigFile::validate`;
+        // skipping them here keeps doctor's lenient load from panicking on a
+        // config it is about to report as invalid anyway.
+        let mut tag_mode_overrides: Vec<(TagMode, globset::GlobSet)> = Vec::new();
+        for (key, patterns) in &config.publish.tag_mode_overrides {
+            let Some(mode) = TagMode::from_key(key) else {
+                continue;
+            };
+            match build_globset(patterns) {
+                Ok(set) => tag_mode_overrides.push((mode, set)),
+                Err(err) => {
+                    diagnostics.error(format!("invalid `tag-mode-overrides.{key}` glob: {err:#}"));
+                }
+            }
+        }
         let mut members = Vec::new();
         for dir in member_dirs {
             let rel_path = rel_path_string(root, &dir);
@@ -233,12 +251,19 @@ impl Workspace {
                         .as_ref()
                         .map(|set| !set.is_match(&rel_path))
                         .unwrap_or(true);
+                    let tag_mode = resolve_tag_mode(
+                        &tag_mode_overrides,
+                        &rel_path,
+                        config.publish.tag_mode,
+                        &mut diagnostics,
+                    );
                     members.push(Member {
                         name: manifest.name.clone(),
                         path: dir,
                         rel_path,
                         manifest,
                         releasable,
+                        tag_mode,
                     });
                 }
                 Err(err) => diagnostics.error(format!("{err:#}")),
@@ -609,6 +634,39 @@ fn discover_member_dirs(root: &Path, diagnostics: &mut Diagnostics) -> Vec<PathB
     dirs.into_iter().collect()
 }
 
+/// The member's tag mode: `default`, unless exactly one override claims it.
+/// Two overrides claiming the same member is ambiguous — there is no sensible
+/// precedence between `series` and `both` — so it is reported rather than
+/// silently resolved.
+fn resolve_tag_mode(
+    overrides: &[(TagMode, globset::GlobSet)],
+    rel_path: &str,
+    default: TagMode,
+    diagnostics: &mut Diagnostics,
+) -> TagMode {
+    let matched: Vec<TagMode> = overrides
+        .iter()
+        .filter(|(_, set)| set.is_match(rel_path))
+        .map(|(mode, _)| *mode)
+        .collect();
+    match matched.as_slice() {
+        [] => default,
+        [mode] => *mode,
+        modes => {
+            diagnostics.error(format!(
+                "member `{rel_path}` matches `tag-mode-overrides` globs for {}; \
+                 a member may have only one tag mode",
+                modes
+                    .iter()
+                    .map(|mode| format!("`{}`", mode.key()))
+                    .collect::<Vec<_>>()
+                    .join(" and ")
+            ));
+            default
+        }
+    }
+}
+
 fn build_globset(patterns: &[String]) -> Result<globset::GlobSet> {
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in patterns {
@@ -682,6 +740,53 @@ mod tests {
         assert!(
             cycle.len() == 4,
             "cycle should name all three members: {cycle:?}"
+        );
+    }
+
+    fn globs(patterns: &[&str]) -> globset::GlobSet {
+        build_globset(&names(patterns)).unwrap()
+    }
+
+    #[test]
+    fn tag_mode_falls_back_to_the_workspace_default() {
+        let mut diagnostics = Diagnostics::default();
+        let overrides = vec![(TagMode::Both, globs(&["packages/lat_*"]))];
+        assert_eq!(
+            resolve_tag_mode(&overrides, "packages/cli", TagMode::Exact, &mut diagnostics),
+            TagMode::Exact
+        );
+        assert_eq!(
+            resolve_tag_mode(
+                &overrides,
+                "packages/lat_core",
+                TagMode::Exact,
+                &mut diagnostics
+            ),
+            TagMode::Both
+        );
+        assert!(diagnostics.errors.is_empty());
+    }
+
+    #[test]
+    fn a_member_matching_two_tag_modes_is_an_error() {
+        let mut diagnostics = Diagnostics::default();
+        let overrides = vec![
+            (TagMode::Series, globs(&["packages/*"])),
+            (TagMode::Both, globs(&["packages/lat_*"])),
+        ];
+        let mode = resolve_tag_mode(
+            &overrides,
+            "packages/lat_core",
+            TagMode::Exact,
+            &mut diagnostics,
+        );
+        assert_eq!(mode, TagMode::Exact, "falls back to the default");
+        assert_eq!(diagnostics.errors.len(), 1);
+        let error = &diagnostics.errors[0];
+        assert!(error.contains("packages/lat_core"), "{error}");
+        assert!(
+            error.contains("`series`") && error.contains("`both`"),
+            "{error}"
         );
     }
 

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -577,6 +577,377 @@ fn publish_rejects_unreleasable_package() {
         .stderr(predicate::str::contains("excluded from release"));
 }
 
+// ---- series tags -----------------------------------------------------------
+
+/// The basic fixture with `[tools.trellis.publish]` replaced by `publish`, in
+/// a git repo with a bare origin. The returned remote must outlive the test.
+fn series_repo(root: &Path, publish: &str) -> tempfile::TempDir {
+    copy_fixture_to(root);
+    write(
+        &root.join("gleam.toml"),
+        &format!(
+            "[tools.trellis]\nmembers = [\"packages/*\", \"examples/*\"]\n\
+             exclude = {{ \"@release\" = [\"examples/*\"] }}\n\n\
+             [tools.trellis.publish]\n{publish}\n"
+        ),
+    );
+    init_repo(root);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    remote
+}
+
+fn set_version(root: &Path, package: &str, version: &str) {
+    let path = root.join("packages").join(package).join("gleam.toml");
+    let text = fs::read_to_string(&path).unwrap();
+    let text: Vec<String> = text
+        .lines()
+        .map(|line| {
+            if line.starts_with("version = ") {
+                format!("version = \"{version}\"")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+    fs::write(&path, text.join("\n") + "\n").unwrap();
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git {args:?} failed");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn commit_of(dir: &Path, revision: &str) -> String {
+    git_stdout(dir, &["rev-parse", &format!("{revision}^{{commit}}")])
+}
+
+#[test]
+fn series_tag_moves_with_each_release_while_exact_tags_stay_put() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let remote = series_repo(
+        root,
+        "tag-mode-overrides = { both = [\"packages/lat_cli\"] }",
+    );
+    let remote = remote.path();
+    set_version(root, "lat_cli", "0.0.1");
+    git(root, &["commit", "-qam", "lat_cli 0.0.1"]);
+
+    // The first release of a series creates both tags at the same commit.
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tagged lat_cli-v0.0.1"))
+        .stdout(predicate::str::contains("tagged lat_cli-v0.0"));
+    let first = commit_of(root, "HEAD");
+    assert_eq!(commit_of(root, "lat_cli-v0.0.1"), first);
+    assert_eq!(commit_of(root, "lat_cli-v0.0"), first);
+    // Other packages keep the default mode: exact tags only.
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert!(tags.contains("lat_core-v1.2.0"), "{tags}");
+    assert!(!tags.contains("lat_core-v1\n"), "{tags}");
+
+    set_version(root, "lat_cli", "0.0.2");
+    git(root, &["commit", "-qam", "lat_cli 0.0.2"]);
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tagged lat_cli-v0.0.2"))
+        .stdout(predicate::str::contains("moved lat_cli-v0.0"))
+        .stdout(predicate::str::contains("force-pushed lat_cli-v0.0"));
+
+    let second = commit_of(root, "HEAD");
+    assert_ne!(first, second);
+    assert_eq!(commit_of(root, "lat_cli-v0.0"), second, "series tag moved");
+    assert_eq!(
+        commit_of(root, "lat_cli-v0.0.1"),
+        first,
+        "exact tags are immutable"
+    );
+    assert_eq!(commit_of(root, "lat_cli-v0.0.2"), second);
+    // Origin has the move too, not just the local repo.
+    assert_eq!(commit_of(remote, "lat_cli-v0.0"), second);
+    assert_eq!(commit_of(remote, "lat_cli-v0.0.1"), first);
+
+    // Re-running moves nothing.
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("moved").not())
+        .stdout(predicate::str::contains("force-pushed").not());
+    assert_eq!(commit_of(root, "lat_cli-v0.0"), second);
+    trellis(root)
+        .args(["tag", "plan"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("already tagged"));
+}
+
+#[test]
+fn info_reports_the_tags_a_package_actually_gets() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag-mode-overrides = { both = [\"packages/lat_cli\"] }",
+    );
+
+    trellis(root)
+        .args(["info", "lat_cli"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tag:        lat_cli-v0.3.1"))
+        .stdout(predicate::str::contains("series tag: lat_cli-v0.3"));
+    trellis(root)
+        .args(["info", "lat_core"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tag:        lat_core-v1.2.0"))
+        .stdout(predicate::str::contains("series tag:").not());
+}
+
+#[test]
+fn tag_plan_reports_the_series_move() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag-mode-overrides = { both = [\"packages/lat_cli\"] }",
+    );
+    trellis(root).args(["tag", "create"]).assert().success();
+    git(root, &["commit", "-q", "--allow-empty", "-m", "later work"]);
+
+    trellis(root)
+        .args(["tag", "plan"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "lat_cli: 0.3.1 moves tag lat_cli-v0.3",
+        ));
+
+    let output = trellis(root)
+        .args(["tag", "plan", "--json"])
+        .output()
+        .unwrap();
+    let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let plan = plan.as_array().unwrap();
+    assert_eq!(plan.len(), 1, "only the series tag needs work: {plan:?}");
+    assert_eq!(plan[0]["tag"], "lat_cli-v0.3");
+    assert_eq!(plan[0]["kind"], "series");
+    assert_eq!(plan[0]["action"], "move");
+}
+
+#[test]
+fn github_releases_skip_series_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag-mode-overrides = { both = [\"packages/lat_cli\"] }",
+    );
+    let gh = install_fake_gh(root);
+
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args(["tag", "create", "--github-release"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "created GitHub release lat_cli-v0.3.1",
+        ));
+
+    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
+    assert!(log.contains("release create lat_cli-v0.3.1"), "{log}");
+    // A release bound to a moving tag would silently retarget on the next move.
+    assert!(!log.contains("release create lat_cli-v0.3 "), "{log}");
+    assert!(!log.contains("release view lat_cli-v0.3 "), "{log}");
+    // The series tag itself is still created and pushed.
+    assert_eq!(commit_of(root, "lat_cli-v0.3"), commit_of(root, "HEAD"));
+}
+
+#[test]
+fn series_only_mode_creates_no_exact_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(root, "tag-mode = \"series\"");
+    // A prerelease belongs to no series, so it moves nothing.
+    set_version(root, "lat_mid", "0.6.0-rc.1");
+    git(root, &["commit", "-qam", "lat_mid rc"]);
+
+    trellis(root).args(["tag", "create"]).assert().success();
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert_eq!(
+        tags.lines().collect::<Vec<_>>(),
+        vec!["lat_cli-v0.3", "lat_core-v1"]
+    );
+
+    trellis(root)
+        .args(["ci", "outputs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tags=[]\n"))
+        .stdout(predicate::str::contains(
+            "series-tags=[\"lat_core-v1\",\"lat_cli-v0.3\"]",
+        ));
+}
+
+#[test]
+fn default_config_creates_no_series_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+
+    trellis(root).args(["tag", "create"]).assert().success();
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert_eq!(
+        tags.lines().collect::<Vec<_>>(),
+        vec!["lat_cli-v0.3.1", "lat_core-v1.2.0", "lat_mid-v0.5.0"]
+    );
+    trellis(root)
+        .args(["ci", "outputs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("series-tags=[]"));
+}
+
+#[test]
+fn a_series_tag_names_a_package_but_never_a_release() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag-mode-overrides = { both = [\"packages/lat_cli\"] }",
+    );
+
+    // CI can still route on it…
+    trellis(root)
+        .args(["ci", "tag-package", "lat_cli-v0.3"])
+        .assert()
+        .success()
+        .stdout("lat_cli\n");
+    let output = trellis(root)
+        .args(["ci", "tag-package", "lat_cli-v0.3", "--json"])
+        .output()
+        .unwrap();
+    let resolved: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(resolved["name"], "lat_cli");
+    assert_eq!(resolved["tag-kind"], "series");
+    assert_eq!(resolved["tag-series"], "0.3");
+    assert!(resolved.get("tag-version").is_none());
+
+    // …but it names no version, so it cannot trigger a publish.
+    trellis(root)
+        .args(["publish", "--tag", "lat_cli-v0.3"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("moving v0.3 series tag"))
+        .stderr(predicate::str::contains("--all-untagged"));
+
+    // The exact tag still resolves as before.
+    let output = trellis(root)
+        .args(["ci", "tag-package", "lat_cli-v0.3.1", "--json"])
+        .output()
+        .unwrap();
+    let resolved: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(resolved["tag-kind"], "exact");
+    assert_eq!(resolved["tag-version"], "0.3.1");
+}
+
+#[test]
+fn doctor_warns_about_a_repo_wide_series_tag_whatever_the_versions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag-mode = \"both\"\nseries-tag-format = \"v{series}\"",
+    );
+
+    // lat_core 1.2.0, lat_mid 0.5.0 and lat_cli 0.3.1 are three distinct
+    // series, so no two members render the same tag — and it is ambiguous
+    // anyway, because a `{name}`-less format matches every member.
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "`series-tag-format` `v{series}` has no {name}, so one repository-wide series tag \
+             covers `lat_core`, `lat_mid`, `lat_cli`",
+        ));
+    trellis(root)
+        .args(["ci", "tag-package", "v0.3"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("names no single package"));
+
+    // Colliding versions are the same warning, not a new one.
+    set_version(root, "lat_cli", "0.5.2");
+    git(root, &["commit", "-qam", "lat_cli 0.5.2"]);
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("has no {name}"));
+}
+
+#[test]
+fn a_named_series_format_stays_unambiguous() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(root, "tag-mode = \"both\"");
+    // Two packages in the same series: with `{name}` in the format their tags
+    // stay distinct, so there is nothing to warn about and each still resolves.
+    set_version(root, "lat_cli", "0.5.2");
+    git(root, &["commit", "-qam", "lat_cli 0.5.2"]);
+
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("series tag").not());
+    trellis(root)
+        .args(["ci", "tag-package", "lat_cli-v0.5"])
+        .assert()
+        .success()
+        .stdout("lat_cli\n");
+    trellis(root)
+        .args(["ci", "tag-package", "lat_mid-v0.5"])
+        .assert()
+        .success()
+        .stdout("lat_mid\n");
+}
+
+#[test]
+fn doctor_rejects_a_tag_mode_override_that_matches_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag-mode-overrides = { series = [\"packages/nope\"] }",
+    );
+
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "`tag-mode-overrides.series` glob `packages/nope` matches no member",
+        ));
+}
+
 // ---- lockfile refresh ------------------------------------------------------
 
 #[test]

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -37,6 +37,8 @@ export default defineConfig({
         "./src/styles/starlight.css",
       ],
       components: {
+        Head: "./src/components/starlight/Head.astro",
+        Header: "./src/components/starlight/Header.astro",
         ThemeProvider: "./src/components/starlight/ThemeProvider.astro",
         ThemeSelect: "./src/components/starlight/ThemeSelect.astro",
       },

--- a/website/src/components/AnnounceDismissScript.astro
+++ b/website/src/components/AnnounceDismissScript.astro
@@ -1,0 +1,22 @@
+---
+// Runs in <head>, parser-blocking, before first paint: a reader who dismissed
+// the current release must never see the bar flash and the page jump. Setting
+// the attribute here zeroes --announce-h (tokens.css), which collapses every
+// offset derived from it — so the layout is correct on the very first frame.
+import { ANNOUNCE_STORAGE_KEY } from "../lib/announce";
+import { TRELLIS_VERSION } from "../lib/version";
+---
+
+<script
+  is:inline
+  define:vars={{ key: ANNOUNCE_STORAGE_KEY, version: TRELLIS_VERSION }}
+>
+  try {
+    if (localStorage.getItem(key) === version) {
+      document.documentElement.dataset.announceDismissed = "";
+    }
+  } catch {
+    // Storage can throw when cookies are blocked; showing the bar is the
+    // right fallback.
+  }
+</script>

--- a/website/src/components/AnnouncementBar.astro
+++ b/website/src/components/AnnouncementBar.astro
@@ -1,0 +1,155 @@
+---
+// A thin band naming the current release and linking to its notes. The version
+// is derived from Cargo.toml (see lib/version.ts), so cutting a release is the
+// only edit this bar ever needs. Positioning is left to the consumer: the
+// landing page sticks it above the header (global.css), the docs pin it to the
+// top strip of Starlight's fixed header (starlight.css).
+// Dismissal is version-keyed and applied in <head> by AnnounceDismissScript.
+import { TRELLIS_VERSION } from "../lib/version";
+
+const href = `https://github.com/tylerbutler/trellis/releases/tag/v${TRELLIS_VERSION}`;
+---
+
+<div class="announce" data-version={TRELLIS_VERSION}>
+  <a
+    class="announce-link"
+    href={href}
+    aria-label={`Latest release: trellis v${TRELLIS_VERSION} — read the release notes`}
+  >
+    <span class="announce-label">Latest release</span>
+    <span class="announce-version">v{TRELLIS_VERSION}</span>
+    <span class="announce-cta">
+      Release notes<span class="announce-arrow" aria-hidden="true">→</span>
+    </span>
+  </a>
+  <button class="announce-dismiss" type="button" aria-label="Dismiss release announcement">
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+      <path
+        d="M2.5 2.5 9.5 9.5M9.5 2.5 2.5 9.5"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+      ></path>
+    </svg>
+  </button>
+</div>
+
+<script>
+  import { ANNOUNCE_STORAGE_KEY } from "../lib/announce";
+
+  const bar = document.querySelector<HTMLElement>(".announce");
+  const dismiss = bar?.querySelector<HTMLButtonElement>(".announce-dismiss");
+
+  dismiss?.addEventListener("click", () => {
+    const version = bar?.dataset.version;
+    if (version) {
+      try {
+        localStorage.setItem(ANNOUNCE_STORAGE_KEY, version);
+      } catch {
+        // Dismissal simply won't persist if storage is unavailable.
+      }
+    }
+    document.documentElement.dataset.announceDismissed = "";
+  });
+</script>
+
+<style>
+  .announce {
+    position: relative;
+    height: var(--announce-h);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--cobalt-band);
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  .announce-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    max-width: 100%;
+    /* Keeps the message centred in the bar rather than in the space left
+       over by the dismiss button. */
+    padding-inline: 2.75rem;
+    color: var(--ink-soft);
+    font-size: var(--text-fine);
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .announce-label {
+    color: var(--muted);
+    font-size: 0.6875rem;
+    font-weight: 620;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+  }
+
+  .announce-version {
+    color: var(--brass);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+  }
+
+  .announce-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .announce-arrow {
+    transition: transform 160ms var(--ease-out);
+  }
+
+  .announce-link:hover {
+    color: var(--brass-bright);
+  }
+
+  .announce-link:hover .announce-cta {
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  .announce-link:hover .announce-arrow {
+    transform: translateX(0.15rem);
+  }
+
+  .announce-dismiss {
+    position: absolute;
+    inset-inline-end: var(--sp-xs);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    transition: color 160ms var(--ease-out), background 160ms var(--ease-out);
+  }
+
+  .announce-dismiss:hover {
+    color: var(--ink);
+    background: color-mix(in oklch, var(--ink) 10%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .announce-arrow,
+    .announce-dismiss {
+      transition: none;
+    }
+  }
+
+  @media (max-width: 30rem) {
+    .announce-label {
+      display: none;
+    }
+  }
+</style>

--- a/website/src/components/starlight/Head.astro
+++ b/website/src/components/starlight/Head.astro
@@ -1,0 +1,10 @@
+---
+// Starlight builds the whole <head>, so the dismissal script joins it through
+// an override — it has to run before first paint, which the `head` config
+// array can't express (it has no access to the derived version).
+import Default from "@astrojs/starlight/components/Head.astro";
+import AnnounceDismissScript from "../AnnounceDismissScript.astro";
+---
+
+<Default />
+<AnnounceDismissScript />

--- a/website/src/components/starlight/Header.astro
+++ b/website/src/components/starlight/Header.astro
@@ -1,0 +1,13 @@
+---
+// Starlight's header is fixed to the top of the viewport, so the announcement
+// bar rides along inside it: starlight.css grows --sl-nav-height by
+// --announce-h and pads the nav row down, leaving the top strip for the bar.
+// Growing the nav height (rather than absolutely placing a bar above it) keeps
+// the sidebar inset, main padding, and scroll offsets correct for free — they
+// are all derived from --sl-nav-height.
+import Default from "@astrojs/starlight/components/Header.astro";
+import AnnouncementBar from "../AnnouncementBar.astro";
+---
+
+<AnnouncementBar />
+<Default />

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -82,7 +82,7 @@ series-tags=["lat_cli-v0.3"]
 
 `tags` lists the immutable per-version tags and `series-tags` the moving ones,
 each covering only the packages whose
-[`tag-mode`](/docs/configuration/#pre-10-series-tags) creates that kind — so a
+[`tag-mode`](/docs/configuration/#series-tags) creates that kind — so a
 `series`-only workspace reports an empty `tags`.
 
 ## PR gates
@@ -124,7 +124,7 @@ a tag-push workflow publishes each package:
 ```
 
 This shape needs per-version tags. A moving
-[series tag](/docs/configuration/#pre-10-series-tags) matches `*-v*` too, but
+[series tag](/docs/configuration/#series-tags) matches `*-v*` too, but
 names no particular version, so `publish --tag` rejects it by design —
 `ci tag-package` still resolves it, so the workflow can route on it. Packages
 tagged `series`-only belong in the publish-then-tag shape below.

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -77,7 +77,13 @@ projects=["lat_core","lat_mid","lat_cli","package_a"]
 releasable=["lat_core","lat_mid","lat_cli"]
 version-files=["packages/lat_core/gleam.toml","packages/lat_mid/gleam.toml","packages/lat_cli/gleam.toml"]
 tags=["lat_core-v1.2.0","lat_mid-v0.5.0","lat_cli-v0.3.1"]
+series-tags=["lat_cli-v0.3"]
 ```
+
+`tags` lists the immutable per-version tags and `series-tags` the moving ones,
+each covering only the packages whose
+[`tag-mode`](/docs/configuration/#pre-10-series-tags) creates that kind — so a
+`series`-only workspace reports an empty `tags`.
 
 ## PR gates
 
@@ -116,6 +122,12 @@ a tag-push workflow publishes each package:
 - run: trellis publish --tag "$GITHUB_REF_NAME"
 - run: trellis lockfile refresh --package "$(trellis ci tag-package "$GITHUB_REF_NAME")"
 ```
+
+This shape needs per-version tags. A moving
+[series tag](/docs/configuration/#pre-10-series-tags) matches `*-v*` too, but
+names no particular version, so `publish --tag` rejects it by design —
+`ci tag-package` still resolves it, so the workflow can route on it. Packages
+tagged `series`-only belong in the publish-then-tag shape below.
 
 Or publish-then-tag — one idempotent run publishes everything not yet on Hex,
 in topological order, then records what shipped:

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -37,6 +37,8 @@ needs-deps = true            # run `gleam deps download` first if not cached
 
 [tools.trellis.publish]
 tag-format = "{name}-v{version}"
+series-tag-format = "{name}-v{series}"
+tag-mode = "exact"
 ```
 
 Each member is a directory with its own `gleam.toml`. Path dependencies
@@ -84,6 +86,9 @@ their roots.
 | `exclude.@members` | no | Directories removed from workspace membership entirely — never parsed, graphed, or touched by any command. Useful for committed test fixtures that auto-discovery would otherwise sweep in; also filters explicit `members` globs. |
 | `tasks.<name>` | no | Custom tasks for `trellis run`. A task with a built-in's name (`build`, `test`, …) overrides it. `needs-deps = true` downloads dependencies first. |
 | `publish.tag-format` | no | Template for per-member git tags. Default: `{name}-v{version}`. |
+| `publish.series-tag-format` | no | Template for the moving series tag, substituting `{name}` and `{series}`. Omit `{name}` for one repository-wide tag. Default: `{name}-v{series}`. |
+| `publish.tag-mode` | no | Which tags a release creates: `exact` (default), `series`, or `both`. |
+| `publish.tag-mode-overrides` | no | Per-package tag modes: a map of mode name to member-path globs. A member matching globs under two modes is an error. |
 | `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial-delay, multiplier }`. |
 | `changelog.kinds` | no | Change kinds and the version bump each implies. The largest bump among a package's unreleased fragments wins. |
 | `changelog.*-format` | no | Minijinja templates for rendered changelog sections: `version-format`, `kind-format`, `change-format`. |
@@ -142,12 +147,74 @@ will never exist on Hex.
 
 </Callout>
 
+## Pre-1.0 series tags
+
+Trellis 0.7.0 added a second tag lifecycle. Alongside the immutable
+`{name}-v{version}` tag a release creates, a package can move a **series tag**
+that always points at the newest release in its series — so consumers pin
+`lat_cli-v0.0` once instead of chasing `0.0.1`, `0.0.2`, `0.0.3`.
+
+The series is derived from the version, never configured. While the major is
+0, every minor bump is a breaking change, so the series is `major.minor`;
+afterward it is the major alone:
+
+| Version | Series tag |
+| --- | --- |
+| `0.0.1`, `0.0.2`, `0.0.3` | `lat_cli-v0.0` |
+| `0.1.0`, `0.1.4` | `lat_cli-v0.1` |
+| `1.2.1`, `1.9.0` | `lat_cli-v1` |
+| `0.0.1-rc.1` | none — a prerelease belongs to no series and moves no tag |
+
+`tag-mode` picks the lifecycle for the workspace, and `tag-mode-overrides`
+picks it per package, as globs matched against member paths:
+
+```toml title="gleam.toml"
+[tools.trellis.publish]
+tag-mode = "exact"                                    # workspace default
+tag-mode-overrides = { both = ["packages/lat_cli"] }  # lat_cli also moves a series tag
+```
+
+Releasing `lat_cli` twice then leaves the exact tags where they were and the
+series tag on the newest release:
+
+```console
+$ trellis tag create --push        # releasing 0.0.1
+tagged lat_cli-v0.0.1
+pushed lat_cli-v0.0.1
+tagged lat_cli-v0.0
+pushed lat_cli-v0.0
+
+$ trellis tag create --push        # releasing 0.0.2
+tagged lat_cli-v0.0.2
+pushed lat_cli-v0.0.2
+moved lat_cli-v0.0
+force-pushed lat_cli-v0.0
+```
+
+Setting `series-tag-format = "v{series}"` drops `{name}` and gives the whole
+repository one shared series tag — exactly right for a single-package repo.
+With more than one package it is still allowed, but it costs something: the
+tag no longer identifies a package, so `trellis ci tag-package` cannot resolve
+it. That is true of every such tag regardless of how the packages are
+versioned — there is no `{name}` to tell them apart — so `doctor` warns as
+soon as a second package moves one, rather than waiting for two packages to
+land in the same series.
+
+<Callout>
+
+Series tags are the one ref trellis rewrites — they are force-moved and
+force-pushed on every release. That is also why they never carry a GitHub
+Release: the release would silently retarget on the next move. See
+[Publishing](/docs/publishing/#tags) for how the two lifecycles differ.
+
+</Callout>
+
 ## Changelog configuration
 
 The changelog engine is native — no second tool to install, no config file to
 keep in sync. Changes live as TOML fragments in `.changes/unreleased/`;
 rendering is controlled by small minijinja templates, each with a context of
-`name`, `version`, `date`, `tag`, `kind`, and `body` as applicable:
+`name`, `version`, `date`, `tag`, `series`, `kind`, and `body` as applicable:
 
 ```toml wrap
 [tools.trellis.changelog]

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -147,7 +147,7 @@ will never exist on Hex.
 
 </Callout>
 
-## Pre-1.0 series tags
+## Series tags
 
 Trellis 0.7.0 added a second tag lifecycle. Alongside the immutable
 `{name}-v{version}` tag a release creates, a package can move a **series tag**

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -69,7 +69,7 @@ A package tags in one of two lifecycles, chosen by `tag-mode`:
   force-moves its tag to the release commit and force-pushes it, so consumers
   can pin `lat_cli-v0.4` and follow the series instead of chasing patch tags.
   The series is derived from the version — see
-  [pre-1.0 series tags](/docs/configuration/#pre-10-series-tags).
+  [series tags](/docs/configuration/#series-tags).
 
 ```console
 $ trellis tag plan

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -25,7 +25,15 @@ Tag format, path-dep rewriting, and Hex retry policy are configured under
 
 ```toml title="gleam.toml" wrap
 [tools.trellis.publish]
-tag-format = "{name}-v{version}"      # lat_core-v1.2.0
+tag-format = "{name}-v{version}"          # lat_core-v1.2.0
+series-tag-format = "{name}-v{series}"    # lat_core-v1, lat_cli-v0.4
+# Which tags a release creates:
+#   exact   → the immutable per-version tag only   (default)
+#   series  → the moving series tag only
+#   both    → one of each
+tag-mode = "exact"
+# Per-package overrides, as globs matched against member paths.
+tag-mode-overrides = { both = ["packages/lat_cli"] }
 # How a path dep is rewritten to a Hex requirement at publish time, from the
 # dependency's current version X.Y.Z:
 #   minor  → ">= X.Y.Z and < (X+1).0.0"   (default)
@@ -46,23 +54,48 @@ and is a no-op when there are no fragments.
 
 ## Tags
 
-`tag plan` lists releasable packages whose `gleam.toml` version has no tag
-yet, per the configured `tag-format`. `tag create` creates the missing tags
-in topological order; `--push` pushes them, and `--github-release` (which
-implies `--push` and requires the `gh` CLI) also creates a GitHub Release per
-tag with the matching CHANGELOG section as the body.
+`tag plan` lists the tags the current versions call for and don't have yet.
+`tag create` reconciles them in topological order; `--push` pushes them, and
+`--github-release` (which implies `--push` and requires the `gh` CLI) also
+creates a GitHub Release per tag with the matching CHANGELOG section as the
+body.
+
+A package tags in one of two lifecycles, chosen by `tag-mode`:
+
+- **Exact tags** (`{name}-v{version}`) are immutable. They are created once,
+  fetched when origin already has them, and never rewritten — local and remote
+  disagreeing about what one names is an error, not something to reconcile.
+- **Series tags** (`{name}-v{series}`) move. Every release in a series
+  force-moves its tag to the release commit and force-pushes it, so consumers
+  can pin `lat_cli-v0.4` and follow the series instead of chasing patch tags.
+  The series is derived from the version — see
+  [pre-1.0 series tags](/docs/configuration/#pre-10-series-tags).
 
 ```console
 $ trellis tag plan
 lat_core: 1.2.0 needs tag lat_core-v1.2.0
 lat_cli: 0.4.3 needs tag lat_cli-v0.4.3
+lat_cli: 0.4.3 moves tag lat_cli-v0.4
 
 $ trellis tag create --github-release
 tagged lat_core-v1.2.0
 pushed lat_core-v1.2.0
 tagged lat_cli-v0.4.3
 pushed lat_cli-v0.4.3
+moved lat_cli-v0.4
+force-pushed lat_cli-v0.4
 ```
+
+<Callout>
+`--github-release` skips series tags. A release attached to a moving tag would
+silently retarget on the next release, so only the immutable per-version tags
+carry one.
+</Callout>
+
+Under `tag-mode = "series"` a package has no per-version tags at all, so there
+is no tag to trigger a publish from: run `trellis publish --all-untagged` on
+release-PR merge instead. Passing a series tag to `publish --tag` is an error
+— it names a package, but no particular version.
 
 ## Publishing to Hex
 

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -2,6 +2,8 @@
 import "@fontsource-variable/archivo/wdth.css";
 import "@fontsource-variable/martian-mono";
 import "../styles/global.css";
+import AnnouncementBar from "../components/AnnouncementBar.astro";
+import AnnounceDismissScript from "../components/AnnounceDismissScript.astro";
 
 interface Props {
   title: string;
@@ -29,9 +31,11 @@ const github = "https://github.com/tylerbutler/trellis";
     <meta property="og:url" content={Astro.url.href} />
     <meta property="og:image" content={new URL("/og.png", Astro.site)} />
     <meta name="twitter:card" content="summary_large_image" />
+    <AnnounceDismissScript />
   </head>
   <body>
     <a class="skip-link" href="#main">Skip to content</a>
+    <AnnouncementBar />
     <header class="site-header">
       <div class="shell">
         <a class="brand" href="/" aria-label="Trellis home">

--- a/website/src/lib/announce.ts
+++ b/website/src/lib/announce.ts
@@ -1,0 +1,4 @@
+// Dismissal state for the announcement bar. The stored value is the version
+// that was dismissed, not a boolean: silencing v0.6.0 says nothing about
+// v0.7.0, so the next release surfaces the bar again for everyone.
+export const ANNOUNCE_STORAGE_KEY = "trellis:announce-dismissed";

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -110,11 +110,21 @@ kbd {
   margin-inline: auto;
 }
 
+/* -- announcement bar ---------------------------------------- */
+
+/* Pinned above the header so the current release stays one click away.
+   Visual styling lives in components/AnnouncementBar.astro. */
+.announce {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-sticky);
+}
+
 /* -- header -------------------------------------------------- */
 
 .site-header {
   position: sticky;
-  top: 0;
+  top: var(--announce-h);
   z-index: var(--z-sticky);
   background: color-mix(in oklch, var(--bg) 94%, transparent);
   border-bottom: 1px solid var(--line-soft);

--- a/website/src/styles/starlight.css
+++ b/website/src/styles/starlight.css
@@ -48,6 +48,18 @@
 
   /* layout */
   --sl-content-width: 38rem;
+
+  /* The announcement bar lives inside the fixed header, so the nav height
+     grows to cover both. Every other offset Starlight computes — sidebar
+     inset, main padding, scroll-padding — derives from --sl-nav-height and
+     follows automatically. Values mirror Starlight's own defaults. */
+  --sl-nav-height: calc(3.5rem + var(--announce-h));
+}
+
+@media (min-width: 50em) {
+  :root {
+    --sl-nav-height: calc(4rem + var(--announce-h));
+  }
 }
 
 /* -- base ----------------------------------------------------- */
@@ -85,6 +97,30 @@ kbd {
 header.header {
   background-color: var(--sl-color-bg-nav);
   border-bottom: 1px solid var(--line-soft);
+  /* Reserve the top strip of the header box for the announcement bar. */
+  padding-block-start: calc(var(--sl-nav-pad-y) + var(--announce-h));
+}
+
+/* The bar is pinned to the very top of the viewport; the padding above keeps
+   the nav row clear of it. */
+header.header .announce {
+  position: fixed;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  width: 100%;
+}
+
+/* Starlight sizes the logo and the mobile menu button off --sl-nav-height,
+   which now also covers the announcement strip. Subtract the strip back out so
+   both stay proportioned to the nav row itself. */
+.site-title img {
+  height: calc(var(--sl-nav-height) - var(--announce-h) - 2 * var(--sl-nav-pad-y));
+}
+
+starlight-menu-button button {
+  top: calc(
+    var(--announce-h) + (var(--sl-nav-height) - var(--announce-h) - var(--sl-menu-button-size)) / 2
+  );
 }
 
 .site-title {

--- a/website/src/styles/tokens.css
+++ b/website/src/styles/tokens.css
@@ -52,10 +52,24 @@
 
   --measure: 68ch;
   --content-width: 72rem;
+  --announce-h: 2.25rem;
 
   /* semantic z scale */
   --z-sticky: 10;
   --z-skip: 20;
 
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* A dismissed announcement collapses the token rather than just hiding the
+   bar: every offset that reserves room for it — the landing header's sticky
+   top, Starlight's nav height and the sizes derived from it — is expressed in
+   --announce-h, so zeroing it reclaims the space with no leftover gap.
+   Set by AnnounceDismissScript before first paint. */
+:root[data-announce-dismissed] {
+  --announce-h: 0px;
+}
+
+:root[data-announce-dismissed] .announce {
+  display: none;
 }


### PR DESCRIPTION
Adds a second tag lifecycle. Alongside the immutable `{name}-v{version}` tag a release creates, a package can move a **series tag** that always points at the newest release in its series — so consumers pin `pkg-v0.0` once instead of chasing `0.0.1`, `0.0.2`, `0.0.3`.

The series is derived from the version, never configured: `0.Y` while the major is 0 (where every minor bump is breaking), `X` after. Prereleases belong to no series and move nothing.

## Configuration

```toml
[tools.trellis.publish]
tag-format = "{name}-v{version}"          # unchanged
series-tag-format = "{name}-v{series}"    # omit {name} for one repo-wide tag
tag-mode = "exact"                        # exact | series | both — workspace default
tag-mode-overrides = { both = ["packages/lat_cli"] }   # per-package, glob-matched
```

Defaults are unchanged, so existing workspaces behave exactly as before.

## Behavior

Series tags are the one ref trellis rewrites: `tag create` force-moves them to the release commit and force-pushes, and the local/remote divergence check that guards exact tags is deliberately skipped — divergence is the normal state for a moving tag. Three consequences follow from a tag that names no particular version:

- it never carries a GitHub Release, which would silently retarget on the next move;
- `publish --tag` refuses it, while `ci tag-package` still resolves it so CI can route on it;
- a `series`-only workspace publishes via `--all-untagged` rather than a tag-push trigger.

`resolve_tag` now validates what a template captured before accepting a match, so the two formats don't claim each other's tags when they share a prefix, as the defaults do.

## Elsewhere

- `ci outputs` gained `series-tags=` and filters `tags=` by mode.
- `doctor` checks series-tag collisions. A `{name}`-less `series-tag-format` warns instead of erroring once a workspace has more than one series member — sharing one repository-wide tag is the point for a single-package repo, and costs only the ability to resolve the tag back to a package. The warning keys on the format rather than on current versions, because with no `{name}` to substitute every series tag matches every member however they are versioned.
- `info` reports only the tags a package actually gets.
- `series` joined the changelog template context.
- Docs updated: configuration, publishing, and CI pages, README, and DESIGN.