### PR TITLE
docs(changelog): reword the unreleased fragments for an external audience

### DIFF
--- a/.changes/unreleased/Added-20260725-180119.yaml
+++ b/.changes/unreleased/Added-20260725-180119.yaml
@@ -1,3 +1,0 @@
-kind: Added
-body: '`trellis completions <shell>` prints a shell snippet that enables tab-completion for bash, zsh, fish, PowerShell, and elvish. Candidates are computed by the binary as you type, so completions offer real package names, task names, and changelog kinds from the surrounding workspace. Release archives also ship man pages (`trellis.1` plus a page per subcommand) under `man/`.'
-time: 2026-07-25T18:01:19.474540769-07:00

--- a/.changes/unreleased/Added-20260725-completions.yaml
+++ b/.changes/unreleased/Added-20260725-completions.yaml
@@ -1,0 +1,10 @@
+kind: Added
+body: |-
+  **`trellis completions <shell>` generates tab-completion for bash, zsh, fish,
+    PowerShell, and elvish.** Candidates are computed by the binary as you type, so
+    completion offers the real package names, task names, and changelog kinds from
+    the surrounding workspace.
+
+    Release archives also ship man pages under `man/` — `trellis.1` plus a page per
+    subcommand.
+time: 2026-07-25T18:01:19.474540769-07:00

--- a/.changes/unreleased/Added-20260725-doctor-structured-output.yaml
+++ b/.changes/unreleased/Added-20260725-doctor-structured-output.yaml
@@ -1,3 +1,12 @@
 kind: Added
-body: '`trellis doctor --format json|github` adds a machine-readable form to the command you run on every PR. Every finding is a typed record — `{check, severity, message, file, package, fixable}` — so CI can group findings by package, filter to the ones `--fix` would clear, or render them into a PR comment, instead of parsing prose written for a terminal. `--format github` emits the same findings as GitHub Actions workflow commands, so they annotate the offending file in a PR''s Files tab rather than scrolling past in a log. The `check` values are a documented enum on the [JSON output contract](https://trellis.tylerbutler.com/docs/json-output/) page; `message` prose is explicitly not contractual. Text output is unchanged.'
+body: |-
+  **`trellis doctor --format json|github` reports findings as data instead of
+    prose.** Each finding is a typed record — `{check, severity, message, file,
+    package, fixable}` — so CI can group findings by package or filter to the ones
+    `--fix` would clear. `--format github` emits them as GitHub Actions workflow
+    commands, which annotate the offending file in a PR's Files tab.
+
+    `check` values are a documented enum on the [JSON output
+    contract](https://trellis.tylerbutler.com/docs/json-output/) page; `message`
+    prose is not contractual. Text output is unchanged.
 time: 2026-07-25T18:30:00.000000-07:00

--- a/.changes/unreleased/Added-20260725-json-output-contract.yaml
+++ b/.changes/unreleased/Added-20260725-json-output-contract.yaml
@@ -1,3 +1,12 @@
 kind: Added
-body: 'Every JSON document now carries a `schema` identifier naming the payload and its major version (`"schema": "trellis.list/1"`), so a workflow can assert on the shape it was built against instead of discovering a breaking change through wrong results. The new [JSON output contract](https://trellis.tylerbutler.com/docs/json-output/) page states what stability permits — fields may be added, but renaming, removing, or retyping one bumps the major — and documents the two payloads shaped by GitHub Actions rather than by trellis (`ci matrix` and `ci outputs`), which carry no `schema` field. The six `--json` flags that rendered without help text now have it.'
+body: |-
+  **Every JSON document now names its payload and major version in a `schema`
+    field** — `"schema": "trellis.list/1"` — so a workflow can assert on the shape it
+    was built against.
+
+    The new [JSON output
+    contract](https://trellis.tylerbutler.com/docs/json-output/) page sets the rules:
+    fields may be added, but renaming, removing, or retyping one bumps the major. `ci
+    matrix` and `ci outputs` are shaped by GitHub Actions and carry no `schema`. Six
+    `--json` flags that had no help text now have it.
 time: 2026-07-25T09:01:00.000000-07:00

--- a/.changes/unreleased/Added-20260725-ripple-bumps.yaml
+++ b/.changes/unreleased/Added-20260725-ripple-bumps.yaml
@@ -1,3 +1,12 @@
 kind: Added
-body: When a package bumps, its workspace dependents now bump too — transitively, by a patch, each with a generated `Dependencies` changelog entry naming what moved. A path dependency's Hex requirement is derived from the dependency's version at publish time, so a dependent left unbumped meant one published version could resolve to two different dependency sets depending on whether it was fetched before or after the release. A dependent needs no fragment of its own; a package with one keeps its own, larger bump; `@release`-excluded packages never bump and a ripple stops at one. Two new keys under `[tools.trellis.changelog]` control the generated entries — `dependency_kind` (default `Dependencies`, and it must name one of `kinds`) and `dependency_body`.
+body: |-
+  **When a package bumps, its workspace dependents now bump too** — transitively,
+    one patch each, with a generated `Dependencies` entry naming what moved. A path
+    dependency's Hex requirement is derived at publish time, so an unbumped dependent
+    could resolve to two different dependency sets.
+
+    A dependent needs no fragment of its own, a package that has one keeps its larger
+    bump, and a ripple stops at an `@release`-excluded package. Two new keys under
+    `[tools.trellis.changelog]` shape the generated entry: `dependency_kind` and
+    `dependency_body`.
 time: 2026-07-25T09:00:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-global-flags.yaml
+++ b/.changes/unreleased/Added-20260726-global-flags.yaml
@@ -1,3 +1,13 @@
 kind: Added
-body: 'Four global flags, accepted before or after the subcommand. `--color auto|always|never` overrides the terminal detection that previously could not be overridden in either direction, so `--color always` survives a pipe and `--color never` survives a terminal; `auto` keeps honoring `NO_COLOR` and `CLICOLOR=0`. `-q/--quiet` drops the per-package output stream and the summary table without touching exit codes, and `-v/--verbose` writes a `+ ` trace to stderr for every `gleam`, `git`, and `gh` command trellis shells out to, naming the directory it ran in. `--no-update-check` suppresses the release check for one invocation, which was previously possible only through the `TRELLIS_NO_UPDATE_CHECK` and `DO_NOT_TRACK` environment variables. Live progress rows stay tied to terminal detection regardless of `--color`, so forcing color into a pipe does not start drawing spinners into it.'
+body: |-
+  **Four global flags now work before or after the subcommand.** `--color
+    auto|always|never` overrides terminal detection in both directions, so `--color
+    always` survives a pipe and `--color never` survives a terminal; `auto` still
+    honors `NO_COLOR` and `CLICOLOR=0`. Progress rows stay tied to terminal
+    detection, so forcing color into a pipe draws no spinners.
+
+    `-q/--quiet` drops the per-package stream and the summary table without changing
+    exit codes. `-v/--verbose` traces every `gleam`, `git`, and `gh` command to
+    stderr, prefixed `+ ` and naming the directory it ran in. `--no-update-check`
+    skips the release check for one invocation.
 time: 2026-07-26T09:00:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-init.yaml
+++ b/.changes/unreleased/Added-20260726-init.yaml
@@ -1,3 +1,11 @@
 kind: Added
-body: '`trellis init` bootstraps a workspace: it writes the `[tools.trellis]` table into the repository root''s `gleam.toml`, creating a config-only manifest if the root is not itself a package and preserving formatting, comments, and any other `[tools.*]` table if it is. What it writes is almost empty: the table''s presence is what marks the workspace root, and members stay auto-discovered, so `members` is derivable and is not declared. In its place are comments pointing at what can be configured. It reports the members it discovered so they can be checked, refuses to run if the repository is already a trellis workspace or if a member manifest carries the table, and finishes by running `doctor`.'
+body: |-
+  **`trellis init` bootstraps a workspace.** It writes the `[tools.trellis]` table
+    into the repository root's `gleam.toml`, creating a config-only manifest if the
+    root is not itself a package and preserving comments and formatting if it is.
+
+    What it writes is nearly empty: the table's presence is what marks the workspace
+    root, members stay auto-discovered, and comments point at what can be configured.
+    `init` lists the members it found, refuses to run on a repository that is already
+    a trellis workspace, and finishes by running `doctor`.
 time: 2026-07-26T09:06:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-prereleases.yaml
+++ b/.changes/unreleased/Added-20260726-prereleases.yaml
@@ -1,3 +1,15 @@
 kind: Added
-body: '`version apply --pre rc` cuts a release candidate, and repeating it advances the counter within the same base version (`1.0.0-rc.1`, then `1.0.0-rc.2`) instead of deriving a fresh bump from the same fragments each time; `--pre none` promotes the candidate to its final version. Fragments survive a prerelease: the candidate renders its changelog section but leaves them in `.changes/unreleased/`, since retiring them at `rc.1` would leave `1.0.0` with nothing to say. The consequence is that an entry appears twice in `CHANGELOG.md`, once under the RC that shipped it and once under the final, and `version --json` now reports `fragments_retained` so a workflow can tell a cut RC from a completed release. A prerelease labels the whole plan including rippled dependents, so the workspace moves as one coherent candidate, while a package that gained fragments only after the RC was cut still bumps normally under `--pre none`. Once a package sits at a prerelease a plain `version apply` is an error naming both ways out, rather than silently bumping past the cycle. See [prereleases](https://trellis.tylerbutler.com/docs/changelog/#prereleases).'
+body: |-
+  **`version apply --pre rc` cuts a release candidate, and `--pre none` promotes it
+    to the final version.** Repeating `--pre rc` advances the counter within the same
+    base version — `1.0.0-rc.1`, then `1.0.0-rc.2`.
+
+    Fragments survive a prerelease: the candidate renders its changelog section but
+    leaves them in `.changes/unreleased/`, so an entry appears twice in
+    `CHANGELOG.md` — once under the RC, once under the final release. `version
+    --json` reports `fragments_retained` so a workflow can tell the two apart.
+
+    A prerelease labels the whole plan, rippled dependents included. Once a package
+    sits at a prerelease, a plain `version apply` is an error naming both ways out.
+    See [prereleases](https://trellis.tylerbutler.com/docs/changelog/#prereleases).
 time: 2026-07-26T09:03:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-run-exec-json.yaml
+++ b/.changes/unreleased/Added-20260726-run-exec-json.yaml
@@ -1,3 +1,13 @@
 kind: Added
-body: '`trellis run` and `trellis exec` accept `--json`, emitting the new `trellis.run/1` and `trellis.exec/1` payloads: one record per package carrying its path, status, wall-clock duration, and — when it failed — the exit code and the command that produced it. Previously the only machine-readable signal was the overall exit code, so "only test what a PR touched" was doable but not reportable. Because a job runs several commands when a custom task sets `needs_deps`, `exit_code` and `command` describe the one that failed rather than the whole job, and a package that never ran because scheduling stopped at an earlier failure reports `skipped` — which is not a pass and still fails the command. Under `--json` the per-package stream moves to stderr so a long run stays observable while stdout carries nothing but the payload, and the progress rows and summary table are suppressed. See the [JSON output contract](https://trellis.tylerbutler.com/docs/json-output/).'
+body: |-
+  **`trellis run` and `trellis exec` accept `--json`.** The new `trellis.run/1` and
+    `trellis.exec/1` payloads carry one record per package — path, status, wall-clock
+    duration, and, on failure, the exit code and the command that produced it.
+    Previously the only machine-readable signal was the overall exit code.
+
+    `exit_code` and `command` describe the command that failed, not the whole job. A
+    package that never ran because scheduling stopped at an earlier failure reports
+    `skipped`, which still fails the command. Under `--json` the per-package stream
+    moves to stderr so stdout carries only the payload, and progress rows and the
+    summary table are suppressed.
 time: 2026-07-26T09:01:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-shared-dependency-check.yaml
+++ b/.changes/unreleased/Added-20260726-shared-dependency-check.yaml
@@ -1,3 +1,11 @@
 kind: Added
-body: '`trellis doctor` now checks that members agree on the external dependencies they share — `packages/lat_core` requiring `gleam_stdlib >= 0.44.0` while `packages/lat_cli` requires `>= 0.60.0`. Requirements are compared as written rather than parsed as ranges, so `>= 1.0` and `>=1.0` read as divergent, which the message says out loud. Path dependencies are out of scope, carrying no requirement to agree on. Divergence is sometimes intended, so it is a warning by default and does not fail CI; the new `[tools.trellis.doctor] shared_dependencies` key takes `warn`, `error`, or `off`. There is no `doctor --fix` for it: unifying to the highest requirement is a judgment call rather than a mechanical remedy.'
+body: |-
+  **`trellis doctor` now checks that members agree on the external dependencies they
+    share** — `lat_core` requiring `gleam_stdlib >= 0.44.0` while `lat_cli` requires
+    `>= 0.60.0`. Requirements are compared as written rather than parsed as ranges, so
+    `>= 1.0` and `>=1.0` read as divergent; path dependencies are out of scope.
+
+    Divergence is often intended, so this is a warning by default and does not fail
+    CI. The new `[tools.trellis.doctor] shared_dependencies` key takes `warn`,
+    `error`, or `off`. There is no `--fix` for it.
 time: 2026-07-26T09:05:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-unknown-config-keys.yaml
+++ b/.changes/unreleased/Added-20260726-unknown-config-keys.yaml
@@ -1,3 +1,9 @@
 kind: Added
-body: 'Keys under `[tools.trellis]` that trellis does not recognize are now reported instead of ignored, so a misspelled key no longer leaves the workspace silently using the default. `doctor` reports each one as a warning rather than an error: an unrecognized key may belong to a newer trellis, and erroring would make the workspace unloadable under a pinned older one. The free-form tables — `exclude`, `tasks`, and `publish.tag_mode_overrides` — take keys you choose, hyphens and all, and are never reported.'
+body: |-
+  **Keys under `[tools.trellis]` that trellis does not recognize are now reported
+    instead of ignored,** so a misspelled key no longer leaves the workspace silently
+    on the default. `doctor` reports each as a warning rather than an error, since an
+    unrecognized key may belong to a newer trellis. The free-form tables — `exclude`,
+    `tasks`, and `publish.tag_mode_overrides` — take keys you choose and are never
+    reported.
 time: 2026-07-26T09:04:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-version-overrides.yaml
+++ b/.changes/unreleased/Added-20260726-version-overrides.yaml
@@ -1,3 +1,13 @@
 kind: Added
-body: '`version plan` and `version apply` accept `--bump` and `--set`, so the version no longer has to be whatever the pending fragments'' kinds derive. `--bump major` overrides the level for the whole plan and `--bump lat_core=major` for one package, which is the escape hatch for a breaking change filed as `Fixed` and already merged; `--set lat_core=1.0.0` pins an exact version, for the jump to 1.0 that the pre-1.0 rule would otherwise treat as a minor, or a one-off number matching something upstream. Precedence runs `--set`, then per-package `--bump`, then workspace-wide `--bump`, then the derived level. Both commands take the same flags, so an override is visible in the dry run before it is applied, and naming a package in both flags, naming one that is not a releasable member, or pinning a version that is not ahead of the current one are all errors raised before anything is written.'
+body: |-
+  **`version plan` and `version apply` accept `--bump` and `--set`,** so the version
+    no longer has to be whatever the pending fragments derive. `--bump major` sets the
+    level for the whole plan and `--bump lat_core=major` for one package; `--set
+    lat_core=1.0.0` pins an exact version, for the jump to 1.0 that the pre-1.0 rule
+    would otherwise treat as a minor.
+
+    Precedence runs `--set`, then per-package `--bump`, then workspace-wide `--bump`,
+    then the derived level. Both commands take the same flags, so an override shows up
+    in the dry run first, and conflicting or backwards overrides are rejected before
+    anything is written.
 time: 2026-07-26T09:02:00.000000-07:00

--- a/.changes/unreleased/Added-20260729-changelog-categories.yaml
+++ b/.changes/unreleased/Added-20260729-changelog-categories.yaml
@@ -1,3 +1,17 @@
 kind: Added
-body: 'Changelog entries can carry a second grouping axis. `categories` under `[tools.trellis.changelog]` is a vocabulary like `kinds` but with no bump attached, and a fragment naming one renders under a category heading *above* the kind headings — so a package made of several distinct parts, such as the subcommands of a CLI, gets a section per part instead of one flat list per version. Write one with `trellis changelog new --category <name>`, which records a `category` key in the fragment. The axis is opt-in and empty by default, and the category stays optional on each fragment once configured — entries naming none, including the generated dependency entries, trail the named categories under `uncategorized_label` (`Other` by default). An unknown category is an invalid fragment, exactly as an unknown kind is: `doctor` reports it with the offending file and `version` refuses. While the axis is on, kind headings drop from `###` to `####` to sit under the categories, unless `kind_format` is set explicitly. Fragments are strict about unknown keys, so one carrying a `category` will not parse under an older trellis. See [categories](https://trellis.tylerbutler.com/docs/configuration/#categories).'
+body: |-
+  **Changelog entries can group under a second axis above their kind.** `categories`
+    under `[tools.trellis.changelog]` is a vocabulary like `kinds` but with no bump
+    attached; a fragment naming one renders under a category heading *above* the kind
+    headings, so a package made of distinct parts — the subcommands of a CLI, say —
+    gets a section per part instead of one flat list. Write one with `trellis changelog
+    new --category <name>`.
+
+    The axis is opt-in and empty by default, and the category stays optional on each
+    fragment; entries naming none trail the rest under `uncategorized_label` (`Other`
+    by default). An unknown category is an invalid fragment, exactly as an unknown kind
+    is. Kind headings drop from `###` to `####` while the axis is on, unless
+    `kind_format` says otherwise, and a fragment carrying a `category` will not parse
+    under an older trellis. See
+    [categories](https://trellis.tylerbutler.com/docs/configuration/#categories).
 time: 2026-07-29T12:00:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260725-json-envelopes.yaml
+++ b/.changes/unreleased/Breaking-20260725-json-envelopes.yaml
@@ -1,3 +1,10 @@
 kind: Breaking
-body: 'Three `--json` payloads that were bare arrays are now objects, so they can carry the new `schema` field: `list --json` wraps its array under `packages`, `version plan --json` under `bumped` (matching `version apply`), and `tag plan --json` under `tags`. A consumer doing `trellis list --json | jq ".[].name"` becomes `jq ".packages[].name"`. Every other payload is unchanged apart from the added `schema` key; `ci matrix` and `ci outputs` are untouched.'
+body: |-
+  **Three `--json` payloads that were bare arrays are now objects,** so they can
+    carry the new `schema` field: `list --json` wraps its array under `packages`,
+    `version plan --json` under `bumped` (matching `version apply`), and `tag plan
+    --json` under `tags`. Every other payload is unchanged apart from the added
+    `schema` key, and `ci matrix` and `ci outputs` are untouched.
+
+    `trellis list --json | jq ".[].name"` becomes `jq ".packages[].name"`.
 time: 2026-07-25T09:00:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260728-ci-output-names.yaml
+++ b/.changes/unreleased/Breaking-20260728-ci-output-names.yaml
@@ -1,3 +1,11 @@
 kind: Breaking
-body: '`trellis ci outputs` renames two of its GitHub Actions outputs to snake_case: `version-files` becomes `version_files` and `series-tags` becomes `series_tags`. `releasable` and `tags` are unchanged; `projects` is superseded by `packages` and kept as a deprecated alias. A workflow reading `steps.<id>.outputs.version-files` or `.series-tags` must be updated — nothing else in the command changes, and the values are identical. These are trellis''s own names rather than a convention GitHub imposes, so they follow the same snake_case rule as the config keys and the `--json` payloads.'
+body: |-
+  **`trellis ci outputs` renames two of its GitHub Actions outputs to snake_case:**
+    `version-files` becomes `version_files` and `series-tags` becomes `series_tags`.
+    `releasable` and `tags` are unchanged; `projects` is superseded by `packages` and
+    kept as a deprecated alias. The values are identical — only the names moved, to
+    follow the same snake_case rule as the config keys and the `--json` payloads.
+
+    A workflow reading `steps.<id>.outputs.version-files` or `.series-tags` must
+    switch to `.version_files` and `.series_tags`.
 time: 2026-07-28T18:01:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260728-doctor-json-package-keys.yaml
+++ b/.changes/unreleased/Breaking-20260728-doctor-json-package-keys.yaml
@@ -1,3 +1,11 @@
 kind: Breaking
-body: '`trellis.doctor/1` renames two identifiers to match the package/member rule: the workspace-size field `members` becomes `packages`, and the `member_manifest` check value becomes `package_manifest`. A consumer doing `jq ".members"` becomes `jq ".packages"`, and a workflow branching on `check == "member_manifest"` must match `"package_manifest"`. `member_glob` keeps its name — it genuinely reports on the `members` globs — as do `configless` and `auto_members`, which describe how membership was determined rather than the packages themselves.'
+body: |-
+  **`trellis.doctor/1` renames two identifiers to match the package/member rule:**
+    the workspace-size field `members` becomes `packages`, and the `member_manifest`
+    check value becomes `package_manifest`. `member_glob`, `configless`, and
+    `auto_members` keep their names — they report on the `members` globs and on how
+    membership was determined, not on the packages themselves.
+
+    A consumer doing `jq ".members"` becomes `jq ".packages"`, and a workflow
+    branching on `check == "member_manifest"` must match `"package_manifest"`.
 time: 2026-07-28T18:04:00.000000-07:00

--- a/.changes/unreleased/Changed-20260728-exit-codes.yaml
+++ b/.changes/unreleased/Changed-20260728-exit-codes.yaml
@@ -1,3 +1,14 @@
 kind: Changed
-body: 'Trellis now exits `3` when it could not run at all — an unparseable config, a missing `gleam`/`gh`, a directory that is not a git repository, or Hex unreachable after retries — distinct from the `1` it returns when a command ran correctly and found problems. Previously both were `1`, so a workflow could not tell a workspace with `doctor` findings from a broken environment. The full contract is `0` success, `1` ran correctly and found problems, `2` usage error, `3` trellis itself could not run; a failed task exits `1` and does not propagate the child''s exit code. The new [Compatibility](https://trellis.tylerbutler.com/docs/compatibility/) page documents the contract alongside what semver covers at 1.0 — the CLI surface, configuration keys, exit codes, and the JSON payloads, but not human-readable output or anything in `src/` — and declares an MSRV of 1.85.'
+body: |-
+  **Trellis now exits `3` when it could not run at all,** distinct from the `1` it
+    returns when a command ran correctly and found problems. An unparseable config, a
+    missing `gleam` or `gh`, a non-git directory, and Hex unreachable after retries all
+    exit `3`; previously they exited `1`, indistinguishable from `doctor` findings.
+
+    The full contract is `0` success, `1` ran correctly and found problems, `2` usage
+    error, `3` could not run. A failed task exits `1` and does not propagate the
+    child's exit code. The new
+    [Compatibility](https://trellis.tylerbutler.com/docs/compatibility/) page
+    documents it alongside what semver will cover at 1.0, and declares an MSRV of
+    1.85.
 time: 2026-07-28T09:00:00.000000-07:00

--- a/.changes/unreleased/Changed-20260728-package-not-project.yaml
+++ b/.changes/unreleased/Changed-20260728-package-not-project.yaml
@@ -1,3 +1,13 @@
 kind: Changed
-body: '`package` replaces `project` as the word for a Gleam package everywhere trellis names one. A changelog fragment''s `project` key is now `package`, `trellis ci outputs` emits `packages` alongside its existing `projects` line, and the `changelog.dependency_body` template context gains `package`. Every old spelling still works — fragments already sitting in `.changes/unreleased/` parse unchanged, `projects` carries a value identical to `packages`, and `{{ project }}` still renders — so nothing breaks; `changelog new` writes the new spelling and the aliases go away at 1.0. The rule is that a package is the thing and a member is a package that belongs to the workspace, so "member" survives only where membership is the point: the `members` key, the `@members` exclusion, and the member paths that exclusion globs match. Error messages naming a fragment''s package follow suit — `doctor`''s `changelog_fragment` findings now read "package `x` is not a workspace member" rather than "project `x`". CLI help and `doctor`''s text output move with them: `trellis list` now describes itself as listing packages rather than members, `--since` selects packages, `doctor` summarizes "ok: 4 package(s)", and its `checked:` preamble names packages except where a line is genuinely about the `members` globs.'
+body: |-
+  **`package` replaces `project` as the word for a Gleam package everywhere trellis
+    names one.** A fragment's `project` key is now `package`, `trellis ci outputs`
+    emits `packages` alongside `projects`, and the `changelog.dependency_body`
+    template context gains `package`. Help text and `doctor`'s output follow — it now
+    summarizes "ok: 4 package(s)".
+
+    Nothing breaks: existing fragments parse unchanged, `projects` carries the same
+    value as `packages`, and `{{ project }}` still renders. `changelog new` writes the
+    new spelling, and the aliases go away at 1.0. "Member" survives where membership
+    is the point — the `members` key and the `@members` exclusion.
 time: 2026-07-28T18:02:00.000000-07:00

--- a/.changes/unreleased/Changed-20260728-snake-case-config.yaml
+++ b/.changes/unreleased/Changed-20260728-snake-case-config.yaml
@@ -1,3 +1,14 @@
 kind: Changed
-body: 'Every identifier trellis controls is now snake_case, matching Gleam''s own convention and the spellings `gleam.toml` uses for its own settings. `[tools.trellis]` keys lose their hyphens — `tag-format` becomes `tag_format`, `needs-deps` becomes `needs_deps`, and so on for all fourteen multi-word keys — as do the `--json` payloads, whose object keys, `check`/`kind`/`action` enum values, and `schema` payload names all follow. Every key spelling released through v0.7.0 is still accepted, so existing workspaces keep working unchanged; `doctor` reports each one as a warning naming its replacement, and the aliases go away at 1.0. Keys added since v0.7.0 — `changelog.dependency_kind`, `changelog.dependency_body`, and `doctor.shared_dependencies` — never shipped a hyphenated spelling and get no alias. The free-form tables (`exclude`, `tasks`, `publish.tag_mode_overrides`) take keys you choose, hyphens and all, and are untouched; so are the Gleam manifest''s own keys, such as `dev-dependencies`, which are not trellis''s to rename.'
+body: |-
+  **Every identifier trellis controls is now snake_case,** matching Gleam's own
+    convention. `[tools.trellis]` keys lose their hyphens — `tag-format` becomes
+    `tag_format`, `needs-deps` becomes `needs_deps`, and so on for all fourteen
+    multi-word keys — as do the `--json` payloads' object keys, enum values, and
+    `schema` names.
+
+    Every spelling released through v0.7.0 is still accepted, so existing workspaces
+    keep working; `doctor` warns on each one and names its replacement, and the
+    aliases go away at 1.0. Untouched are the free-form tables (`exclude`, `tasks`,
+    `publish.tag_mode_overrides`) and Gleam's own manifest keys, such as
+    `dev-dependencies`.
 time: 2026-07-28T18:00:00.000000-07:00

--- a/.changes/unreleased/Fixed-20260725-changelog-adoption.yaml
+++ b/.changes/unreleased/Fixed-20260725-changelog-adoption.yaml
@@ -1,3 +1,12 @@
 kind: Fixed
-body: '`version apply` no longer deletes a package''s pre-existing changelog. Because `CHANGELOG.md` is regenerated from the sections under `.changes/<package>/`, a package that already had a changelog when it adopted trellis lost all of it on its first release. That history is now captured verbatim as a single section on the first release, dated by the newest version its headings mention. `trellis doctor` reports the pending capture and `doctor --fix` performs it up front, so the restructuring can land in its own diff.'
+body: |-
+  **`version apply` no longer deletes a package's pre-existing changelog.** Because
+    `CHANGELOG.md` is regenerated from the sections under `.changes/<package>/`, a
+    package that already had a changelog when it adopted trellis lost all of it on
+    its first release.
+
+    That history is now captured verbatim as a single section on the first release,
+    dated by the newest version its headings mention. `trellis doctor` reports the
+    pending capture and `doctor --fix` performs it up front, so the restructuring can
+    land in its own diff.
 time: 2026-07-25T09:00:01.000000-07:00

--- a/.changes/unreleased/Fixed-20260726-quiet-everywhere.yaml
+++ b/.changes/unreleased/Fixed-20260726-quiet-everywhere.yaml
@@ -1,6 +1,8 @@
 kind: Fixed
-body: '`-q/--quiet` suppresses normal-path narration — progress lines, summaries,
-  confirmations — across every command, not just `run`/`exec`. `--json`/`--format
-  json|github`/`--format dot|mermaid` payloads, `man`/`completions`/`markdown-help`
-  output, fatal errors, and exit codes are unaffected.'
+body: |-
+  **`-q/--quiet` now suppresses normal-path narration across every command,** not
+    just `run` and `exec` — progress lines, summaries, and confirmations.
+    `--json`, `--format json|github`, and `--format dot|mermaid` payloads,
+    `man`/`completions`/`markdown-help` output, fatal errors, and exit codes are
+    unaffected.
 time: 2026-07-26T09:30:00.000000-07:00

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -29,7 +29,8 @@ kinds:
 newlines:
     afterChangelogHeader: 1
     afterChangelogVersion: 1
-    afterKind: 1
+    afterKind: 0
     afterVersion: 1
+    beforeChange: 1
     beforeKind: 1
     endOfVersion: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,48 @@ Config keys released through v0.7.0 keep their kebab-case spelling as a
 `#[serde(alias)]`, reported by `doctor` as a deprecation. These come out at 1.0;
 new keys never get one.
 
+## Changelog fragments
+
+Every user-visible change needs one: a YAML file in `.changes/unreleased/` named
+`<Kind>-<YYYYMMDD>-<slug>.yaml`, with `kind`, `body`, and `time`. The audience is
+a stranger reading the release notes, not the reviewer of your PR.
+
+Write the body as a `|-` block scalar with a **bolded lead-in sentence**, then
+paragraphs:
+
+```yaml
+kind: Added
+body: |-
+  **`trellis completions` generates tab-completion for five shells.** Candidates
+    are computed by the binary as you type, so completion offers real package,
+    task, and changelog-kind names from the surrounding workspace.
+
+    Release archives also ship man pages under `man/`.
+time: 2026-07-25T18:01:19.474540769-07:00
+```
+
+changie renders each body as `- {{.Body}}`, one bullet, so every line after the
+first needs a 2-space indent to stay inside it. YAML takes the block's
+indentation from its **first** line, so write the first line at 2 spaces and
+every later line at **4** — that lands as the 2-space markdown indent. A line at
+6+ spaces becomes a code block; a line at 2 becomes a sibling bullet.
+
+- The lead-in is one sentence, ≤ ~15 words, naming the command, flag, or key and
+  what it now does. For a small change it is the whole entry.
+- Keep what a reader acts on: the change, its user-visible consequence, the
+  migration, flags and keys by name, and edge cases they can actually hit.
+- Cut the design rationale — why this shape, what was rejected, how it is
+  implemented. That belongs in [docs/DESIGN.md](docs/DESIGN.md) or the website
+  docs. At most one "previously…" clause, where the fix makes no sense without it.
+- End a `Breaking` entry with the concrete migration: old spelling → new, or the
+  `jq` change.
+- Use current spellings in prose: snake_case keys, "package" not "project".
+- 40–90 words for most entries; two or three short paragraphs for a big one.
+
 ## Conventions
 
 - **Commits** use [conventional commits](https://www.conventionalcommits.org/):
   `type(scope): description`. Include a body; skip attribution trailers.
-- **Changelog fragments** are required for user-visible changes — a YAML file in
-  `.changes/unreleased/` with `kind`, `body`, and `time`. Prose, not a summary:
-  say what changed and why it was worth changing.
 - **Tests** come first for bug fixes and new behavior.
 
 ## Commands

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+# Batches .changes/unreleased/ fragments into CHANGELOG.md. The release workflow
+# runs it via tylerbutler/actions/changie-release; this is for local previews
+# (`changie batch <level> --dry-run`).
+changie = "latest"


### PR DESCRIPTION
The 20 fragments in `.changes/unreleased/` were written as working notes: one
dense paragraph each, mixing the user-visible change with internal design
rationale. changie renders each body as a single bullet, so the v0.8.0 section —
and the GitHub release notes generated from it — would have been twenty walls of
text with no scannable entry point.

## What changed

Each body now opens with a **bolded lead-in sentence** that names the change,
followed by paragraphs of detail. Bodies move from single-quoted flow scalars to
`|-` block scalars, which is what carries the paragraph breaks; continuation
lines sit at 4 spaces in YAML so they land as the 2-space markdown indent that
keeps them inside changie's bullet.

Rationale that only matters to contributors came out — it already lives in
`docs/DESIGN.md` and the website docs. Migrations, config keys, flags, and edge
cases a user can actually hit all stayed. Net 2255 → 1662 words; the four
longest entries (categories, prereleases, exit codes, snake_case) came down
25–40% each.

`Added-20260725-180119.yaml` is renamed to `Added-20260725-completions.yaml`, so
the one auto-timestamped filename matches the descriptive naming of the other 19.

`AGENTS.md` gains a `## Changelog fragments` section with the skeleton, the
indentation rule and what breaks if you miss it, and the prose rules.

`mise.toml` adds changie, so `changie batch <level> --dry-run` can preview a
version section locally.

## Verification

- `changie batch minor --dry-run` renders the full v0.8.0 section; every entry's
  paragraphs nest correctly inside their bullet.
- All 20 fragments parse, carry exactly `kind`/`body`/`time` with `time`
  untouched, start with a bold lead-in, and have no unindented or over-indented
  line.
- No Rust or config code changed, so `cargo test` was not run.