### PR TITLE
feat!: define and version the --json output contract

### DIFF
--- a/.changes/unreleased/Added-20260725-json-output-contract.yaml
+++ b/.changes/unreleased/Added-20260725-json-output-contract.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Every JSON document now carries a `schema` identifier naming the payload and its major version (`"schema": "trellis.list/1"`), so a workflow can assert on the shape it was built against instead of discovering a breaking change through wrong results. The new [JSON output contract](https://trellis.tylerbutler.com/docs/json-output/) page states what stability permits — fields may be added, but renaming, removing, or retyping one bumps the major — and documents the two payloads shaped by GitHub Actions rather than by trellis (`ci matrix` and `ci outputs`), which carry no `schema` field. Each payload is now snapshot-tested, and the six `--json` flags that rendered without help text have it.'
+time: 2026-07-25T09:01:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260725-json-envelopes.yaml
+++ b/.changes/unreleased/Breaking-20260725-json-envelopes.yaml
@@ -1,0 +1,3 @@
+kind: Breaking
+body: 'Three `--json` payloads that were bare arrays are now objects, so they can carry the new `schema` field: `list --json` wraps its array under `packages`, `version plan --json` under `bumped` (matching `version apply`), and `tag plan --json` under `tags`. A consumer doing `trellis list --json | jq ".[].name"` becomes `jq ".packages[].name"`. Every other payload is unchanged apart from the added `schema` key; `ci matrix` and `ci outputs` are untouched.'
+time: 2026-07-25T09:00:00.000000-07:00

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +787,48 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1025,6 +1082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1280,7 @@ dependencies = [
  "globset",
  "ignore",
  "indicatif",
+ "insta",
  "minijinja",
  "predicates",
  "semver",
@@ -1229,6 +1293,12 @@ dependencies = [
  "ureq",
  "vergen-gitcl",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ ureq = { version = "3.3.0", features = ["json"] }
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
+insta = { version = "1.48.0", features = ["json", "redactions"] }
 predicates = "3.1.4"
 tempfile = "3.27.0"
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,18 @@ origin/main` filters to packages owning changed files (committed, uncommitted,
 and untracked); `--with-dependents` adds the reverse-dependency closure. This
 is the primitive behind "only test what a PR touched."
 
+#### JSON output
+
+Every `--json` payload carries a `schema` field naming the payload and its
+major version (`"schema": "trellis.list/1"`), so a workflow can assert on the
+shape it was built against and detect a breaking change instead of silently
+producing wrong results. Fields may be added without a bump; renaming,
+removing, or retyping one bumps the major. Human-readable text output carries
+no such guarantee. `trellis ci matrix` and `ci outputs` are the two
+exceptions — their shapes are dictated by GitHub Actions.
+
+Full details: [docs/json-output](https://trellis.tylerbutler.com/docs/json-output/).
+
 ### Task running
 
 ```

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -2,9 +2,9 @@
 //! writes a fragment; `check` decides which changed packages still need one.
 
 use crate::changelog;
+use crate::json::{ChangelogCheckDocument, ChangelogPackage};
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
-use serde_json::json;
 
 // ---- new ---------------------------------------------------------------
 
@@ -101,19 +101,23 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
     let ok = needs_entry.is_empty() && fragments.problems.is_empty();
 
     if options.json {
-        let payload = json!({
-            "has-entries": !fragments.fragments.is_empty(),
-            "needs-entry": !needs_entry.is_empty(),
-            "invalid-fragments": fragments.problems,
-            "packages": statuses.iter().map(|status| json!({
-                "name": status.name,
-                "changed": true,
-                "has-entry": status.fragments > 0,
-                "fragments": status.fragments,
-            })).collect::<Vec<_>>(),
-            "preview": preview(&statuses, &fragments.problems),
-        });
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        let document = ChangelogCheckDocument {
+            schema: ChangelogCheckDocument::SCHEMA,
+            has_entries: !fragments.fragments.is_empty(),
+            needs_entry: !needs_entry.is_empty(),
+            invalid_fragments: &fragments.problems,
+            packages: statuses
+                .iter()
+                .map(|status| ChangelogPackage {
+                    name: &status.name,
+                    changed: true,
+                    has_entry: status.fragments > 0,
+                    fragments: status.fragments,
+                })
+                .collect(),
+            preview: preview(&statuses, &fragments.problems),
+        };
+        println!("{}", serde_json::to_string_pretty(&document)?);
     } else {
         if statuses.is_empty() {
             println!(

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -3,10 +3,10 @@
 //! lines suitable for `$GITHUB_OUTPUT`; `tag-package` resolves a pushed tag
 //! ($GITHUB_REF_NAME) to the package it belongs to.
 
-use super::tag::ResolvedTag;
+use super::tag::{ResolvedTag, TagKind};
+use crate::json::{CiMatrix, CiTagPackageDocument};
 use crate::workspace::{SelectionFilter, Workspace};
 use anyhow::Result;
-use serde_json::json;
 
 /// Resolve a tag to its package for shell substitution, e.g.
 /// `trellis lockfile refresh --package "$(trellis ci tag-package "$GITHUB_REF_NAME")"`.
@@ -16,23 +16,20 @@ pub fn tag_package(workspace: &Workspace, tag: &str, json_output: bool) -> Resul
     if json_output {
         // A series tag identifies the package but no version, so it reports
         // the series it names instead of `tag-version`.
-        let payload = match &resolved {
-            ResolvedTag::Exact { version, .. } => json!({
-                "name": member.name,
-                "path": member.rel_path,
-                "version": member.version(),
-                "tag-kind": "exact",
-                "tag-version": version,
-            }),
-            ResolvedTag::Series { series, .. } => json!({
-                "name": member.name,
-                "path": member.rel_path,
-                "version": member.version(),
-                "tag-kind": "series",
-                "tag-series": series,
-            }),
+        let (tag_kind, tag_version, tag_series) = match &resolved {
+            ResolvedTag::Exact { version, .. } => (TagKind::Exact, Some(version.as_str()), None),
+            ResolvedTag::Series { series, .. } => (TagKind::Series, None, Some(series.as_str())),
         };
-        println!("{}", serde_json::to_string(&payload)?);
+        let document = CiTagPackageDocument {
+            schema: CiTagPackageDocument::SCHEMA,
+            name: &member.name,
+            path: &member.rel_path,
+            version: member.version(),
+            tag_kind,
+            tag_version,
+            tag_series,
+        };
+        println!("{}", serde_json::to_string(&document)?);
     } else {
         println!("{}", member.name);
     }
@@ -46,18 +43,8 @@ pub fn matrix(workspace: &Workspace, since: Option<String>, releasable: bool) ->
         with_dependents: true, // a change to a dep can break its dependents
         releasable_only: releasable,
     })?;
-    let include: Vec<_> = selected
-        .iter()
-        .map(|&idx| {
-            let member = &workspace.members[idx];
-            json!({
-                "name": member.name,
-                "path": member.rel_path,
-                "version": member.version(),
-            })
-        })
-        .collect();
-    println!("{}", serde_json::to_string(&json!({ "include": include }))?);
+    let matrix = CiMatrix::new(workspace, &selected);
+    println!("{}", serde_json::to_string(&matrix)?);
     Ok(())
 }
 

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -1,9 +1,9 @@
 //! `trellis graph` — render the computed dependency graph. The mermaid output
 //! keeps docs diagrams generated instead of hand-drawn.
 
+use crate::json::GraphDocument;
 use crate::workspace::Workspace;
 use anyhow::Result;
-use serde_json::json;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum GraphFormat {
@@ -66,31 +66,8 @@ pub fn run(workspace: &Workspace, format: GraphFormat) -> Result<()> {
             }
         }
         GraphFormat::Json => {
-            let nodes: Vec<_> = workspace
-                .members
-                .iter()
-                .map(|member| {
-                    json!({
-                        "name": member.name,
-                        "version": member.version(),
-                        "path": member.rel_path,
-                        "releasable": member.releasable,
-                    })
-                })
-                .collect();
-            let mut edges = Vec::new();
-            for (idx, member) in workspace.members.iter().enumerate() {
-                for &dep in workspace.deps_of(idx) {
-                    edges.push(json!({
-                        "from": member.name,
-                        "to": workspace.members[dep].name,
-                    }));
-                }
-            }
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&json!({ "nodes": nodes, "edges": edges }))?
-            );
+            let document = GraphDocument::new(workspace);
+            println!("{}", serde_json::to_string_pretty(&document)?);
         }
     }
     Ok(())

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -1,6 +1,7 @@
 //! `trellis info <package>` — details for a single member.
 
 use crate::gleam::Requirement;
+use crate::json::InfoDocument;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result};
 
@@ -9,10 +10,8 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
         .member_index(name)
         .with_context(|| format!("unknown package `{name}`"))?;
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&super::member_json(workspace, idx))?
-        );
+        let document = InfoDocument::new(workspace, idx);
+        println!("{}", serde_json::to_string_pretty(&document)?);
         return Ok(());
     }
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,6 +1,7 @@
 //! `trellis list` — members in topological order. This alone replaces the
 //! hand-maintained, hand-ordered package list in a justfile.
 
+use crate::json::ListDocument;
 use crate::workspace::{SelectionFilter, Workspace};
 use anyhow::Result;
 
@@ -20,11 +21,8 @@ pub fn run(workspace: &Workspace, options: &ListOptions) -> Result<()> {
     })?;
 
     if options.json {
-        let items: Vec<_> = selected
-            .iter()
-            .map(|&idx| super::member_json(workspace, idx))
-            .collect();
-        println!("{}", serde_json::to_string_pretty(&items)?);
+        let document = ListDocument::new(workspace, &selected);
+        println!("{}", serde_json::to_string_pretty(&document)?);
     } else {
         for idx in selected {
             println!("{}", workspace.members[idx].name);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,9 +13,6 @@ pub mod run;
 pub mod tag;
 pub mod version;
 
-use crate::workspace::Workspace;
-use serde_json::json;
-
 /// Render the whole command tree as a Starlight `.md` page, straight from the
 /// clap definition, so the website's CLI reference can never drift from the
 /// actual flags. `trellis markdown-help` prints exactly this; a test asserts
@@ -43,25 +40,4 @@ pub fn markdown_help() -> String {
          {}",
         body.trim_end()
     ) + "\n"
-}
-
-/// The JSON shape shared by `list --json` and `info --json`.
-pub fn member_json(workspace: &Workspace, idx: usize) -> serde_json::Value {
-    let member = &workspace.members[idx];
-    json!({
-        "name": member.name,
-        "version": member.version(),
-        "path": member.rel_path,
-        "releasable": member.releasable,
-        "dependencies": workspace
-            .deps_of(idx)
-            .iter()
-            .map(|&dep| workspace.members[dep].name.clone())
-            .collect::<Vec<_>>(),
-        "dependents": workspace
-            .dependents_of(idx)
-            .iter()
-            .map(|&dep| workspace.members[dep].name.clone())
-            .collect::<Vec<_>>(),
-    })
 }

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -7,16 +7,19 @@
 //! series releases. Only the immutable ones can carry a GitHub Release — a
 //! release bound to a moving tag would silently retarget.
 
+use crate::json::TagPlanDocument;
 use crate::tools;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
-use serde_json::json;
+use serde::Serialize;
 use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
-/// Which tag lifecycle a planned tag belongs to.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Which tag lifecycle a planned tag belongs to. The serialized names are wire
+/// format — see `crate::json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum TagKind {
     /// An immutable `tag-format` tag naming one version.
     Exact,
@@ -24,17 +27,10 @@ pub enum TagKind {
     Series,
 }
 
-impl TagKind {
-    fn key(self) -> &'static str {
-        match self {
-            TagKind::Exact => "exact",
-            TagKind::Series => "series",
-        }
-    }
-}
-
 /// The work `tag create` would do for a planned tag, from local state alone.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// The serialized names are wire format — see `crate::json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum TagAction {
     /// The tag does not exist locally.
     Create,
@@ -42,16 +38,6 @@ pub enum TagAction {
     Move,
     /// The tag already points where it should; only the remote may need work.
     UpToDate,
-}
-
-impl TagAction {
-    fn key(self) -> &'static str {
-        match self {
-            TagAction::Create => "create",
-            TagAction::Move => "move",
-            TagAction::UpToDate => "up-to-date",
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -133,20 +119,23 @@ pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
         .filter(|planned| planned.action != TagAction::UpToDate)
         .collect();
     if json {
-        let items: Vec<_> = pending
-            .iter()
-            .map(|planned| {
-                let member = &workspace.members[planned.member];
-                json!({
-                    "name": member.name,
-                    "version": member.version(),
-                    "tag": planned.tag,
-                    "kind": planned.kind.key(),
-                    "action": planned.action.key(),
+        let document = TagPlanDocument {
+            schema: TagPlanDocument::SCHEMA,
+            tags: pending
+                .iter()
+                .map(|planned| {
+                    let member = &workspace.members[planned.member];
+                    crate::json::PlannedTag {
+                        name: &member.name,
+                        version: member.version(),
+                        tag: &planned.tag,
+                        kind: planned.kind,
+                        action: planned.action,
+                    }
                 })
-            })
-            .collect();
-        println!("{}", serde_json::to_string_pretty(&items)?);
+                .collect(),
+        };
+        println!("{}", serde_json::to_string_pretty(&document)?);
     } else if pending.is_empty() {
         println!("every releasable package version is already tagged");
     } else {

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -5,10 +5,10 @@
 //! CHANGELOG.md — all with zero Hex network calls.
 
 use crate::changelog;
+use crate::json::{Bump, VersionApplyDocument, VersionPlanDocument};
 use crate::lockfile;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
-use serde_json::json;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
@@ -55,7 +55,11 @@ pub fn compute_plan(workspace: &Workspace) -> Result<Vec<PlanEntry>> {
 pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
     let plan = compute_plan(workspace)?;
     if json {
-        println!("{}", serde_json::to_string_pretty(&plan_json(&plan))?);
+        let document = VersionPlanDocument {
+            schema: VersionPlanDocument::SCHEMA,
+            bumped: bumps(&plan),
+        };
+        println!("{}", serde_json::to_string_pretty(&document)?);
     } else if plan.is_empty() {
         println!("no unreleased changes; nothing to bump");
     } else {
@@ -69,19 +73,17 @@ pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn plan_json(plan: &[PlanEntry]) -> serde_json::Value {
-    json!(
-        plan.iter()
-            .map(|entry| {
-                json!({
-                    "name": entry.name,
-                    "current": entry.current,
-                    "next": entry.next,
-                    "fragments": entry.fragments,
-                })
-            })
-            .collect::<Vec<_>>()
-    )
+/// `version plan` and `version apply` report the same entry shape under the
+/// same `bumped` key, so they share one conversion.
+fn bumps(plan: &[PlanEntry]) -> Vec<Bump<'_>> {
+    plan.iter()
+        .map(|entry| Bump {
+            name: &entry.name,
+            current: &entry.current,
+            next: &entry.next,
+            fragments: entry.fragments,
+        })
+        .collect()
 }
 
 /// The release step: preflight every pending package and lockfile, write all
@@ -90,7 +92,12 @@ pub fn apply(workspace: &Workspace, json: bool) -> Result<bool> {
     let plan = compute_plan(workspace)?;
     if plan.is_empty() {
         if json {
-            println!("{}", json!({"bumped": [], "lockfiles": []}));
+            let document = VersionApplyDocument {
+                schema: VersionApplyDocument::SCHEMA,
+                bumped: Vec::new(),
+                lockfiles: Vec::new(),
+            };
+            println!("{}", serde_json::to_string_pretty(&document)?);
         } else {
             println!("no unreleased changes; nothing to apply");
         }
@@ -211,13 +218,12 @@ pub fn apply(workspace: &Workspace, json: bool) -> Result<bool> {
         .collect();
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&json!({
-                "bumped": plan_json(&plan),
-                "lockfiles": patched_files,
-            }))?
-        );
+        let document = VersionApplyDocument {
+            schema: VersionApplyDocument::SCHEMA,
+            bumped: bumps(&plan),
+            lockfiles: patched_files,
+        };
+        println!("{}", serde_json::to_string_pretty(&document)?);
     } else {
         for entry in &plan {
             println!("bumped {}: {} -> {}", entry.name, entry.current, entry.next);

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,311 @@
+//! The `--json` output contract.
+//!
+//! Every payload trellis emits for machine consumption is defined here, once,
+//! as a `Serialize` struct — so the wire format is reviewable in one file
+//! instead of inferred from `json!` literals spread across seven commands.
+//!
+//! Each *document* carries a `schema` identifier of the form
+//! `trellis.<payload>/<major>`. Consumers assert on it. Adding a field leaves
+//! the identifier alone; renaming, removing, or retyping one bumps the major.
+//! `website/src/content/docs/docs/json-output.mdx` states the full policy, and
+//! `tests/json_contract.rs` snapshots every shape below so a breaking change
+//! fails here rather than in a consumer's repository.
+//!
+//! Key naming is kebab-case, matching the config module's deserialize side.
+//! `#[serde(rename_all = "kebab-case")]` sits on every struct — a no-op for
+//! single-word fields, but it means a later multi-word field cannot silently
+//! arrive as snake_case.
+//!
+//! Two payloads deliberately carry no `schema` field; see [`CiMatrix`] and
+//! `commands::ci::outputs`.
+
+use crate::workspace::Workspace;
+use serde::Serialize;
+
+/// A workspace member, as `list` and `info` report it.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Package<'a> {
+    pub name: &'a str,
+    pub version: &'a str,
+    pub path: &'a str,
+    pub releasable: bool,
+    pub dependencies: Vec<&'a str>,
+    pub dependents: Vec<&'a str>,
+}
+
+impl<'a> Package<'a> {
+    pub fn new(workspace: &'a Workspace, idx: usize) -> Self {
+        let member = &workspace.members[idx];
+        Self {
+            name: &member.name,
+            version: member.version(),
+            path: &member.rel_path,
+            releasable: member.releasable,
+            dependencies: member_names(workspace, workspace.deps_of(idx)),
+            dependents: member_names(workspace, workspace.dependents_of(idx)),
+        }
+    }
+}
+
+fn member_names<'a>(workspace: &'a Workspace, indices: &[usize]) -> Vec<&'a str> {
+    indices
+        .iter()
+        .map(|&idx| workspace.members[idx].name.as_str())
+        .collect()
+}
+
+/// `trellis list --json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ListDocument<'a> {
+    pub schema: &'static str,
+    pub packages: Vec<Package<'a>>,
+}
+
+impl<'a> ListDocument<'a> {
+    pub const SCHEMA: &'static str = "trellis.list/1";
+
+    pub fn new(workspace: &'a Workspace, selected: &[usize]) -> Self {
+        Self {
+            schema: Self::SCHEMA,
+            packages: selected
+                .iter()
+                .map(|&idx| Package::new(workspace, idx))
+                .collect(),
+        }
+    }
+}
+
+/// `trellis info <package> --json`. The package's fields are flattened to the
+/// top level, so this is `list`'s element shape plus a `schema`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct InfoDocument<'a> {
+    pub schema: &'static str,
+    #[serde(flatten)]
+    pub package: Package<'a>,
+}
+
+impl<'a> InfoDocument<'a> {
+    pub const SCHEMA: &'static str = "trellis.info/1";
+
+    pub fn new(workspace: &'a Workspace, idx: usize) -> Self {
+        Self {
+            schema: Self::SCHEMA,
+            package: Package::new(workspace, idx),
+        }
+    }
+}
+
+/// One node in `trellis graph --format json`. Deliberately not [`Package`]:
+/// the edges carry the dependency relation, so repeating it per node would
+/// state the same fact twice.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GraphNode<'a> {
+    pub name: &'a str,
+    pub version: &'a str,
+    pub path: &'a str,
+    pub releasable: bool,
+}
+
+/// A dependency edge, pointing from dependent to dependency.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GraphEdge<'a> {
+    pub from: &'a str,
+    pub to: &'a str,
+}
+
+/// `trellis graph --format json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct GraphDocument<'a> {
+    pub schema: &'static str,
+    pub nodes: Vec<GraphNode<'a>>,
+    pub edges: Vec<GraphEdge<'a>>,
+}
+
+impl<'a> GraphDocument<'a> {
+    pub const SCHEMA: &'static str = "trellis.graph/1";
+
+    pub fn new(workspace: &'a Workspace) -> Self {
+        let nodes = workspace
+            .members
+            .iter()
+            .map(|member| GraphNode {
+                name: &member.name,
+                version: member.version(),
+                path: &member.rel_path,
+                releasable: member.releasable,
+            })
+            .collect();
+        let mut edges = Vec::new();
+        for (idx, member) in workspace.members.iter().enumerate() {
+            for &dep in workspace.deps_of(idx) {
+                edges.push(GraphEdge {
+                    from: &member.name,
+                    to: &workspace.members[dep].name,
+                });
+            }
+        }
+        Self {
+            schema: Self::SCHEMA,
+            nodes,
+            edges,
+        }
+    }
+}
+
+/// One changed package in `trellis changelog check --json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ChangelogPackage<'a> {
+    pub name: &'a str,
+    /// Always true — the list only contains packages the diff touched. Kept so
+    /// a future `--all` can report unchanged packages without a schema bump.
+    pub changed: bool,
+    pub has_entry: bool,
+    pub fragments: usize,
+}
+
+/// `trellis changelog check --json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ChangelogCheckDocument<'a> {
+    pub schema: &'static str,
+    pub has_entries: bool,
+    pub needs_entry: bool,
+    pub invalid_fragments: &'a [String],
+    pub packages: Vec<ChangelogPackage<'a>>,
+    /// Markdown for a PR sticky comment. The field is contractual; its prose
+    /// is not, and changes without a schema bump.
+    pub preview: String,
+}
+
+impl ChangelogCheckDocument<'_> {
+    pub const SCHEMA: &'static str = "trellis.changelog-check/1";
+}
+
+/// One planned or applied version bump. Shared by `version plan` and
+/// `version apply` so the two never drift.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct Bump<'a> {
+    pub name: &'a str,
+    pub current: &'a str,
+    pub next: &'a str,
+    pub fragments: usize,
+}
+
+/// `trellis version plan --json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct VersionPlanDocument<'a> {
+    pub schema: &'static str,
+    pub bumped: Vec<Bump<'a>>,
+}
+
+impl VersionPlanDocument<'_> {
+    pub const SCHEMA: &'static str = "trellis.version-plan/1";
+}
+
+/// `trellis version apply --json`. `bumped` repeats `version plan`'s shape;
+/// `lockfiles` names the manifests that were rewritten.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct VersionApplyDocument<'a> {
+    pub schema: &'static str,
+    pub bumped: Vec<Bump<'a>>,
+    pub lockfiles: Vec<&'a str>,
+}
+
+impl VersionApplyDocument<'_> {
+    pub const SCHEMA: &'static str = "trellis.version-apply/1";
+}
+
+/// One pending tag in `trellis tag plan --json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct PlannedTag<'a> {
+    pub name: &'a str,
+    pub version: &'a str,
+    pub tag: &'a str,
+    pub kind: crate::commands::tag::TagKind,
+    pub action: crate::commands::tag::TagAction,
+}
+
+/// `trellis tag plan --json`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TagPlanDocument<'a> {
+    pub schema: &'static str,
+    pub tags: Vec<PlannedTag<'a>>,
+}
+
+impl TagPlanDocument<'_> {
+    pub const SCHEMA: &'static str = "trellis.tag-plan/1";
+}
+
+/// `trellis ci tag-package --json`.
+///
+/// A series tag identifies the package but no version, so exactly one of
+/// `tag-version` and `tag-series` is present, keyed by `tag-kind`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CiTagPackageDocument<'a> {
+    pub schema: &'static str,
+    pub name: &'a str,
+    pub path: &'a str,
+    pub version: &'a str,
+    pub tag_kind: crate::commands::tag::TagKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_version: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag_series: Option<&'a str>,
+}
+
+impl CiTagPackageDocument<'_> {
+    pub const SCHEMA: &'static str = "trellis.ci-tag-package/1";
+}
+
+/// One job in `trellis ci matrix`.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct MatrixEntry<'a> {
+    pub name: &'a str,
+    pub path: &'a str,
+    pub version: &'a str,
+}
+
+/// `trellis ci matrix`.
+///
+/// **This document has no `schema` field, on purpose.** GitHub Actions feeds it
+/// straight to `strategy.matrix` via `fromJSON()`, and every top-level key
+/// other than `include` becomes an additional matrix axis — a `schema` sibling
+/// would multiply the job matrix by one. The shape is dictated by GitHub, so
+/// its stability is GitHub's contract, not ours.
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CiMatrix<'a> {
+    pub include: Vec<MatrixEntry<'a>>,
+}
+
+impl<'a> CiMatrix<'a> {
+    pub fn new(workspace: &'a Workspace, selected: &[usize]) -> Self {
+        Self {
+            include: selected
+                .iter()
+                .map(|&idx| {
+                    let member = &workspace.members[idx];
+                    MatrixEntry {
+                        name: &member.name,
+                        path: &member.rel_path,
+                        version: member.version(),
+                    }
+                })
+                .collect(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod git;
 mod gleam;
 mod hex;
+mod json;
 mod lockfile;
 mod rewrite;
 mod runner;
@@ -75,6 +76,7 @@ enum Command {
     /// Show details for one package
     Info {
         package: String,
+        /// Emit JSON instead of the text summary
         #[arg(long)]
         json: bool,
     },
@@ -225,6 +227,7 @@ enum ChangelogCommand {
         /// Head ref of the change range
         #[arg(long, default_value = "HEAD")]
         head: String,
+        /// Emit JSON, including a Markdown `preview` for a PR comment
         #[arg(long)]
         json: bool,
     },
@@ -234,11 +237,13 @@ enum ChangelogCommand {
 enum VersionCommand {
     /// Dry-run: show what `version apply` would bump
     Plan {
+        /// Emit JSON instead of text
         #[arg(long)]
         json: bool,
     },
     /// Bump versions, render changelogs, patch manifest.toml locked versions
     Apply {
+        /// Emit JSON listing every bump and patched lockfile
         #[arg(long)]
         json: bool,
     },
@@ -261,6 +266,7 @@ enum ReleaseCommand {
 enum TagCommand {
     /// List releasable packages whose current version has no tag yet
     Plan {
+        /// Emit JSON instead of text
         #[arg(long)]
         json: bool,
     },
@@ -302,6 +308,7 @@ enum CiCommand {
     /// Resolve a pushed tag (e.g. $GITHUB_REF_NAME) to its package name
     TagPackage {
         tag: String,
+        /// Emit JSON with the resolved package, version, and tag kind
         #[arg(long)]
         json: bool,
     },

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -53,8 +53,9 @@ fn list_json_includes_graph_facts() {
         .output()
         .unwrap();
     assert!(output.status.success());
-    let items: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let items = items.as_array().unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(document["schema"], "trellis.list/1");
+    let items = document["packages"].as_array().unwrap();
     assert_eq!(items.len(), 4);
     let mid = items.iter().find(|i| i["name"] == "lat_mid").unwrap();
     assert_eq!(mid["version"], "0.5.0");

--- a/tests/configless.rs
+++ b/tests/configless.rs
@@ -84,8 +84,8 @@ fn configless_single_package_repo_has_the_root_as_member() {
 
     let output = trellis(root).args(["list", "--json"]).output().unwrap();
     assert!(output.status.success());
-    let items: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let items = items.as_array().unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = document["packages"].as_array().unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["name"], "solo");
     assert_eq!(items[0]["path"], ".");

--- a/tests/json_contract.rs
+++ b/tests/json_contract.rs
@@ -1,0 +1,294 @@
+//! Snapshot tests over every `--json` payload trellis emits.
+//!
+//! These exist so that a breaking change to a documented shape fails *here*
+//! rather than in a consumer's workflow. They assert the wire format and
+//! nothing else — behavior is covered by `cli.rs`, `phase2.rs`, and
+//! `phase3.rs`.
+//!
+//! A failing snapshot is not automatically a bug: adding a field is permitted
+//! by the contract. Renaming, removing, or retyping one is not, and needs the
+//! `schema` identifier bumped along with it. See
+//! `website/src/content/docs/docs/json-output.mdx`.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn trellis(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("trellis").unwrap();
+    cmd.current_dir(dir);
+    // Deterministic dates in rendered changelogs: 2026-07-11.
+    cmd.env("SOURCE_DATE_EPOCH", "1783728000");
+    cmd
+}
+
+/// Run a command and parse its stdout as JSON. Takes the expected exit status
+/// because `changelog check` reports failure through it while still emitting a
+/// well-formed payload.
+fn json_output(dir: &Path, args: &[&str], expect_success: bool) -> serde_json::Value {
+    let output = trellis(dir).args(args).output().unwrap();
+    assert_eq!(
+        output.status.success(),
+        expect_success,
+        "unexpected exit for {args:?}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|err| panic!("{args:?} did not emit JSON: {err}"))
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn copy_fixture_to(root: &Path) {
+    fn walk(dir: &Path, files: &mut Vec<PathBuf>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                walk(&path, files);
+            } else {
+                files.push(path);
+            }
+        }
+    }
+    let from = fixture("basic");
+    let mut files = Vec::new();
+    walk(&from, &mut files);
+    for file in files {
+        let dest = root.join(file.strip_prefix(&from).unwrap());
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::copy(&file, &dest).unwrap();
+    }
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn init_repo(root: &Path) {
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+}
+
+fn add_fragment(root: &Path, project: &str, kind: &str, body: &str) {
+    let dir = root.join(".changes/unreleased");
+    fs::create_dir_all(&dir).unwrap();
+    for n in 1u32.. {
+        let path = dir.join(format!("{project}-{n}.toml"));
+        if !path.exists() {
+            write(
+                &path,
+                &format!("project = \"{project}\"\nkind = \"{kind}\"\nbody = \"{body}\"\n"),
+            );
+            return;
+        }
+    }
+}
+
+// ---- introspection -------------------------------------------------------
+
+#[test]
+fn list_json_contract() {
+    insta::assert_json_snapshot!(json_output(&fixture("basic"), &["list", "--json"], true));
+}
+
+#[test]
+fn info_json_contract() {
+    insta::assert_json_snapshot!(json_output(
+        &fixture("basic"),
+        &["info", "lat_mid", "--json"],
+        true
+    ));
+}
+
+#[test]
+fn graph_json_contract() {
+    insta::assert_json_snapshot!(json_output(
+        &fixture("basic"),
+        &["graph", "--format", "json"],
+        true
+    ));
+}
+
+// ---- changelog & versioning ---------------------------------------------
+
+#[test]
+fn changelog_check_json_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    git(root, &["checkout", "-q", "-b", "feature"]);
+    // One releasable package with a fragment, one without, so the payload
+    // exercises both `has-entry` states and a non-empty `preview`.
+    write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
+    write(&root.join("packages/lat_mid/src/new.gleam"), "// x\n");
+    add_fragment(root, "lat_core", "Added", "something");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
+
+    let payload = json_output(
+        root,
+        &["changelog", "check", "--base", "main", "--json"],
+        false,
+    );
+    // `preview` is contractual as a field, not as prose — it is Markdown for a
+    // PR comment and free to change. Pin its presence and type, not its text.
+    assert!(payload["preview"].is_string());
+    insta::assert_json_snapshot!(payload, { ".preview" => "[markdown]" });
+}
+
+#[test]
+fn version_plan_json_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    add_fragment(root, "lat_core", "Added", "minor-level change");
+    add_fragment(root, "lat_mid", "Breaking", "major-level change");
+
+    insta::assert_json_snapshot!(json_output(root, &["version", "plan", "--json"], true));
+}
+
+#[test]
+fn version_apply_json_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    add_fragment(root, "lat_core", "Added", "minor-level change");
+
+    insta::assert_json_snapshot!(json_output(root, &["version", "apply", "--json"], true));
+}
+
+/// The empty plan returns early through a separate branch, so it gets its own
+/// snapshot — it is the payload a no-op release job actually sees.
+#[test]
+fn version_apply_json_contract_when_nothing_to_do() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+
+    insta::assert_json_snapshot!(json_output(root, &["version", "apply", "--json"], true));
+}
+
+// ---- tagging -------------------------------------------------------------
+
+#[test]
+fn tag_plan_json_contract() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    // lat_core is already tagged, so it drops out of the plan.
+    git(root, &["tag", "-a", "lat_core-v1.2.0", "-m", "existing"]);
+
+    insta::assert_json_snapshot!(json_output(root, &["tag", "plan", "--json"], true));
+}
+
+// ---- ci ------------------------------------------------------------------
+
+#[test]
+fn ci_matrix_contract() {
+    let matrix = json_output(&fixture("basic"), &["ci", "matrix"], true);
+    // `ci matrix` carries no `schema` key on purpose: GitHub Actions treats
+    // every top-level key beside `include` as another matrix axis, so adding
+    // one would multiply the job matrix.
+    assert!(
+        matrix.get("schema").is_none(),
+        "ci matrix must stay a bare GitHub matrix object"
+    );
+    assert_eq!(matrix.as_object().unwrap().len(), 1);
+    insta::assert_json_snapshot!(matrix);
+}
+
+#[test]
+fn ci_outputs_contract() {
+    let output = trellis(&fixture("basic"))
+        .args(["ci", "outputs"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // Not a JSON document — `key=<json>` lines for `$GITHUB_OUTPUT`. The
+    // contract is the set of keys and each value's element type.
+    let pairs: Vec<(&str, serde_json::Value)> = stdout
+        .lines()
+        .map(|line| {
+            let (key, value) = line.split_once('=').expect("every line is key=value");
+            (key, serde_json::from_str(value).expect("value is JSON"))
+        })
+        .collect();
+    let keys: Vec<&str> = pairs.iter().map(|(key, _)| *key).collect();
+    assert_eq!(
+        keys,
+        [
+            "projects",
+            "releasable",
+            "version-files",
+            "tags",
+            "series-tags"
+        ]
+    );
+    insta::assert_json_snapshot!(serde_json::Value::Object(
+        pairs
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect()
+    ));
+}
+
+#[test]
+fn ci_tag_package_json_contract_for_an_exact_tag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+
+    insta::assert_json_snapshot!(json_output(
+        root,
+        &["ci", "tag-package", "lat_mid-v0.5.0", "--json"],
+        true,
+    ));
+}
+
+/// A series tag resolves to `tag-series` instead of `tag-version`, so the two
+/// variants serialize different key sets and both need pinning.
+#[test]
+fn ci_tag_package_json_contract_for_a_series_tag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\", \"examples/*\"]\n\
+         exclude = { \"@release\" = [\"examples/*\"] }\n\n\
+         [tools.trellis.publish]\n\
+         tag-mode-overrides = { both = [\"packages/lat_cli\"] }\n",
+    );
+    init_repo(root);
+
+    insta::assert_json_snapshot!(json_output(
+        root,
+        &["ci", "tag-package", "lat_cli-v0.3", "--json"],
+        true,
+    ));
+}

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -267,10 +267,13 @@ fn version_plan_bumps_by_the_largest_kind() {
     let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(
         plan,
-        serde_json::json!([
-            {"name": "lat_core", "current": "1.2.0", "next": "1.3.0", "fragments": 2},
-            {"name": "lat_mid", "current": "0.5.0", "next": "1.0.0", "fragments": 1},
-        ])
+        serde_json::json!({
+            "schema": "trellis.version-plan/1",
+            "bumped": [
+                {"name": "lat_core", "current": "1.2.0", "next": "1.3.0", "fragments": 2},
+                {"name": "lat_mid", "current": "0.5.0", "next": "1.0.0", "fragments": 1},
+            ],
+        })
     );
 }
 

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -198,8 +198,9 @@ fn tag_plan_lists_untagged_versions_and_create_tags_them() {
         .output()
         .unwrap();
     assert!(output.status.success());
-    let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let plan = plan.as_array().unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(document["schema"], "trellis.tag-plan/1");
+    let plan = document["tags"].as_array().unwrap();
     let names: Vec<&str> = plan.iter().map(|p| p["name"].as_str().unwrap()).collect();
     // package_a is @release-excluded; lat_core already tagged.
     assert_eq!(names, vec!["lat_mid", "lat_cli"]);
@@ -742,8 +743,8 @@ fn tag_plan_reports_the_series_move() {
         .args(["tag", "plan", "--json"])
         .output()
         .unwrap();
-    let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    let plan = plan.as_array().unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let plan = document["tags"].as_array().unwrap();
     assert_eq!(plan.len(), 1, "only the series tag needs work: {plan:?}");
     assert_eq!(plan[0]["tag"], "lat_cli-v0.3");
     assert_eq!(plan[0]["kind"], "series");

--- a/tests/snapshots/json_contract__changelog_check_json_contract.snap
+++ b/tests/snapshots/json_contract__changelog_check_json_contract.snap
@@ -1,0 +1,25 @@
+---
+source: tests/json_contract.rs
+expression: payload
+---
+{
+  "has-entries": true,
+  "invalid-fragments": [],
+  "needs-entry": true,
+  "packages": [
+    {
+      "changed": true,
+      "fragments": 1,
+      "has-entry": true,
+      "name": "lat_core"
+    },
+    {
+      "changed": true,
+      "fragments": 0,
+      "has-entry": false,
+      "name": "lat_mid"
+    }
+  ],
+  "preview": "[markdown]",
+  "schema": "trellis.changelog-check/1"
+}

--- a/tests/snapshots/json_contract__ci_matrix_contract.snap
+++ b/tests/snapshots/json_contract__ci_matrix_contract.snap
@@ -1,0 +1,28 @@
+---
+source: tests/json_contract.rs
+expression: matrix
+---
+{
+  "include": [
+    {
+      "name": "lat_core",
+      "path": "packages/lat_core",
+      "version": "1.2.0"
+    },
+    {
+      "name": "lat_mid",
+      "path": "packages/lat_mid",
+      "version": "0.5.0"
+    },
+    {
+      "name": "lat_cli",
+      "path": "packages/lat_cli",
+      "version": "0.3.1"
+    },
+    {
+      "name": "package_a",
+      "path": "examples/package-a",
+      "version": "0.0.0"
+    }
+  ]
+}

--- a/tests/snapshots/json_contract__ci_outputs_contract.snap
+++ b/tests/snapshots/json_contract__ci_outputs_contract.snap
@@ -1,0 +1,28 @@
+---
+source: tests/json_contract.rs
+expression: "serde_json::Value::Object(pairs.into_iter().map(|(key, value)|\n(key.to_string(), value)).collect())"
+---
+{
+  "projects": [
+    "lat_core",
+    "lat_mid",
+    "lat_cli",
+    "package_a"
+  ],
+  "releasable": [
+    "lat_core",
+    "lat_mid",
+    "lat_cli"
+  ],
+  "series-tags": [],
+  "tags": [
+    "lat_core-v1.2.0",
+    "lat_mid-v0.5.0",
+    "lat_cli-v0.3.1"
+  ],
+  "version-files": [
+    "packages/lat_core/gleam.toml",
+    "packages/lat_mid/gleam.toml",
+    "packages/lat_cli/gleam.toml"
+  ]
+}

--- a/tests/snapshots/json_contract__ci_tag_package_json_contract_for_a_series_tag.snap
+++ b/tests/snapshots/json_contract__ci_tag_package_json_contract_for_a_series_tag.snap
@@ -1,0 +1,12 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(root, &[\"ci\", \"tag-package\", \"lat_cli-v0.3\", \"--json\"], true,)"
+---
+{
+  "name": "lat_cli",
+  "path": "packages/lat_cli",
+  "schema": "trellis.ci-tag-package/1",
+  "tag-kind": "series",
+  "tag-series": "0.3",
+  "version": "0.3.1"
+}

--- a/tests/snapshots/json_contract__ci_tag_package_json_contract_for_an_exact_tag.snap
+++ b/tests/snapshots/json_contract__ci_tag_package_json_contract_for_an_exact_tag.snap
@@ -1,0 +1,12 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(root, &[\"ci\", \"tag-package\", \"lat_mid-v0.5.0\", \"--json\"], true,)"
+---
+{
+  "name": "lat_mid",
+  "path": "packages/lat_mid",
+  "schema": "trellis.ci-tag-package/1",
+  "tag-kind": "exact",
+  "tag-version": "0.5.0",
+  "version": "0.5.0"
+}

--- a/tests/snapshots/json_contract__graph_json_contract.snap
+++ b/tests/snapshots/json_contract__graph_json_contract.snap
@@ -1,0 +1,51 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(&fixture(\"basic\"), &[\"graph\", \"--format\", \"json\"], true)"
+---
+{
+  "edges": [
+    {
+      "from": "lat_mid",
+      "to": "lat_core"
+    },
+    {
+      "from": "lat_cli",
+      "to": "lat_core"
+    },
+    {
+      "from": "lat_cli",
+      "to": "lat_mid"
+    },
+    {
+      "from": "package_a",
+      "to": "lat_cli"
+    }
+  ],
+  "nodes": [
+    {
+      "name": "lat_core",
+      "path": "packages/lat_core",
+      "releasable": true,
+      "version": "1.2.0"
+    },
+    {
+      "name": "lat_mid",
+      "path": "packages/lat_mid",
+      "releasable": true,
+      "version": "0.5.0"
+    },
+    {
+      "name": "lat_cli",
+      "path": "packages/lat_cli",
+      "releasable": true,
+      "version": "0.3.1"
+    },
+    {
+      "name": "package_a",
+      "path": "examples/package-a",
+      "releasable": false,
+      "version": "0.0.0"
+    }
+  ],
+  "schema": "trellis.graph/1"
+}

--- a/tests/snapshots/json_contract__info_json_contract.snap
+++ b/tests/snapshots/json_contract__info_json_contract.snap
@@ -1,0 +1,17 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(&fixture(\"basic\"), &[\"info\", \"lat_mid\", \"--json\"], true)"
+---
+{
+  "dependencies": [
+    "lat_core"
+  ],
+  "dependents": [
+    "lat_cli"
+  ],
+  "name": "lat_mid",
+  "path": "packages/lat_mid",
+  "releasable": true,
+  "schema": "trellis.info/1",
+  "version": "0.5.0"
+}

--- a/tests/snapshots/json_contract__list_json_contract.snap
+++ b/tests/snapshots/json_contract__list_json_contract.snap
@@ -1,0 +1,55 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(&fixture(\"basic\"), &[\"list\", \"--json\"], true)"
+---
+{
+  "packages": [
+    {
+      "dependencies": [],
+      "dependents": [
+        "lat_mid",
+        "lat_cli"
+      ],
+      "name": "lat_core",
+      "path": "packages/lat_core",
+      "releasable": true,
+      "version": "1.2.0"
+    },
+    {
+      "dependencies": [
+        "lat_core"
+      ],
+      "dependents": [
+        "lat_cli"
+      ],
+      "name": "lat_mid",
+      "path": "packages/lat_mid",
+      "releasable": true,
+      "version": "0.5.0"
+    },
+    {
+      "dependencies": [
+        "lat_core",
+        "lat_mid"
+      ],
+      "dependents": [
+        "package_a"
+      ],
+      "name": "lat_cli",
+      "path": "packages/lat_cli",
+      "releasable": true,
+      "version": "0.3.1"
+    },
+    {
+      "dependencies": [
+        "lat_cli"
+      ],
+      "dependents": [],
+      "name": "package_a",
+      "path": "examples/package-a",
+      "releasable": false,
+      "version": "0.0.0"
+    }
+  ],
+  "schema": "trellis.list/1"
+}

--- a/tests/snapshots/json_contract__tag_plan_json_contract.snap
+++ b/tests/snapshots/json_contract__tag_plan_json_contract.snap
@@ -1,0 +1,23 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(root, &[\"tag\", \"plan\", \"--json\"], true)"
+---
+{
+  "schema": "trellis.tag-plan/1",
+  "tags": [
+    {
+      "action": "create",
+      "kind": "exact",
+      "name": "lat_mid",
+      "tag": "lat_mid-v0.5.0",
+      "version": "0.5.0"
+    },
+    {
+      "action": "create",
+      "kind": "exact",
+      "name": "lat_cli",
+      "tag": "lat_cli-v0.3.1",
+      "version": "0.3.1"
+    }
+  ]
+}

--- a/tests/snapshots/json_contract__version_apply_json_contract.snap
+++ b/tests/snapshots/json_contract__version_apply_json_contract.snap
@@ -1,0 +1,18 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(root, &[\"version\", \"apply\", \"--json\"], true)"
+---
+{
+  "bumped": [
+    {
+      "current": "1.2.0",
+      "fragments": 1,
+      "name": "lat_core",
+      "next": "1.3.0"
+    }
+  ],
+  "lockfiles": [
+    "packages/lat_mid/manifest.toml"
+  ],
+  "schema": "trellis.version-apply/1"
+}

--- a/tests/snapshots/json_contract__version_apply_json_contract_when_nothing_to_do.snap
+++ b/tests/snapshots/json_contract__version_apply_json_contract_when_nothing_to_do.snap
@@ -1,0 +1,9 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(root, &[\"version\", \"apply\", \"--json\"], true)"
+---
+{
+  "bumped": [],
+  "lockfiles": [],
+  "schema": "trellis.version-apply/1"
+}

--- a/tests/snapshots/json_contract__version_plan_json_contract.snap
+++ b/tests/snapshots/json_contract__version_plan_json_contract.snap
@@ -1,0 +1,21 @@
+---
+source: tests/json_contract.rs
+expression: "json_output(root, &[\"version\", \"plan\", \"--json\"], true)"
+---
+{
+  "bumped": [
+    {
+      "current": "1.2.0",
+      "fragments": 1,
+      "name": "lat_core",
+      "next": "1.3.0"
+    },
+    {
+      "current": "0.5.0",
+      "fragments": 1,
+      "name": "lat_mid",
+      "next": "1.0.0"
+    }
+  ],
+  "schema": "trellis.version-plan/1"
+}

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -24,6 +24,7 @@ export default defineConfig({
         { label: "Changelog & versioning", slug: "docs/changelog" },
         { label: "Publishing", slug: "docs/publishing" },
         { label: "CI recipes", slug: "docs/ci" },
+        { label: "JSON output contract", slug: "docs/json-output" },
         { label: "CLI reference", slug: "docs/reference" },
         {
           label: "Full README ↗",

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -60,6 +60,7 @@ comment:
 
 ```json
 {
+  "schema": "trellis.changelog-check/1",
   "has-entries": true,
   "needs-entry": true,
   "invalid-fragments": [],
@@ -70,6 +71,11 @@ comment:
   "preview": "| package | status |\n| --- | --- |\n…"
 }
 ```
+
+The `schema` field is there so a workflow can assert on the shape it expects;
+the [JSON output contract](/docs/json-output/) covers what it promises. Note
+that `preview` is guaranteed to be present and a string, but its Markdown is
+prose — render it rather than parsing it.
 
 ## Planning a release
 

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -85,11 +85,16 @@ each covering only the packages whose
 [`tag-mode`](/docs/configuration/#series-tags) creates that kind — so a
 `series`-only workspace reports an empty `tags`.
 
+Both `ci matrix` and `ci outputs` are shaped by GitHub rather than by trellis,
+which is why neither carries the `schema` field every other payload does — see
+the [JSON output contract](/docs/json-output/) for what each one promises.
+
 ## PR gates
 
 Run `doctor` on every PR — it checks every workspace invariant at once and
-exits non-zero on any error. Pair it with `changelog check`, whose JSON
-payload (including a markdown `preview`) feeds a sticky comment:
+exits non-zero on any error. Pair it with `changelog check`, whose
+[JSON payload](/docs/json-output/) (including a markdown `preview`) feeds a
+sticky comment:
 
 ```yaml
 # on: pull_request

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -43,7 +43,8 @@ a time:
 
 Commands that feed automation emit structured JSON (`--json`,
 `trellis ci`), so any single piece slots into whatever tooling already
-surrounds it.
+surrounds it — under a [versioned contract](/docs/json-output/) you can
+assert on.
 
 ## Getting started
 
@@ -65,4 +66,5 @@ surrounds it.
 | [Changelog & versioning](/docs/changelog/) | TOML change fragments, PR enforcement, planning and applying version bumps. |
 | [Publishing](/docs/publishing/) | Release PRs, per-package tags, publishing to Hex in dependency order with path deps rewritten. |
 | [CI recipes](/docs/ci/) | GitHub Actions shapes: affected-only matrices, PR gates, and the release pipeline. |
+| [JSON output contract](/docs/json-output/) | What the `--json` payloads promise: the `schema` field, what a stable shape permits, and where the guarantee stops. |
 | [CLI reference](/docs/reference/) | Every command, flag, and argument, generated from the CLI itself. |

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -1,0 +1,142 @@
+---
+title: JSON output contract
+description: What trellis promises about its --json payloads — the schema field, what a stable shape permits, and where the guarantee stops.
+---
+
+import Callout from "../../../components/Callout.astro";
+
+Nine trellis commands emit JSON for machine consumption, and workflows are
+built on them. This page states what those shapes promise, so you can wire one
+into CI and know what would break it.
+
+Every JSON *document* trellis emits carries a `schema` field naming the payload
+and its major version:
+
+```json
+{
+  "schema": "trellis.list/1",
+  "packages": [
+    {
+      "name": "lat_core",
+      "version": "1.2.0",
+      "path": "packages/lat_core",
+      "releasable": true,
+      "dependencies": [],
+      "dependents": ["lat_mid", "lat_cli"]
+    }
+  ]
+}
+```
+
+(Trimmed to one package; `packages` holds one entry per selected member, in
+topological order.)
+
+Assert on it. An identifier you don't recognize is a version you don't support,
+and that is a condition your workflow can detect and report — rather than one
+it discovers by producing wrong results.
+
+## What "stable" permits
+
+For a payload with a `schema` identifier:
+
+| Change | Allowed? |
+| --- | --- |
+| Adding a field | **Yes** — without bumping the identifier. Ignore fields you don't know. |
+| Adding an element to an existing array | **Yes**, subject to the command's documented selection rules. |
+| Renaming a field | No — bumps the major (`trellis.list/1` → `/2`). |
+| Removing a field | No — bumps the major. |
+| Changing a field's type | No — bumps the major. |
+| Changing a documented enum's values (`kind`, `action`, `tag-kind`) | No — bumps the major. |
+
+Two things are explicitly **not** part of the contract:
+
+- **Key order.** Parse as JSON; don't pattern-match the serialized text.
+- **Whitespace.** Some commands pretty-print and some emit a single line,
+  because `ci` output is meant to survive being pasted into a shell variable.
+  That split may change.
+
+<Callout>
+  **Human-readable output is not covered.** Text output is written for a person
+  at a terminal, is already TTY-dependent, and changes freely. If you are
+  parsing it, you are on your own — the `--json` form exists so you don't have
+  to.
+</Callout>
+
+## The payloads
+
+| Command | Schema and top-level keys |
+| --- | --- |
+| `list --json` | `trellis.list/1`<br />`{schema, packages[]}` |
+| `info <pkg> --json` | `trellis.info/1`<br />`{schema, name, version, path, releasable, dependencies[], dependents[]}` |
+| `graph --format json` | `trellis.graph/1`<br />`{schema, nodes[], edges[]}` |
+| `changelog check --json` | `trellis.changelog-check/1`<br />`{schema, has-entries, needs-entry, invalid-fragments[], packages[], preview}` |
+| `version plan --json` | `trellis.version-plan/1`<br />`{schema, bumped[]}` |
+| `version apply --json` | `trellis.version-apply/1`<br />`{schema, bumped[], lockfiles[]}` |
+| `tag plan --json` | `trellis.tag-plan/1`<br />`{schema, tags[]}` |
+| `ci tag-package --json` | `trellis.ci-tag-package/1`<br />`{schema, name, path, version, tag-kind, tag-version \| tag-series}` |
+
+A `packages[]` entry in `list` and the top level of `info` are the same shape,
+so a consumer can handle one package the same way whichever command produced
+it. `version plan` and `version apply` likewise share the `bumped[]` entry
+shape (`name`, `current`, `next`, `fragments`).
+
+### Conditional fields
+
+`ci tag-package` resolves either an immutable per-version tag or a moving
+series tag, and reports whichever applies:
+
+```json
+{"schema":"trellis.ci-tag-package/1","name":"lat_cli","path":"packages/lat_cli","version":"0.3.1","tag-kind":"exact","tag-version":"0.3.1"}
+{"schema":"trellis.ci-tag-package/1","name":"lat_cli","path":"packages/lat_cli","version":"0.3.1","tag-kind":"series","tag-series":"0.3"}
+```
+
+Branch on `tag-kind`: `exact` carries `tag-version`, `series` carries
+`tag-series`, and the other key is absent rather than null. A series tag names
+no version, which is why it cannot trigger a publish.
+
+### `preview` is a field, not a text
+
+`changelog check --json` includes `preview`, Markdown intended for a PR sticky
+comment. The field is contractual — always present, always a string. **Its
+prose is not**, and will change without a schema bump. Render it; don't parse
+it.
+
+## The two exceptions
+
+`trellis ci matrix` and `trellis ci outputs` carry **no `schema` field**. Their
+shapes are dictated by GitHub Actions rather than by trellis, so what they
+promise is what GitHub accepts.
+
+`ci matrix` emits exactly one key:
+
+```json
+{"include":[{"name":"lat_core","path":"packages/lat_core","version":"1.2.0"},{"name":"lat_mid","path":"packages/lat_mid","version":"0.5.0"},{"name":"lat_cli","path":"packages/lat_cli","version":"0.3.1"},{"name":"package_a","path":"examples/package-a","version":"0.0.0"}]}
+```
+
+<Callout>
+  A `schema` sibling here would be a bug, not an improvement. GitHub feeds this
+  object straight to `strategy.matrix` via `fromJSON()`, where **every
+  top-level key other than `include` becomes another matrix axis** — so adding
+  one would silently multiply the number of jobs.
+</Callout>
+
+`ci outputs` is not a JSON document at all. It emits `key=value` lines for
+`$GITHUB_OUTPUT`, where each value happens to be a JSON array:
+
+```
+projects=["lat_core","lat_mid","lat_cli","package_a"]
+releasable=["lat_core","lat_mid","lat_cli"]
+version-files=["packages/lat_core/gleam.toml","packages/lat_mid/gleam.toml","packages/lat_cli/gleam.toml"]
+tags=["lat_core-v1.2.0","lat_mid-v0.5.0","lat_cli-v0.3.1"]
+series-tags=[]
+```
+
+The contract is the set of output names above and each value's element type —
+all five are arrays of strings. See [CI recipes](/docs/ci/) for how they are
+consumed.
+
+## How this is enforced
+
+Every payload on this page is defined once, as a serializable type, in
+`src/json.rs`, and snapshotted in `tests/json_contract.rs`. A change to a
+stable shape fails trellis's own CI rather than yours.

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -107,7 +107,7 @@ Show details for one package
 
 ###### **Options:**
 
-* `--json`
+* `--json` — Emit JSON instead of the text summary
 
 
 
@@ -197,7 +197,7 @@ Verify changed packages have changelog fragments; non-zero exit if not
 * `--head <HEAD>` — Head ref of the change range
 
   Default value: `HEAD`
-* `--json`
+* `--json` — Emit JSON, including a Markdown `preview` for a PR comment
 
 
 
@@ -222,7 +222,7 @@ Dry-run: show what `version apply` would bump
 
 ###### **Options:**
 
-* `--json`
+* `--json` — Emit JSON instead of text
 
 
 
@@ -234,7 +234,7 @@ Bump versions, render changelogs, patch manifest.toml locked versions
 
 ###### **Options:**
 
-* `--json`
+* `--json` — Emit JSON listing every bump and patched lockfile
 
 
 
@@ -307,7 +307,7 @@ List releasable packages whose current version has no tag yet
 
 ###### **Options:**
 
-* `--json`
+* `--json` — Emit JSON instead of text
 
 
 
@@ -426,4 +426,4 @@ Resolve a pushed tag (e.g. $GITHUB_REF_NAME) to its package name
 
 ###### **Options:**
 
-* `--json`
+* `--json` — Emit JSON with the resolved package, version, and tag kind


### PR DESCRIPTION
Closes #41.

Nine commands emit `--json` and the README pushes them into CI, but nothing said which shapes 1.0 promises to keep. This adds the answer: a `schema` field, a documented policy, and snapshot tests.

## The contract

Every JSON *document* now carries a `schema` identifier naming the payload and its major version:

```json
{"schema": "trellis.list/1", "packages": [...]}
```

Adding a field leaves the identifier alone; renaming, removing, or retyping one bumps the major. Key order and pretty-vs-compact whitespace are explicitly not contractual, and human-readable text output isn't covered at all.

## Breaking change

Three payloads were bare arrays, with nowhere to put a `schema` key. They're now objects wrapping that array:

| Command | Before | After |
| --- | --- | --- |
| `list --json` | `[...]` | `{schema, packages[]}` |
| `version plan --json` | `[...]` | `{schema, bumped[]}` |
| `tag plan --json` | `[...]` | `{schema, tags[]}` |

So `jq '.[].name'` becomes `jq '.packages[].name'`. `version plan` wraps under `bumped` rather than a new name because that's the key `version apply` already used for the identical entry shape — the two now match, and `apply` is unchanged. The other five documents only gained a key.

## The two exemptions

`ci matrix` and `ci outputs` deliberately carry **no** `schema` field, and their output is byte-identical to before. GitHub feeds the matrix object to `strategy.matrix` via `fromJSON()`, where every top-level key other than `include` becomes an additional matrix axis — a `schema` sibling would silently multiply the job count. That reasoning is recorded in `src/json.rs`, on the docs page, and as a test assertion, because it's exactly the kind of thing a later cleanup would "fix" into a bug.

## Implementation

Payloads moved from ad-hoc `serde_json::json!` literals scattered across seven command files into typed `Serialize` structs in the new `src/json.rs` — previously the crate had zero `Serialize` structs, and the kebab-case wire keys (`tag-kind`, `has-entries`) were hand-written string literals held together by discipline. The contract is now one reviewable file, which is also what #39 and #40 should add to rather than inventing new shapes.

Also normalized one latent inconsistency: `version apply`'s empty-plan branch printed compact JSON while its success path printed pretty.

## Tests

New `tests/json_contract.rs` — 12 `insta` snapshots, one per payload, covering both `ci tag-package` variants (they serialize different key sets) and both `version apply` branches. `changelog check`'s `preview` is redacted to `[markdown]`: the field is contractual, its Markdown prose is not.

Six existing assertions that indexed into the now-wrapped arrays were updated; they test behavior and stay.

## Docs

- New [JSON output contract](website/src/content/docs/docs/json-output.mdx) page — policy, per-command table, the exemptions and why, the `preview` carve-out.
- Wired into the sidebar, the overview table, and cross-linked from `ci.mdx` and `changelog.mdx`.
- Six `--json` flags rendered without help text in the generated CLI reference; they have it now, and `reference.md` is regenerated.
- Short README subsection pointing at the page.

## Verification

- `just ci` exits 0 — fmt, `clippy -D warnings`, 160 tests, build.
- `pnpm build` in `website/`; page reviewed rendered at desktop and mobile width.
- `ci matrix` and `ci outputs` confirmed byte-identical to pre-change output.

## Out of scope

The issue's closing note about a JSON Schema for `[tools.trellis]` (editor completion in `gleam.toml`) belongs with #37 — that's an *input* schema and shares nothing with this work but the word "schema".