### PR TITLE
fix(changelog): unwrap fragment bodies to one line per paragraph

### DIFF
--- a/.changes/unreleased/Added-20260725-completions.yaml
+++ b/.changes/unreleased/Added-20260725-completions.yaml
@@ -1,13 +1,7 @@
 component: completions
 kind: Added
 body: |-
-  **`trellis completions <shell>` prints the snippet that turns on tab-completion**
-    for bash, zsh, fish, PowerShell, and elvish. The snippet asks trellis for
-    candidates on each tab-press, so you get the real package names, task names, and
-    changelog kinds from the workspace you're standing in. Evaluate it on shell
-    startup rather than saving it to a completions directory — a saved copy goes
-    stale on the next upgrade.
+  **`trellis completions <shell>` prints the snippet that turns on tab-completion** for bash, zsh, fish, PowerShell, and elvish. The snippet asks trellis for candidates on each tab-press, so you get the real package names, task names, and changelog kinds from the workspace you're standing in. Evaluate it on shell startup rather than saving it to a completions directory — a saved copy goes stale on the next upgrade.
 
-    Release archives also ship man pages under `man/`: `trellis.1`, plus a page per
-    subcommand.
+    Release archives also ship man pages under `man/`: `trellis.1`, plus a page per subcommand.
 time: 2026-07-25T18:01:19.474540769-07:00

--- a/.changes/unreleased/Added-20260725-doctor-structured-output.yaml
+++ b/.changes/unreleased/Added-20260725-doctor-structured-output.yaml
@@ -1,13 +1,7 @@
 component: doctor
 kind: Added
 body: |-
-  **`trellis doctor --format json|github` reports findings as data instead of
-    prose.** Each finding is a typed record — `{check, severity, message, file,
-    package, fixable}` — so CI can group them by package or narrow to the ones
-    `--fix` would clear. `--format github` emits GitHub Actions workflow commands,
-    which annotate the offending file right in a PR's Files tab.
+  **`trellis doctor --format json|github` reports findings as data instead of prose.** Each finding is a typed record — `{check, severity, message, file, package, fixable}` — so CI can group them by package or narrow to the ones `--fix` would clear. `--format github` emits GitHub Actions workflow commands, which annotate the offending file right in a PR's Files tab.
 
-    Branch on `check`: it's a documented enum on the [JSON output
-    contract](https://trellis.tylerbutler.com/docs/json-output/) page. Don't branch
-    on `message` — that prose can change. Text output stays as it was.
+    Branch on `check`: it's a documented enum on the [JSON output contract](https://trellis.tylerbutler.com/docs/json-output/) page. Don't branch on `message` — that prose can change. Text output stays as it was.
 time: 2026-07-25T18:30:00.000000-07:00

--- a/.changes/unreleased/Added-20260725-json-output-contract.yaml
+++ b/.changes/unreleased/Added-20260725-json-output-contract.yaml
@@ -1,15 +1,7 @@
 component: trellis
 kind: Added
 body: |-
-  **Every JSON document now names its payload and major version in a `schema`
-    field** — `"schema": "trellis.list/1"` — so a workflow can assert on the shape it
-    was built against.
+  **Every JSON document now names its payload and major version in a `schema` field** — `"schema": "trellis.list/1"` — so a workflow can assert on the shape it was built against.
 
-    The new [JSON output
-    contract](https://trellis.tylerbutler.com/docs/json-output/) page sets the rules:
-    new fields can turn up at any time, but renaming, removing, or retyping one bumps
-    the major. Every existing payload gains the `schema` key and nothing else, bar the
-    three bare arrays that had to become objects to hold it — `list`, `version plan`,
-    and `tag plan`, each covered in its own entry. `ci matrix` and `ci outputs` take
-    their shape from GitHub Actions and carry no `schema`.
+    The new [JSON output contract](https://trellis.tylerbutler.com/docs/json-output/) page sets the rules: new fields can turn up at any time, but renaming, removing, or retyping one bumps the major. Every existing payload gains the `schema` key and nothing else, bar the three bare arrays that had to become objects to hold it — `list`, `version plan`, and `tag plan`, each covered in its own entry. `ci matrix` and `ci outputs` take their shape from GitHub Actions and carry no `schema`.
 time: 2026-07-25T09:01:00.000000-07:00

--- a/.changes/unreleased/Added-20260725-ripple-bumps.yaml
+++ b/.changes/unreleased/Added-20260725-ripple-bumps.yaml
@@ -1,13 +1,7 @@
 component: version
 kind: Added
 body: |-
-  **When a package bumps, its workspace dependents now bump too** — transitively,
-    one patch each, with a generated `Dependencies` entry naming what moved. Trellis
-    derives a path dependency's Hex requirement at publish time, so a dependent left
-    behind can ship resolving to two different dependency sets.
+  **When a package bumps, its workspace dependents now bump too** — transitively, one patch each, with a generated `Dependencies` entry naming what moved. Trellis derives a path dependency's Hex requirement at publish time, so a dependent left behind can ship resolving to two different dependency sets.
 
-    Dependents need no fragment of their own, and one that already has a fragment
-    keeps its larger bump. A ripple stops at any package excluded from `@release`.
-    Two new keys under `[tools.trellis.changelog]` shape the generated entry:
-    `dependency_kind` and `dependency_body`.
+    Dependents need no fragment of their own, and one that already has a fragment keeps its larger bump. A ripple stops at any package excluded from `@release`. Two new keys under `[tools.trellis.changelog]` shape the generated entry: `dependency_kind` and `dependency_body`.
 time: 2026-07-25T09:00:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-exec-json.yaml
+++ b/.changes/unreleased/Added-20260726-exec-json.yaml
@@ -1,14 +1,7 @@
 component: exec
 kind: Added
 body: |-
-  **`trellis exec` accepts `--json`.** The new `trellis.exec/1` payload echoes the
-    command back as argv, so nothing downstream has to re-split a quoted string, and
-    carries one record per package — path, status, wall-clock duration, and, on
-    failure, the exit code. Until now the only machine-readable signal was the overall
-    exit code.
+  **`trellis exec` accepts `--json`.** The new `trellis.exec/1` payload echoes the command back as argv, so nothing downstream has to re-split a quoted string, and carries one record per package — path, status, wall-clock duration, and, on failure, the exit code. Until now the only machine-readable signal was the overall exit code.
 
-    A package that never ran — scheduling stopped at an earlier failure — reports
-    `skipped`, which still fails the command. Under `--json` the per-package stream
-    moves to stderr and the spinners and summary table go away, leaving stdout to the
-    payload alone.
+    A package that never ran — scheduling stopped at an earlier failure — reports `skipped`, which still fails the command. Under `--json` the per-package stream moves to stderr and the spinners and summary table go away, leaving stdout to the payload alone.
 time: 2026-07-26T09:01:30.000000-07:00

--- a/.changes/unreleased/Added-20260726-global-flags.yaml
+++ b/.changes/unreleased/Added-20260726-global-flags.yaml
@@ -1,14 +1,7 @@
 component: trellis
 kind: Added
 body: |-
-  **Four global flags now work before or after the subcommand.** `--color
-    auto|always|never` overrides terminal detection both ways, so `--color always`
-    survives a pipe and `--color never` survives a terminal; `auto` keeps honoring
-    `NO_COLOR` and `CLICOLOR=0`. Spinners still follow the terminal, so forcing color
-    into a pipe won't draw any.
+  **Four global flags now work before or after the subcommand.** `--color auto|always|never` overrides terminal detection both ways, so `--color always` survives a pipe and `--color never` survives a terminal; `auto` keeps honoring `NO_COLOR` and `CLICOLOR=0`. Spinners still follow the terminal, so forcing color into a pipe won't draw any.
 
-    `-q/--quiet` drops the per-package stream and the summary table without touching
-    exit codes. `-v/--verbose` traces every `gleam`, `git`, and `gh` command to
-    stderr, prefixed `+ ` and naming the directory it ran in. `--no-update-check`
-    skips the release check for one invocation.
+    `-q/--quiet` drops the per-package stream and the summary table without touching exit codes. `-v/--verbose` traces every `gleam`, `git`, and `gh` command to stderr, prefixed `+ ` and naming the directory it ran in. `--no-update-check` skips the release check for one invocation.
 time: 2026-07-26T09:00:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-init.yaml
+++ b/.changes/unreleased/Added-20260726-init.yaml
@@ -1,12 +1,7 @@
 component: init
 kind: Added
 body: |-
-  **`trellis init` bootstraps a workspace.** It writes the `[tools.trellis]` table
-    into the repository root's `gleam.toml`, creating a config-only manifest if the
-    root isn't itself a package and keeping your comments and formatting if it is.
+  **`trellis init` bootstraps a workspace.** It writes the `[tools.trellis]` table into the repository root's `gleam.toml`, creating a config-only manifest if the root isn't itself a package and keeping your comments and formatting if it is.
 
-    The table it writes is nearly bare, and that's the point: its presence alone
-    marks the workspace root, members stay auto-discovered, and the comments point at
-    what you could set. `init` prints the members it found, bails out on a repository
-    that is already a trellis workspace, and finishes by running `doctor`.
+    The table it writes is nearly bare, and that's the point: its presence alone marks the workspace root, members stay auto-discovered, and the comments point at what you could set. `init` prints the members it found, bails out on a repository that is already a trellis workspace, and finishes by running `doctor`.
 time: 2026-07-26T09:06:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-prereleases.yaml
+++ b/.changes/unreleased/Added-20260726-prereleases.yaml
@@ -1,16 +1,9 @@
 component: version
 kind: Added
 body: |-
-  **`version apply --pre rc` cuts a release candidate; `--pre none` promotes it.**
-    Repeat `--pre rc` and the counter advances within the same base version —
-    `1.0.0-rc.1`, then `1.0.0-rc.2`.
+  **`version apply --pre rc` cuts a release candidate; `--pre none` promotes it.** Repeat `--pre rc` and the counter advances within the same base version — `1.0.0-rc.1`, then `1.0.0-rc.2`.
 
-    Fragments survive a prerelease: the candidate renders its changelog section but
-    leaves them in `.changes/unreleased/`, so an entry shows up twice in
-    `CHANGELOG.md` — once under the RC, once under the final release. `version
-    --json` reports `fragments_retained` so a workflow can tell the two apart.
+    Fragments survive a prerelease: the candidate renders its changelog section but leaves them in `.changes/unreleased/`, so an entry shows up twice in `CHANGELOG.md` — once under the RC, once under the final release. `version --json` reports `fragments_retained` so a workflow can tell the two apart.
 
-    The label covers the whole plan, rippled dependents included. Once a package sits
-    at a prerelease, a plain `version apply` errors out and names both ways forward.
-    See [prereleases](https://trellis.tylerbutler.com/docs/changelog/#prereleases).
+    The label covers the whole plan, rippled dependents included. Once a package sits at a prerelease, a plain `version apply` errors out and names both ways forward. See [prereleases](https://trellis.tylerbutler.com/docs/changelog/#prereleases).
 time: 2026-07-26T09:03:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-run-json.yaml
+++ b/.changes/unreleased/Added-20260726-run-json.yaml
@@ -1,14 +1,7 @@
 component: run
 kind: Added
 body: |-
-  **`trellis run` accepts `--json`.** The new `trellis.run/1` payload names the task
-    and the `--target` as you gave it, then carries one record per package — path,
-    status, wall-clock duration, and, on failure, the exit code and the command that
-    produced it. Until now the only machine-readable signal was the overall exit code.
+  **`trellis run` accepts `--json`.** The new `trellis.run/1` payload names the task and the `--target` as you gave it, then carries one record per package — path, status, wall-clock duration, and, on failure, the exit code and the command that produced it. Until now the only machine-readable signal was the overall exit code.
 
-    A task that sets `needs_deps` runs several commands, so `exit_code` and `command`
-    describe the one that failed rather than the whole job. A package that never ran —
-    scheduling stopped at an earlier failure — reports `skipped`, which still fails the
-    command. Under `--json` the per-package stream moves to stderr and the spinners and
-    summary table go away, leaving stdout to the payload alone.
+    A task that sets `needs_deps` runs several commands, so `exit_code` and `command` describe the one that failed rather than the whole job. A package that never ran — scheduling stopped at an earlier failure — reports `skipped`, which still fails the command. Under `--json` the per-package stream moves to stderr and the spinners and summary table go away, leaving stdout to the payload alone.
 time: 2026-07-26T09:01:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-shared-dependency-check.yaml
+++ b/.changes/unreleased/Added-20260726-shared-dependency-check.yaml
@@ -1,13 +1,7 @@
 component: doctor
 kind: Added
 body: |-
-  **`trellis doctor` now checks that packages agree on the external dependencies
-    they share** — `lat_core` wanting `gleam_stdlib >= 0.44.0` while `lat_cli` wants
-    `>= 0.60.0`. It compares the requirement strings as written instead of parsing
-    them as ranges, so `>= 1.0` and `>=1.0` count as a disagreement; path
-    dependencies are out of scope.
+  **`trellis doctor` now checks that packages agree on the external dependencies they share** — `lat_core` wanting `gleam_stdlib >= 0.44.0` while `lat_cli` wants `>= 0.60.0`. It compares the requirement strings as written instead of parsing them as ranges, so `>= 1.0` and `>=1.0` count as a disagreement; path dependencies are out of scope.
 
-    Disagreeing on purpose is common enough that this only warns and won't fail CI.
-    Set `shared_dependencies` under `[tools.trellis.doctor]` to `warn`, `error`, or
-    `off`. Nothing here is `--fix`-able.
+    Disagreeing on purpose is common enough that this only warns and won't fail CI. Set `shared_dependencies` under `[tools.trellis.doctor]` to `warn`, `error`, or `off`. Nothing here is `--fix`-able.
 time: 2026-07-26T09:05:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-unknown-config-keys.yaml
+++ b/.changes/unreleased/Added-20260726-unknown-config-keys.yaml
@@ -1,10 +1,5 @@
 component: doctor
 kind: Added
 body: |-
-  **Trellis now reports keys under `[tools.trellis]` it doesn't recognize instead of
-    ignoring them,** so a typo no longer leaves the workspace quietly sitting on a
-    default. `doctor` calls each one a warning rather than an error — an unrecognized
-    key may simply belong to a newer trellis. The free-form tables (`exclude`,
-    `tasks`, and `publish.tag_mode_overrides`) take keys you choose, and never get
-    reported.
+  **Trellis now reports keys under `[tools.trellis]` it doesn't recognize instead of ignoring them,** so a typo no longer leaves the workspace quietly sitting on a default. `doctor` calls each one a warning rather than an error — an unrecognized key may simply belong to a newer trellis. The free-form tables (`exclude`, `tasks`, and `publish.tag_mode_overrides`) take keys you choose, and never get reported.
 time: 2026-07-26T09:04:00.000000-07:00

--- a/.changes/unreleased/Added-20260726-version-overrides.yaml
+++ b/.changes/unreleased/Added-20260726-version-overrides.yaml
@@ -1,14 +1,7 @@
 component: version
 kind: Added
 body: |-
-  **`version plan` and `version apply` accept `--bump` and `--set`,** so the version
-    no longer has to be whatever the pending fragments derive. `--bump major` sets the
-    level for the whole plan, `--bump lat_core=major` for one package; `--set
-    lat_core=1.0.0` pins an exact version, for the jump to 1.0 that the pre-1.0 rule
-    would otherwise call a minor.
+  **`version plan` and `version apply` accept `--bump` and `--set`,** so the version no longer has to be whatever the pending fragments derive. `--bump major` sets the level for the whole plan, `--bump lat_core=major` for one package; `--set lat_core=1.0.0` pins an exact version, for the jump to 1.0 that the pre-1.0 rule would otherwise call a minor.
 
-    `--set` wins over a per-package `--bump`, which wins over a workspace-wide one,
-    which wins over the derived level. Both commands take the same flags, so you see
-    an override in the dry run first, and trellis rejects conflicting or backwards
-    overrides before writing anything.
+    `--set` wins over a per-package `--bump`, which wins over a workspace-wide one, which wins over the derived level. Both commands take the same flags, so you see an override in the dry run first, and trellis rejects conflicting or backwards overrides before writing anything.
 time: 2026-07-26T09:02:00.000000-07:00

--- a/.changes/unreleased/Added-20260729-changelog-categories.yaml
+++ b/.changes/unreleased/Added-20260729-changelog-categories.yaml
@@ -1,16 +1,7 @@
 component: changelog
 kind: Added
 body: |-
-  **Changelog entries can group under a second axis above their kind.** Set
-    `categories` under `[tools.trellis.changelog]` — a vocabulary like `kinds`, but
-    with no bump attached — then write a fragment into one with `trellis changelog
-    new --category <name>`.
+  **Changelog entries can group under a second axis above their kind.** Set `categories` under `[tools.trellis.changelog]` — a vocabulary like `kinds`, but with no bump attached — then write a fragment into one with `trellis changelog new --category <name>`.
 
-    Leave `categories` unset and nothing changes. Even with it set, a fragment needn't
-    name one; those that don't trail the rest under `uncategorized_label`, which is
-    `Other` unless you say otherwise. Naming a category that isn't in the list
-    invalidates the fragment, exactly as an unknown kind does. While the axis is on,
-    kind headings drop from `###` to `####` unless `kind_format` says otherwise — and
-    an older trellis will choke on a fragment carrying a `category`. See
-    [categories](https://trellis.tylerbutler.com/docs/configuration/#categories).
+    Leave `categories` unset and nothing changes. Even with it set, a fragment needn't name one; those that don't trail the rest under `uncategorized_label`, which is `Other` unless you say otherwise. Naming a category that isn't in the list invalidates the fragment, exactly as an unknown kind does. While the axis is on, kind headings drop from `###` to `####` unless `kind_format` says otherwise — and an older trellis will choke on a fragment carrying a `category`. See [categories](https://trellis.tylerbutler.com/docs/configuration/#categories).
 time: 2026-07-29T12:00:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260725-list-json-envelope.yaml
+++ b/.changes/unreleased/Breaking-20260725-list-json-envelope.yaml
@@ -1,9 +1,7 @@
 component: list
 kind: Breaking
 body: |-
-  **`trellis list --json` returns an object, not a bare array.** The array moves under
-    a `packages` key so the document can carry the new `schema` field:
-    `{"schema": "trellis.list/1", "packages": [...]}`.
+  **`trellis list --json` returns an object, not a bare array.** The array moves under a `packages` key so the document can carry the new `schema` field: `{"schema": "trellis.list/1", "packages": [...]}`.
 
     `trellis list --json | jq ".[].name"` becomes `jq ".packages[].name"`.
 time: 2026-07-25T09:00:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260725-tag-plan-json-envelope.yaml
+++ b/.changes/unreleased/Breaking-20260725-tag-plan-json-envelope.yaml
@@ -1,9 +1,7 @@
 component: tag
 kind: Breaking
 body: |-
-  **`trellis tag plan --json` returns an object, not a bare array.** The array moves
-    under a `tags` key so the document can carry the new `schema` field:
-    `{"schema": "trellis.tag_plan/1", "tags": [...]}`.
+  **`trellis tag plan --json` returns an object, not a bare array.** The array moves under a `tags` key so the document can carry the new `schema` field: `{"schema": "trellis.tag_plan/1", "tags": [...]}`.
 
     `trellis tag plan --json | jq ".[].tag"` becomes `jq ".tags[].tag"`.
 time: 2026-07-25T09:00:02.000000-07:00

--- a/.changes/unreleased/Breaking-20260725-version-plan-json-envelope.yaml
+++ b/.changes/unreleased/Breaking-20260725-version-plan-json-envelope.yaml
@@ -1,9 +1,7 @@
 component: version
 kind: Breaking
 body: |-
-  **`trellis version plan --json` returns an object, not a bare array.** The array
-    moves under a `bumped` key so the document can carry the new `schema` field —
-    matching `version apply`, which already used that name.
+  **`trellis version plan --json` returns an object, not a bare array.** The array moves under a `bumped` key so the document can carry the new `schema` field — matching `version apply`, which already used that name.
 
     `trellis version plan --json | jq ".[].name"` becomes `jq ".bumped[].name"`.
 time: 2026-07-25T09:00:01.000000-07:00

--- a/.changes/unreleased/Breaking-20260728-ci-output-names.yaml
+++ b/.changes/unreleased/Breaking-20260728-ci-output-names.yaml
@@ -1,13 +1,7 @@
 component: ci
 kind: Breaking
 body: |-
-  **`trellis ci outputs` renames two of its GitHub Actions outputs to snake_case:**
-    `version-files` becomes `version_files` and `series-tags` becomes `series_tags`.
-    `releasable` and `tags` are unchanged; `packages` supersedes `projects`, which
-    sticks around as a deprecated alias. The values are identical — only the names
-    moved, to follow the same snake_case rule as the config keys and the `--json`
-    payloads.
+  **`trellis ci outputs` renames two of its GitHub Actions outputs to snake_case:** `version-files` becomes `version_files` and `series-tags` becomes `series_tags`. `releasable` and `tags` are unchanged; `packages` supersedes `projects`, which sticks around as a deprecated alias. The values are identical — only the names moved, to follow the same snake_case rule as the config keys and the `--json` payloads.
 
-    A workflow reading `steps.<id>.outputs.version-files` or `.series-tags` has to
-    switch to `.version_files` and `.series_tags`.
+    A workflow reading `steps.<id>.outputs.version-files` or `.series-tags` has to switch to `.version_files` and `.series_tags`.
 time: 2026-07-28T18:01:00.000000-07:00

--- a/.changes/unreleased/Breaking-20260728-doctor-json-package-keys.yaml
+++ b/.changes/unreleased/Breaking-20260728-doctor-json-package-keys.yaml
@@ -1,12 +1,7 @@
 component: doctor
 kind: Breaking
 body: |-
-  **`trellis.doctor/1` renames two identifiers to match the package/member rule:**
-    the workspace-size field `members` becomes `packages`, and the `member_manifest`
-    check value becomes `package_manifest`. `member_glob`, `configless`, and
-    `auto_members` keep their names — they report on the `members` globs and on how
-    trellis worked out membership, not on the packages themselves.
+  **`trellis.doctor/1` renames two identifiers to match the package/member rule:** the workspace-size field `members` becomes `packages`, and the `member_manifest` check value becomes `package_manifest`. `member_glob`, `configless`, and `auto_members` keep their names — they report on the `members` globs and on how trellis worked out membership, not on the packages themselves.
 
-    A consumer doing `jq ".members"` switches to `jq ".packages"`, and a workflow
-    branching on `check == "member_manifest"` has to match `"package_manifest"`.
+    A consumer doing `jq ".members"` switches to `jq ".packages"`, and a workflow branching on `check == "member_manifest"` has to match `"package_manifest"`.
 time: 2026-07-28T18:04:00.000000-07:00

--- a/.changes/unreleased/Changed-20260728-exit-codes.yaml
+++ b/.changes/unreleased/Changed-20260728-exit-codes.yaml
@@ -1,14 +1,7 @@
 component: trellis
 kind: Changed
 body: |-
-  **Trellis now exits `3` when it couldn't run at all,** as distinct from the `1` it
-    returns when a command ran fine and found problems. An unparseable config, a
-    missing `gleam` or `gh`, a non-git directory, and Hex unreachable after retries
-    all exit `3`; they used to exit `1`, indistinguishable from `doctor` findings.
+  **Trellis now exits `3` when it couldn't run at all,** as distinct from the `1` it returns when a command ran fine and found problems. An unparseable config, a missing `gleam` or `gh`, a non-git directory, and Hex unreachable after retries all exit `3`; they used to exit `1`, indistinguishable from `doctor` findings.
 
-    The whole contract: `0` success, `1` ran fine and found problems, `2` usage error,
-    `3` couldn't run. A failed task exits `1` and doesn't pass along the child's exit
-    code. The new [Compatibility](https://trellis.tylerbutler.com/docs/compatibility/)
-    page writes all this down next to what semver covers at 1.0, and declares an MSRV
-    of 1.85.
+    The whole contract: `0` success, `1` ran fine and found problems, `2` usage error, `3` couldn't run. A failed task exits `1` and doesn't pass along the child's exit code. The new [Compatibility](https://trellis.tylerbutler.com/docs/compatibility/) page writes all this down next to what semver covers at 1.0, and declares an MSRV of 1.85.
 time: 2026-07-28T09:00:00.000000-07:00

--- a/.changes/unreleased/Changed-20260728-package-not-project.yaml
+++ b/.changes/unreleased/Changed-20260728-package-not-project.yaml
@@ -1,14 +1,7 @@
 component: trellis
 kind: Changed
 body: |-
-  **`package` replaces `project` as the word for a Gleam package everywhere trellis
-    names one.** A fragment's `project` key is now `package`, `trellis ci outputs`
-    emits `packages` alongside `projects`, and the `changelog.dependency_body`
-    template context gains `package`. Help text and `doctor`'s output follow — it now
-    sums up with "ok: 4 package(s)".
+  **`package` replaces `project` as the word for a Gleam package everywhere trellis names one.** A fragment's `project` key is now `package`, `trellis ci outputs` emits `packages` alongside `projects`, and the `changelog.dependency_body` template context gains `package`. Help text and `doctor`'s output follow — it now sums up with "ok: 4 package(s)".
 
-    Nothing breaks: existing fragments parse unchanged, `projects` carries the same
-    value as `packages`, and `{{ project }}` still renders. `changelog new` writes the
-    new spelling, and the aliases go away at 1.0. "Member" survives where membership
-    is the point — the `members` key and the `@members` exclusion.
+    Nothing breaks: existing fragments parse unchanged, `projects` carries the same value as `packages`, and `{{ project }}` still renders. `changelog new` writes the new spelling, and the aliases go away at 1.0. "Member" survives where membership is the point — the `members` key and the `@members` exclusion.
 time: 2026-07-28T18:02:00.000000-07:00

--- a/.changes/unreleased/Changed-20260728-snake-case-config.yaml
+++ b/.changes/unreleased/Changed-20260728-snake-case-config.yaml
@@ -1,15 +1,7 @@
 component: trellis
 kind: Changed
 body: |-
-  **Every identifier trellis controls is now snake_case,** matching Gleam's own
-    convention. `[tools.trellis]` keys lose their hyphens — `tag-format` becomes
-    `tag_format`, `needs-deps` becomes `needs_deps`, and so on for the eleven keys
-    that had one — as do the `--json` payloads' object keys, enum values, and `schema`
-    names.
+  **Every identifier trellis controls is now snake_case,** matching Gleam's own convention. `[tools.trellis]` keys lose their hyphens — `tag-format` becomes `tag_format`, `needs-deps` becomes `needs_deps`, and so on for the eleven keys that had one — as do the `--json` payloads' object keys, enum values, and `schema` names.
 
-    Every spelling released through v0.7.0 still parses, so existing workspaces keep
-    working; `doctor` warns on each one and names its replacement, and the aliases go
-    away at 1.0. The free-form tables (`exclude`, `tasks`,
-    `publish.tag_mode_overrides`) and Gleam's own manifest keys, `dev-dependencies`
-    among them, are untouched.
+    Every spelling released through v0.7.0 still parses, so existing workspaces keep working; `doctor` warns on each one and names its replacement, and the aliases go away at 1.0. The free-form tables (`exclude`, `tasks`, `publish.tag_mode_overrides`) and Gleam's own manifest keys, `dev-dependencies` among them, are untouched.
 time: 2026-07-28T18:00:00.000000-07:00

--- a/.changes/unreleased/Fixed-20260725-changelog-adoption.yaml
+++ b/.changes/unreleased/Fixed-20260725-changelog-adoption.yaml
@@ -1,12 +1,7 @@
 component: version
 kind: Fixed
 body: |-
-  **`version apply` no longer deletes a package's pre-existing changelog.** Trellis
-    regenerates `CHANGELOG.md` from the sections under `.changes/<package>/`, so a
-    package that already had a changelog when it adopted trellis lost the lot on its
-    first release.
+  **`version apply` no longer deletes a package's pre-existing changelog.** Trellis regenerates `CHANGELOG.md` from the sections under `.changes/<package>/`, so a package that already had a changelog when it adopted trellis lost the lot on its first release.
 
-    That history now survives verbatim as a single section, filed under the newest
-    version its headings mention. `trellis doctor` flags the pending capture and
-    `doctor --fix` does it up front, so the restructuring lands in a diff of its own.
+    That history now survives verbatim as a single section, filed under the newest version its headings mention. `trellis doctor` flags the pending capture and `doctor --fix` does it up front, so the restructuring lands in a diff of its own.
 time: 2026-07-25T09:00:01.000000-07:00

--- a/.changes/unreleased/Fixed-20260726-quiet-everywhere.yaml
+++ b/.changes/unreleased/Fixed-20260726-quiet-everywhere.yaml
@@ -1,8 +1,5 @@
 component: trellis
 kind: Fixed
 body: |-
-  **`-q/--quiet` now silences the normal chatter of every command,** not just `run`
-    and `exec` — progress lines, summaries, and confirmations. It leaves alone the
-    `--json`, `--format json|github`, and `--format dot|mermaid` payloads, the
-    `man`/`completions`/`markdown-help` output, fatal errors, and exit codes.
+  **`-q/--quiet` now silences the normal chatter of every command,** not just `run` and `exec` — progress lines, summaries, and confirmations. It leaves alone the `--json`, `--format json|github`, and `--format dot|mermaid` payloads, the `man`/`completions`/`markdown-help` output, fatal errors, and exit codes.
 time: 2026-07-26T09:30:00.000000-07:00

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,19 @@ paragraphs:
 component: completions
 kind: Added
 body: |-
-  **`trellis completions` generates tab-completion for five shells.** Candidates
-    are computed by the binary as you type, so completion offers real package,
-    task, and changelog-kind names from the surrounding workspace.
+  **`trellis completions` generates tab-completion for five shells.** Candidates are computed by the binary as you type, so completion offers real package, task, and changelog-kind names from the surrounding workspace.
 
     Release archives also ship man pages under `man/`.
 time: 2026-07-25T18:01:19.474540769-07:00
 ```
+
+**One line per paragraph. Never hard-wrap a body**, however long the line gets —
+the shipped entries run to 500+ characters. cargo-dist copies the version's
+CHANGELOG.md section verbatim into the GitHub release body, and GitHub renders
+release notes the way it renders comments: every single newline becomes a `<br>`,
+unlike a `.md` file in the repo, where it collapses to a space. A body wrapped at
+80 columns reads fine in CHANGELOG.md and arrives in the release notes as a
+ragged column of short lines. Wrap only *between* paragraphs, with a blank line.
 
 `component` is the subcommand the change belongs to, and renders as a `###`
 heading above the `####` kind headings, so a reader can find what changed in
@@ -76,10 +82,10 @@ Two ways to get this wrong, neither of which fails the batch:
 - **Misspelling one** invents a section rather than erroring — changie does not
   validate the value against the configured list.
 
-changie renders each body as `- {{.Body}}`, one bullet, so every line after the
-first needs a 2-space indent to stay inside it. YAML takes the block's
-indentation from its **first** line, so write the first line at 2 spaces and
-every later line at **4** — that lands as the 2-space markdown indent. A line at
+changie renders each body as `- {{.Body}}`, one bullet, so every paragraph after
+the first needs a 2-space indent to stay inside it. YAML takes the block's
+indentation from its **first** line, so write the first paragraph at 2 spaces and
+every later one at **4** — that lands as the 2-space markdown indent. A line at
 6+ spaces becomes a code block; a line at 2 becomes a sibling bullet.
 
 - The lead-in is one sentence, ≤ ~15 words, naming the command, flag, or key and


### PR DESCRIPTION
## The bug

GitHub renders release notes the way it renders comments: **a single newline inside a paragraph becomes a `<br>`.** A `.md` file checked into the repo collapses that same newline to a space. So a body wrapped at 80 columns reads correctly in `CHANGELOG.md` and arrives in the release notes as a ragged column of short lines.

That matters here because cargo-dist copies the version's `CHANGELOG.md` section verbatim into the GitHub release body — the fragments are the only place to fix it.

## Evidence

Confirmed in three places:

- [GitHub's own formatting docs](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax): "If you're writing in issues, pull requests, or discussions in a repository, GitHub will render a line break automatically" — whereas `.md` files need two trailing spaces, a backslash, or `<br/>`.
- [community/community#35750](https://github.com/orgs/community/discussions/35750) demonstrates the same markdown rendering correctly in a README and with unwanted breaks in a release. Still unanswered by GitHub.
- **This repo's own shipped releases.** Every version file already has one long line per paragraph — up to 590 characters in `v0.5.0` — and `gh release view v0.7.0` shows it arriving intact. Only the unreleased set was wrapped.

So this is a regression that hasn't shipped yet, introduced when the fragments were reworded in #63.

## The change

23 fragments unwrapped to one line per paragraph. Bodies are **byte-identical modulo whitespace** — verified by parsing each file's YAML at `HEAD` and here and comparing `re.sub(r'\s+', ' ', body)`. Only line breaks moved; no wording changed.

`AGENTS.md` states the rule and the reason, and its own example no longer contradicts it.

## Verification

All YAML parses; block-scalar indentation still 2-then-4. `changie batch minor --dry-run` renders with no intra-paragraph line breaks anywhere in the output, checked programmatically. Longest rendered line is 551 chars, in line with the 590 already shipped in v0.5.0. Only dry-runs were run, so no fragments were consumed. No Rust changed.
