### PR TITLE
feat(changelog): make check strictness configurable and CI-native

### DIFF
--- a/.changes/unreleased/Added-20260731-changelog-check-github-output.yaml
+++ b/.changes/unreleased/Added-20260731-changelog-check-github-output.yaml
@@ -1,0 +1,7 @@
+component: changelog
+kind: Added
+body: |-
+  **`trellis changelog check --format github` emits `key=value` lines for `$GITHUB_OUTPUT`.** A workflow reads `ok`, `has_entries`, `needs_entry`, `needs_entry_packages`, `invalid_fragments`, and a ready-to-post markdown `preview`, so a PR comment takes a redirect instead of a `jq` pipeline. See [CI recipes](https://trellis.tylerbutler.com/docs/ci/) for the sticky-comment workflow.
+
+    The `trellis.changelog_check/1` payload gains two fields alongside them: `ok`, the verdict after strictness is applied, which matches the exit code, and the `strictness` that decided it. `--format json` is the new spelling of `--json`, which still works as a deprecated alias; passing both is a usage error.
+time: 2026-07-31T18:36:44.000000000-07:00

--- a/.changes/unreleased/Added-20260731-changelog-check-strictness.yaml
+++ b/.changes/unreleased/Added-20260731-changelog-check-strictness.yaml
@@ -1,0 +1,7 @@
+component: changelog
+kind: Added
+body: |-
+  **`changelog.strictness` decides what a missing changelog entry costs.** `error` is the default and fails `trellis changelog check` exactly as before; `warn` reports the missing entry and exits 0; `off` skips the verdict while still listing each changed package's fragment count. `--strictness error|warn|off` overrides the configured value for one run, so a workflow can gate harder than the workspace default without editing `gleam.toml`.
+
+    Strictness covers missing entries only. A fragment that doesn't parse, or that names an unknown package or kind, still fails the check at every setting.
+time: 2026-07-31T18:36:43.348571273-07:00

--- a/README.md
+++ b/README.md
@@ -284,7 +284,8 @@ name — trellis rejects any task named with that prefix.
 
 ```
 trellis changelog new [--package <pkg>] --kind <kind> --body <text>
-trellis changelog check --base <ref> [--head <ref>] [--json]
+trellis changelog check --base <ref> [--head <ref>] [--format text|json|github]
+                       [--strictness error|warn|off]
 trellis version plan  [--bump <level>|<pkg>=<level>] [--set <pkg>=<version>]
                       [--pre <label>|none] [--json]
 trellis version apply [--bump <level>|<pkg>=<level>] [--set <pkg>=<version>]
@@ -296,8 +297,12 @@ to keep in sync. Changes are recorded as TOML fragments in
 `.changes/unreleased/` (`project`, `kind`, `body`); `changelog new` writes
 one, non-interactively, which suits CI and agents as well as shells.
 `changelog check` maps a `base...head` diff to packages and fails if a
-changed releasable package has no unreleased fragment, emitting JSON
-(including a markdown `preview`) for a PR sticky comment.
+changed releasable package has no unreleased fragment. How much that costs is
+configurable — `changelog.strictness` is `error` by default, `warn` to report
+without failing, `off` not to check (an *invalid* fragment fails either way).
+`--format json` emits the payload, including a markdown `preview` for a PR
+sticky comment; `--format github` emits the same facts as `key=value` lines for
+`$GITHUB_OUTPUT`, so a workflow can post that comment without a `jq` pipeline.
 
 `version plan` computes each pending package's next version from its
 fragments' kinds (the largest bump wins; kinds and their bumps are

--- a/assets/man/trellis-changelog-check.1
+++ b/assets/man/trellis-changelog-check.1
@@ -4,7 +4,7 @@
 .SH NAME
 trellis\-changelog\-check \- Verify changed packages have changelog fragments; non\-zero exit if not
 .SH SYNOPSIS
-\fBtrellis changelog check\fR <\fB\-\-base\fR> [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-color\fR] [\fB\-\-head\fR] [\fB\-\-json\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBtrellis changelog check\fR <\fB\-\-base\fR> [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-color\fR] [\fB\-\-head\fR] [\fB\-\-format\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-strictness\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-json\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Verify changed packages have changelog fragments; non\-zero exit if not
 .SH OPTIONS
@@ -33,14 +33,44 @@ never
 \fB\-\-head\fR \fI<HEAD>\fR [default: HEAD]
 Head ref of the change range
 .TP
-\fB\-\-json\fR
-Emit JSON, including a Markdown `preview` for a PR comment
+\fB\-\-format\fR \fI<FORMAT>\fR [default: text]
+How to report: prose, the `trellis.changelog_check/1` JSON payload (including a Markdown `preview` for a PR comment), or `key=value` lines for $GITHUB_OUTPUT
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+text
+.IP \(bu 2
+json: The `trellis.changelog_check/1` payload
+.IP \(bu 2
+github: `key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post, update, or delete a PR comment without a `jq` pipeline
+.RE
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Suppress normal\-path output; JSON/report payloads and errors still print
 .TP
+\fB\-\-strictness\fR \fI<STRICTNESS>\fR
+Override the workspace\*(Aqs changelog.strictness for this run: fail on a missing entry, report it advisorily, or don\*(Aqt check
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+warn
+.IP \(bu 2
+error
+.IP \(bu 2
+off
+.RE
+.TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Trace every command trellis shells out to, on stderr
+.TP
+\fB\-\-json\fR
+Deprecated alias for `\-\-format json`
 .TP
 \fB\-\-no\-update\-check\fR
 Don\*(Aqt check whether a newer trellis release is available

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -2,6 +2,7 @@
 //! writes a fragment; `check` decides which changed packages still need one.
 
 use crate::changelog;
+use crate::config::Strictness;
 use crate::json::{ChangelogCheckDocument, ChangelogPackage};
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
@@ -82,10 +83,26 @@ pub fn new_fragment(
 
 // ---- check -------------------------------------------------------------
 
+/// How `check` reports. `text` is for a person; the other two are the machine
+/// surfaces CI consumes. Mirrors `doctor`'s `--format`, which is the shape a
+/// second structured output always wants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+pub enum CheckFormat {
+    #[default]
+    Text,
+    /// The `trellis.changelog_check/1` payload.
+    Json,
+    /// `key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post, update,
+    /// or delete a PR comment without a `jq` pipeline.
+    Github,
+}
+
 pub struct CheckOptions {
     pub base: String,
     pub head: String,
-    pub json: bool,
+    pub format: CheckFormat,
+    /// Overrides the workspace's `changelog.strictness` for this run.
+    pub strictness: Option<Strictness>,
 }
 
 struct PackageStatus {
@@ -94,9 +111,12 @@ struct PackageStatus {
 }
 
 /// Map the base...head diff to releasable packages and decide which still
-/// need a changelog fragment. Returns false (non-zero exit) when any does,
-/// or when any fragment is invalid.
+/// need a changelog fragment. Returns false (non-zero exit) when one does and
+/// strictness is `error`, or when any fragment is invalid.
 pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
+    let strictness = options
+        .strictness
+        .unwrap_or(workspace.config.changelog.strictness);
     let changed = crate::git::changed_members_between(workspace, &options.base, &options.head)?;
     let fragments = changelog::load_fragments(workspace)?;
 
@@ -111,72 +131,163 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
         })
         .collect();
 
-    let needs_entry: Vec<&str> = statuses
-        .iter()
-        .filter(|status| status.fragments == 0)
-        .map(|status| status.name.as_str())
-        .collect();
-    let ok = needs_entry.is_empty() && fragments.problems.is_empty();
+    // Under `off` the diff is still mapped and reported — the rows are useful
+    // on their own — but nothing is *asked* of the contributor, so there is no
+    // verdict to carry into the payload, the preview, or the exit code.
+    let needs_entry: Vec<&str> = match strictness {
+        Strictness::Off => Vec::new(),
+        Strictness::Warn | Strictness::Error => statuses
+            .iter()
+            .filter(|status| status.fragments == 0)
+            .map(|status| status.name.as_str())
+            .collect(),
+    };
+    // A fragment that does not parse is malformed input, not a judgment call,
+    // so it fails at every strictness.
+    let ok = (strictness != Strictness::Error || needs_entry.is_empty())
+        && fragments.problems.is_empty();
     // `invalid_fragments` is a contract field of `trellis.changelog_check/1`
     // and stays an array of strings; the structured form exists for `doctor`.
     let invalid = fragments.problem_messages();
+    let has_entries = !fragments.fragments.is_empty();
+    let preview = preview(&statuses, &needs_entry, &invalid, strictness);
 
-    if options.json {
-        let document = ChangelogCheckDocument {
-            schema: ChangelogCheckDocument::SCHEMA,
-            has_entries: !fragments.fragments.is_empty(),
-            needs_entry: !needs_entry.is_empty(),
-            invalid_fragments: &invalid,
-            packages: statuses
-                .iter()
-                .map(|status| ChangelogPackage {
-                    name: &status.name,
-                    changed: true,
-                    has_entry: status.fragments > 0,
-                    fragments: status.fragments,
-                })
-                .collect(),
-            preview: preview(&statuses, &invalid),
-        };
-        println!("{}", serde_json::to_string_pretty(&document)?);
-    } else {
-        if statuses.is_empty() {
-            crate::status!(
-                "no releasable packages changed between {} and {}",
-                options.base,
-                options.head
-            );
-        }
-        for status in &statuses {
-            let state = if status.fragments > 0 {
-                format!("{} fragment(s)", status.fragments)
-            } else {
-                "needs a changelog entry".to_string()
+    match options.format {
+        CheckFormat::Json => {
+            let document = ChangelogCheckDocument {
+                schema: ChangelogCheckDocument::SCHEMA,
+                ok,
+                strictness,
+                has_entries,
+                needs_entry: !needs_entry.is_empty(),
+                invalid_fragments: &invalid,
+                packages: statuses
+                    .iter()
+                    .map(|status| ChangelogPackage {
+                        name: &status.name,
+                        changed: true,
+                        has_entry: status.fragments > 0,
+                        fragments: status.fragments,
+                    })
+                    .collect(),
+                preview,
             };
-            crate::status!("{}: {state}", status.name);
+            println!("{}", serde_json::to_string_pretty(&document)?);
         }
-        for problem in &invalid {
-            crate::status!("invalid: {problem}");
+        CheckFormat::Github => print_github_outputs(
+            ok,
+            strictness,
+            has_entries,
+            &needs_entry,
+            &invalid,
+            &preview,
+        )?,
+        CheckFormat::Text => {
+            if statuses.is_empty() {
+                crate::status!(
+                    "no releasable packages changed between {} and {}",
+                    options.base,
+                    options.head
+                );
+            }
+            for status in &statuses {
+                let state = if status.fragments > 0 {
+                    format!("{} fragment(s)", status.fragments)
+                } else if !needs_entry.contains(&status.name.as_str()) {
+                    // `off`: report the fact, ask for nothing.
+                    "no entries".to_string()
+                } else if strictness == Strictness::Warn {
+                    // Named as advisory, so a green exit code doesn't read as
+                    // the line having been ignored.
+                    "needs a changelog entry (warning)".to_string()
+                } else {
+                    "needs a changelog entry".to_string()
+                };
+                crate::status!("{}: {state}", status.name);
+            }
+            for problem in &invalid {
+                crate::status!("invalid: {problem}");
+            }
         }
     }
     Ok(ok)
 }
 
-/// Markdown summary for the PR sticky comment.
-fn preview(statuses: &[PackageStatus], invalid: &[String]) -> String {
+/// Emit `key=value` lines for `$GITHUB_OUTPUT`, in the shape `ci outputs`
+/// established: arrays are JSON, so a workflow reads them with `fromJSON()`.
+fn print_github_outputs(
+    ok: bool,
+    strictness: Strictness,
+    has_entries: bool,
+    needs_entry: &[&str],
+    invalid: &[String],
+    preview: &str,
+) -> Result<()> {
+    println!("ok={ok}");
+    println!(
+        "strictness={}",
+        match strictness {
+            Strictness::Warn => "warn",
+            Strictness::Error => "error",
+            Strictness::Off => "off",
+        }
+    );
+    println!("has_entries={has_entries}");
+    println!("needs_entry={}", !needs_entry.is_empty());
+    println!(
+        "needs_entry_packages={}",
+        serde_json::to_string(needs_entry)?
+    );
+    println!("invalid_fragments={}", serde_json::to_string(invalid)?);
+    // The comment body is markdown, so it needs GitHub's heredoc form.
+    let delimiter = heredoc_delimiter(preview);
+    println!("preview<<{delimiter}");
+    print!("{preview}");
+    if !preview.ends_with('\n') {
+        println!();
+    }
+    println!("{delimiter}");
+    Ok(())
+}
+
+/// A delimiter the value cannot contain. GitHub ends the block at the first
+/// line equal to it, so a value carrying the delimiter would truncate the
+/// output — and let whatever follows be read as further `key=value` lines.
+fn heredoc_delimiter(value: &str) -> String {
+    let mut delimiter = String::from("TRELLIS_PREVIEW");
+    while value.lines().any(|line| line == delimiter) {
+        delimiter.push('_');
+    }
+    delimiter
+}
+
+/// Markdown summary for the PR sticky comment. `needs_entry` is passed rather
+/// than re-derived so the comment says exactly what the exit code did — under
+/// `off` there is no ❌ and no call to action.
+fn preview(
+    statuses: &[PackageStatus],
+    needs_entry: &[&str],
+    invalid: &[String],
+    strictness: Strictness,
+) -> String {
     let mut out = String::from("### Changelog check\n\n");
     if statuses.is_empty() {
         out.push_str("No releasable packages changed.\n");
     } else {
         out.push_str("| package | fragments |\n| --- | --- |\n");
         for status in statuses {
-            if status.fragments > 0 {
-                out.push_str(&format!("| {} | ✅ {} |\n", status.name, status.fragments));
+            let cell = if status.fragments > 0 {
+                format!("✅ {}", status.fragments)
+            } else if !needs_entry.contains(&status.name.as_str()) {
+                "— none".to_string()
+            } else if strictness == Strictness::Warn {
+                "⚠️ no entry".to_string()
             } else {
-                out.push_str(&format!("| {} | ❌ needs an entry |\n", status.name));
-            }
+                "❌ needs an entry".to_string()
+            };
+            out.push_str(&format!("| {} | {cell} |\n", status.name));
         }
-        if statuses.iter().any(|status| status.fragments == 0) {
+        if !needs_entry.is_empty() {
             out.push_str(
                 "\nAdd one with `trellis changelog new --package <name> --kind <kind> --body <text>`.\n",
             );
@@ -186,4 +297,32 @@ fn preview(statuses: &[PackageStatus], invalid: &[String]) -> String {
         out.push_str(&format!("\n⚠️ {problem}\n"));
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_heredoc_delimiter_avoids_the_value_it_wraps() {
+        assert_eq!(
+            heredoc_delimiter("### Changelog check\n"),
+            "TRELLIS_PREVIEW"
+        );
+        // A fragment body quoting the delimiter would otherwise end the block
+        // early and let the rest be read as further `key=value` lines.
+        assert_eq!(
+            heredoc_delimiter("a\nTRELLIS_PREVIEW\nb\n"),
+            "TRELLIS_PREVIEW_"
+        );
+        assert_eq!(
+            heredoc_delimiter("TRELLIS_PREVIEW\nTRELLIS_PREVIEW_\n"),
+            "TRELLIS_PREVIEW__"
+        );
+        // Only a whole line ends a block, so a mention mid-line is harmless.
+        assert_eq!(
+            heredoc_delimiter("see TRELLIS_PREVIEW here\n"),
+            "TRELLIS_PREVIEW"
+        );
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,8 +73,12 @@ pub struct DeprecatedKey {
     pub replacement: String,
 }
 
-/// What `doctor` does about a check that is a judgment call.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+/// What a check that is a judgment call does about what it finds: fail the
+/// run, report it and carry on, or not look at all. Shared by `doctor` and by
+/// `changelog check`, which differ only in which end they default to.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, serde::Serialize, clap::ValueEnum,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum Strictness {
     #[default]
@@ -411,6 +415,16 @@ pub struct ChangelogConfig {
     /// `change_format`. Context: `dependency`, `dependency_version`, `project`.
     #[serde(default = "default_dependency_body")]
     pub dependency_body: String,
+    /// What `changelog check` does when a changed releasable package owns no
+    /// unreleased fragment: fail (the default), report it advisorily, or not
+    /// check at all. Only that verdict is a judgment call — an *invalid*
+    /// fragment fails at every setting.
+    ///
+    /// Spelled with its own default rather than `#[serde(default)]`: the
+    /// derived [`Strictness::default`] is `warn`, which is right for `doctor`
+    /// and would silently unlatch every existing PR gate here.
+    #[serde(default = "default_changelog_strictness")]
+    pub strictness: Strictness,
 }
 
 impl Default for ChangelogConfig {
@@ -427,6 +441,7 @@ impl Default for ChangelogConfig {
             change_format: default_change_format(),
             dependency_kind: default_dependency_kind(),
             dependency_body: default_dependency_body(),
+            strictness: default_changelog_strictness(),
         }
     }
 }
@@ -470,6 +485,10 @@ pub enum Bump {
 
 fn default_changelog_dir() -> String {
     ".changes".to_string()
+}
+
+fn default_changelog_strictness() -> Strictness {
+    Strictness::Error
 }
 
 fn default_kinds() -> Vec<KindConfig> {
@@ -714,6 +733,36 @@ mod tests {
         assert_eq!(config.changelog.uncategorized_label, "Everything else");
         assert!(config.deprecated_keys.is_empty());
         assert!(config.unknown_keys.is_empty());
+    }
+
+    /// `Strictness::default()` is `warn`, which is right for `doctor` and wrong
+    /// here: inheriting it would turn every existing PR gate advisory on
+    /// upgrade. The changelog axis defaults the other way, on purpose.
+    #[test]
+    fn changelog_strictness_defaults_to_error_and_parses() {
+        let unset = ConfigFile::from_gleam_toml("[tools.trellis]\n").unwrap();
+        assert_eq!(unset.changelog.strictness, Strictness::Error);
+        assert_eq!(ChangelogConfig::default().strictness, Strictness::Error);
+        assert_eq!(
+            DoctorConfig::default().shared_dependencies,
+            Strictness::Warn
+        );
+
+        for (value, expected) in [
+            ("warn", Strictness::Warn),
+            ("error", Strictness::Error),
+            ("off", Strictness::Off),
+        ] {
+            let config = ConfigFile::from_gleam_toml(&format!(
+                "[tools.trellis.changelog]\nstrictness = \"{value}\"\n"
+            ))
+            .unwrap();
+            assert_eq!(config.changelog.strictness, expected);
+            assert!(
+                config.unknown_keys.is_empty(),
+                "`strictness` is a known key"
+            );
+        }
     }
 
     /// Categories are a plain string array, not a table, so `walk_schema_keys`

--- a/src/json.rs
+++ b/src/json.rs
@@ -494,6 +494,12 @@ pub struct ChangelogPackage<'a> {
 #[serde(rename_all = "snake_case")]
 pub struct ChangelogCheckDocument<'a> {
     pub schema: &'static str,
+    /// The verdict after `changelog.strictness` is applied — the same thing the
+    /// exit code says. `needs_entry` states the fact; this states the gate, so
+    /// a consumer never has to re-derive it from config it cannot see.
+    pub ok: bool,
+    /// Which policy produced `ok`: `error`, `warn`, or `off`.
+    pub strictness: crate::config::Strictness,
     pub has_entries: bool,
     pub needs_entry: bool,
     pub invalid_fragments: &'a [String],

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,9 +16,11 @@ mod workspace;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use commands::changelog::CheckFormat;
 use commands::doctor::DoctorFormat;
 use commands::graph::GraphFormat;
 use commands::run::Target;
+use config::Strictness;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use term::{ColorChoice, Verbosity};
@@ -314,8 +316,17 @@ enum ChangelogCommand {
         /// Head ref of the change range
         #[arg(long, default_value = "HEAD")]
         head: String,
-        /// Emit JSON, including a Markdown `preview` for a PR comment
-        #[arg(long)]
+        /// How to report: prose, the `trellis.changelog_check/1` JSON payload
+        /// (including a Markdown `preview` for a PR comment), or `key=value`
+        /// lines for $GITHUB_OUTPUT
+        #[arg(long, value_enum, default_value = "text")]
+        format: CheckFormat,
+        /// Override the workspace's changelog.strictness for this run: fail on
+        /// a missing entry, report it advisorily, or don't check
+        #[arg(long, value_enum)]
+        strictness: Option<Strictness>,
+        /// Deprecated alias for `--format json`
+        #[arg(long, conflicts_with = "format")]
         json: bool,
     },
 }
@@ -467,6 +478,12 @@ fn main() -> ExitCode {
                 }
                 | Command::Run { json: true, .. }
                 | Command::Exec { json: true, .. }
+                | Command::Changelog {
+                    command: ChangelogCommand::Check {
+                        format: CheckFormat::Json | CheckFormat::Github,
+                        ..
+                    } | ChangelogCommand::Check { json: true, .. },
+                }
         );
     let result = dispatch(cli);
     if notify_update && result.is_ok() {
@@ -621,10 +638,26 @@ fn dispatch(cli: Cli) -> Result<bool> {
                 )?;
                 Ok(true)
             }
-            ChangelogCommand::Check { base, head, json } => commands::changelog::check(
-                &workspace,
-                &commands::changelog::CheckOptions { base, head, json },
-            ),
+            ChangelogCommand::Check {
+                base,
+                head,
+                format,
+                strictness,
+                json,
+            } => {
+                // `--json` predates `--format` and clap rejects the two
+                // together, so this only ever upgrades the default.
+                let format = if json { CheckFormat::Json } else { format };
+                commands::changelog::check(
+                    &workspace,
+                    &commands::changelog::CheckOptions {
+                        base,
+                        head,
+                        format,
+                        strictness,
+                    },
+                )
+            }
         },
         Command::Version { command } => match command {
             VersionCommand::Plan { overrides, json } => {

--- a/tests/exit_codes.rs
+++ b/tests/exit_codes.rs
@@ -85,6 +85,24 @@ fn usage_error_exits_two() {
         .code(2);
 }
 
+#[test]
+fn json_together_with_format_exits_two() {
+    // `--json` is a deprecated alias for `--format json`. Passing both is
+    // ambiguous rather than redundant, so clap rejects it as usage.
+    trellis(&fixture("basic"))
+        .args([
+            "changelog",
+            "check",
+            "--base",
+            "main",
+            "--json",
+            "--format",
+            "github",
+        ])
+        .assert()
+        .code(2);
+}
+
 // ---- 3: trellis itself could not run ---------------------------------
 
 #[test]

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -62,6 +62,71 @@ fn add_fragment(root: &Path, project: &str, kind: &str, body: &str) {
     }
 }
 
+fn git(root: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
+
+/// Commit the fixture on `main`, branch, then touch two releasable packages and
+/// give only `lat_core` a fragment. Every strictness and `--format github` case
+/// wants the same shape: one package satisfied, one (`lat_mid`) missing.
+fn workspace_with_one_missing_fragment(root: &Path) {
+    copy_fixture_to(root);
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+    git(root, &["checkout", "-q", "-b", "feature"]);
+    write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
+    write(&root.join("packages/lat_mid/src/new.gleam"), "// x\n");
+    add_fragment(root, "lat_core", "Added", "something");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
+}
+
+/// Append a `[tools.trellis.changelog]` table to the fixture's root manifest.
+fn set_changelog_config(root: &Path, body: &str) {
+    let path = root.join("gleam.toml");
+    let existing = fs::read_to_string(&path).unwrap();
+    write(
+        &path,
+        &format!("{existing}\n[tools.trellis.changelog]\n{body}\n"),
+    );
+}
+
+/// Parse `key=value` / `key<<DELIM` heredoc lines the way GitHub Actions does,
+/// so a test asserts on what the runner would actually put in `outputs`.
+fn parse_github_output(text: &str) -> std::collections::BTreeMap<String, String> {
+    let mut out = std::collections::BTreeMap::new();
+    let mut lines = text.lines();
+    while let Some(line) = lines.next() {
+        if let Some((key, delimiter)) = line.split_once("<<") {
+            let mut value = String::new();
+            for line in lines.by_ref() {
+                if line == delimiter {
+                    break;
+                }
+                value.push_str(line);
+                value.push('\n');
+            }
+            out.insert(key.to_string(), value);
+        } else {
+            let (key, value) = line.split_once('=').expect("key=value line");
+            out.insert(key.to_string(), value.to_string());
+        }
+    }
+    out
+}
+
 // ---- changelog new ---------------------------------------------------------
 
 /// `project` was the pre-1.0 spelling of a fragment's `package` key, inherited
@@ -365,31 +430,17 @@ fn changelog_check_maps_diff_to_missing_fragments() {
     let root = tmp.path();
     copy_fixture_to(root);
 
-    let git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
-            .args(args)
-            .current_dir(root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@t")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@t")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .unwrap();
-        assert!(status.success(), "git {args:?} failed");
-    };
-    git(&["init", "-q", "-b", "main"]);
-    git(&["add", "."]);
-    git(&["commit", "-q", "-m", "init"]);
-    git(&["checkout", "-q", "-b", "feature"]);
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+    git(root, &["checkout", "-q", "-b", "feature"]);
     // Change two releasable packages and the example package; add a fragment for one.
     write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
     write(&root.join("packages/lat_mid/src/new.gleam"), "// x\n");
     write(&root.join("examples/package-a/src/new.gleam"), "// x\n");
     add_fragment(root, "lat_core", "Added", "something");
-    git(&["add", "."]);
-    git(&["commit", "-q", "-m", "change"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
 
     let output = trellis(root)
         .args(["changelog", "check", "--base", "main", "--json"])
@@ -415,6 +466,202 @@ fn changelog_check_maps_diff_to_missing_fragments() {
         .assert()
         .success()
         .stdout(predicate::str::contains("lat_mid: 1 fragment(s)"));
+}
+
+// ---- changelog check: strictness ------------------------------------------
+
+#[test]
+fn strictness_warn_reports_a_missing_entry_without_failing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    set_changelog_config(root, "strictness = \"warn\"");
+
+    // Reported, but advisory: the gate does not fail the job.
+    trellis(root)
+        .args(["changelog", "check", "--base", "main"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lat_mid: needs a changelog entry"));
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // `needs_entry` still states the fact; `ok` carries the verdict.
+    assert_eq!(payload["needs_entry"], true);
+    assert_eq!(payload["ok"], true);
+    assert_eq!(payload["strictness"], "warn");
+}
+
+#[test]
+fn strictness_off_drops_the_verdict_but_still_reports_counts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    set_changelog_config(root, "strictness = \"off\"");
+
+    // Nothing is being asked of the contributor, so the prose must not ask.
+    trellis(root)
+        .args(["changelog", "check", "--base", "main"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lat_mid: no entries"))
+        .stdout(predicate::str::contains("needs a changelog entry").not());
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["needs_entry"], false);
+    assert_eq!(payload["ok"], true);
+    // The rows survive — `off` means "don't gate", not "don't report".
+    let packages = payload["packages"].as_array().unwrap();
+    assert_eq!(packages.len(), 2);
+    let mid = packages.iter().find(|p| p["name"] == "lat_mid").unwrap();
+    assert_eq!(mid["has_entry"], false);
+    // No call to action, since nothing is being asked of the contributor.
+    assert!(
+        !payload["preview"]
+            .as_str()
+            .unwrap()
+            .contains("changelog new")
+    );
+}
+
+#[test]
+fn the_strictness_flag_overrides_the_configured_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    set_changelog_config(root, "strictness = \"warn\"");
+
+    // A workflow can gate harder than the workspace's own default.
+    trellis(root)
+        .args([
+            "changelog",
+            "check",
+            "--base",
+            "main",
+            "--strictness",
+            "error",
+        ])
+        .assert()
+        .failure();
+
+    // ...and the other way, over a configured `error`.
+    let strict = tempfile::tempdir().unwrap();
+    let strict_root = strict.path();
+    workspace_with_one_missing_fragment(strict_root);
+    set_changelog_config(strict_root, "strictness = \"error\"");
+    trellis(strict_root)
+        .args([
+            "changelog",
+            "check",
+            "--base",
+            "main",
+            "--strictness",
+            "off",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn invalid_fragments_fail_at_every_strictness() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    set_changelog_config(root, "strictness = \"off\"");
+    write(
+        &root.join(".changes/unreleased/broken-1.toml"),
+        "not toml at all {{{\n",
+    );
+
+    // Strictness is a policy about missing entries. A fragment that does not
+    // parse is malformed input, and no policy setting excuses it.
+    trellis(root)
+        .args(["changelog", "check", "--base", "main"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("broken-1.toml"));
+}
+
+// ---- changelog check: --format github --------------------------------------
+
+#[test]
+fn github_format_emits_github_output_lines() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "github"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "lat_mid lacks a fragment");
+    let text = String::from_utf8(output.stdout).unwrap();
+    let outputs = parse_github_output(&text);
+
+    assert_eq!(outputs["has_entries"], "true");
+    assert_eq!(outputs["needs_entry"], "true");
+    assert_eq!(outputs["ok"], "false");
+    assert_eq!(outputs["strictness"], "error");
+    assert_eq!(outputs["needs_entry_packages"], "[\"lat_mid\"]");
+    assert_eq!(outputs["invalid_fragments"], "[]");
+
+    // The comment body is the same markdown `--format json` reports, so the
+    // two surfaces can never drift.
+    let json = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(
+        outputs["preview"].trim_end(),
+        payload["preview"].as_str().unwrap().trim_end()
+    );
+
+    // Machine surface: no prose leaks into the file the runner parses.
+    assert!(!text.contains("needs a changelog entry"));
+}
+
+#[test]
+fn github_format_reports_a_clean_check() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    add_fragment(root, "lat_mid", "Fixed", "more");
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "github"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let outputs = parse_github_output(&String::from_utf8(output.stdout).unwrap());
+    // The workflow's third state: entries exist, nothing is missing.
+    assert_eq!(outputs["has_entries"], "true");
+    assert_eq!(outputs["needs_entry"], "false");
+    assert_eq!(outputs["needs_entry_packages"], "[]");
+    assert_eq!(outputs["ok"], "true");
+}
+
+#[test]
+fn json_stays_an_alias_for_format_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+
+    // Deprecated, but workflows in the wild pass it — it must keep working.
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--json"])
+        .output()
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["schema"], "trellis.changelog_check/1");
 }
 
 #[test]

--- a/tests/snapshots/json_contract__changelog_check_json_contract.snap
+++ b/tests/snapshots/json_contract__changelog_check_json_contract.snap
@@ -6,6 +6,7 @@ expression: payload
   "has_entries": true,
   "invalid_fragments": [],
   "needs_entry": true,
+  "ok": false,
   "packages": [
     {
       "changed": true,
@@ -21,5 +22,6 @@ expression: payload
     }
   ],
   "preview": "[markdown]",
-  "schema": "trellis.changelog_check/1"
+  "schema": "trellis.changelog_check/1",
+  "strictness": "error"
 }

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -15,7 +15,7 @@ managed workspace needs no second binary in CI.
 
 ```txt wrap
 trellis changelog new [--package <pkg>] --kind <kind> --body <text>
-trellis changelog check --base <ref> [--head <ref>] [--json]
+trellis changelog check --base <ref> [--head <ref>] [--format text|json|github] [--strictness error|warn|off]
 trellis version plan [--json]
 trellis version apply [--json]
 ```
@@ -71,13 +71,56 @@ $ trellis changelog new --package lat_cli --kind Added --category build \
 ## Enforcing entries on PRs
 
 `changelog check` maps a `base...head` diff to packages and fails (non-zero
-exit) if a changed releasable package has no unreleased fragment. `--json`
-emits a payload (including a markdown `preview`) ready for a PR sticky
-comment:
+exit) if a changed releasable package has no unreleased fragment.
+
+```console
+$ trellis changelog check --base origin/main
+lat_core: 2 fragment(s)
+lat_cli: needs a changelog entry
+```
+
+A package counts as changed when the diff touches *any* file under its
+directory — a README edit trips the same gate as a behavior change. That is
+deliberate (the alternative is a heuristic that guesses wrong quietly), but it
+means the gate is sometimes stricter than a repository wants.
+
+### Strictness
+
+`changelog.strictness` sets what a missing entry costs:
+
+| Value | Effect |
+| --- | --- |
+| `error` | Default. A missing entry fails the run. |
+| `warn` | Reported, exit 0 — advisory, so the comment still appears but the check stays green. |
+| `off` | Not checked. Packages and fragment counts are still reported. |
+
+```toml title="gleam.toml"
+[tools.trellis.changelog]
+strictness = "warn"
+```
+
+`--strictness error|warn|off` overrides it for one run, so a workflow can
+gate harder on ready-for-review PRs than the workspace default without editing
+the manifest.
+
+<Callout>
+
+**Strictness governs missing entries, not broken ones.** A fragment that does
+not parse, or that names an unknown package or kind, fails `check` at every
+setting including `off` — that is malformed input, not a policy call.
+
+</Callout>
+
+### The JSON payload
+
+`--format json` emits a payload (including a markdown `preview`) ready for a PR
+sticky comment:
 
 ```json
 {
   "schema": "trellis.changelog_check/1",
+  "ok": false,
+  "strictness": "error",
   "has_entries": true,
   "needs_entry": true,
   "invalid_fragments": [],
@@ -85,14 +128,50 @@ comment:
     { "name": "lat_core", "changed": true, "has_entry": true, "fragments": 2 },
     { "name": "lat_cli", "changed": true, "has_entry": false, "fragments": 0 }
   ],
-  "preview": "| package | status |\n| --- | --- |\n…"
+  "preview": "### Changelog check\n\n| package | fragments |\n| --- | --- |\n…"
 }
 ```
 
-The `schema` field is there so a workflow can assert on the shape it expects;
-the [JSON output](/docs/json-output/) page covers what it promises. Note
-that `preview` is guaranteed to be present and a string, but its Markdown is
-prose — render it rather than parsing it.
+`needs_entry` states the fact; `ok` states the verdict after strictness is
+applied, and matches the exit code. The `schema` field is there so a workflow
+can assert on the shape it expects; the [JSON output](/docs/json-output/) page
+covers what it promises. Note that `preview` is guaranteed to be present and a
+string, but its Markdown is prose — render it rather than parsing it.
+
+<Callout>
+
+`--json` is a deprecated alias for `--format json`. It still works; passing it
+alongside `--format` is a usage error.
+
+</Callout>
+
+### Driving a PR comment
+
+`--format github` emits the same facts as `key=value` lines for
+`$GITHUB_OUTPUT`, so a workflow can post the comment without a `jq` pipeline:
+
+```
+ok=false
+strictness=error
+has_entries=true
+needs_entry=true
+needs_entry_packages=["lat_cli"]
+invalid_fragments=[]
+preview<<TRELLIS_PREVIEW
+### Changelog check
+
+| package | fragments |
+| --- | --- |
+| lat_core | ✅ 2 |
+| lat_cli | ❌ needs an entry |
+
+Add one with `trellis changelog new --package <name> --kind <kind> --body <text>`.
+TRELLIS_PREVIEW
+```
+
+`needs_entry_packages` and `invalid_fragments` are JSON arrays, read with
+`fromJSON()`; `preview` uses GitHub's heredoc form because it is multi-line.
+See [CI recipes](/docs/ci/#the-changelog-comment) for the workflow.
 
 ## Planning a release
 

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -96,14 +96,13 @@ which is why neither carries the `schema` field every other payload does — see
 ## PR gates
 
 Run `doctor` on every PR — it checks every workspace invariant at once and
-exits non-zero on any error. Pair it with `changelog check`, whose
-[JSON payload](/docs/json-output/) (including a markdown `preview`) feeds a
-sticky comment:
+exits non-zero on any error. Pair it with `changelog check`, which fails a PR
+that changes a package without logging it:
 
 ```yaml
 # on: pull_request
 - run: trellis doctor
-- run: trellis changelog check --base "origin/${{ github.base_ref }}" --json
+- run: trellis changelog check --base "origin/${{ github.base_ref }}"
 ```
 
 When the tripwire fires on a mechanical finding, such as a missing
@@ -112,6 +111,72 @@ When the tripwire fires on a mechanical finding, such as a missing
 rest. `--fix` never touches the report-only findings (path-dep escapes, tag
 collisions, versions behind their changelog), so it stays safe to run
 anywhere; keep the bare `trellis doctor` in CI as the gate.
+
+### The changelog comment
+
+A failing gate in a log is easy to miss. `changelog check --format github`
+emits `key=value` lines for `$GITHUB_OUTPUT`, so the same run that gates the PR
+also drives a sticky comment — no `jq`, no second tool:
+
+```yaml
+# on: pull_request
+permissions:
+  pull-requests: write
+
+steps:
+  - uses: actions/checkout@v4
+    with:
+      fetch-depth: 0 # the diff needs the base commit
+  - id: changelog
+    # The gate exits 1 on a missing entry. Let it, but keep going, so the
+    # comment lands before the job fails.
+    continue-on-error: true
+    run: |
+      trellis changelog check \
+        --base "${{ github.event.pull_request.base.sha }}" \
+        --head "${{ github.event.pull_request.head.sha }}" \
+        --format github >> "$GITHUB_OUTPUT"
+  - name: Post the changelog comment
+    if: >-
+      steps.changelog.outputs.has_entries == 'true'
+      || steps.changelog.outputs.needs_entry == 'true'
+      || steps.changelog.outputs.invalid_fragments != '[]'
+    uses: marocchino/sticky-pull-request-comment@v3
+    with:
+      header: changelog
+      message: ${{ steps.changelog.outputs.preview }}
+  - name: Remove it when there is nothing to say
+    if: >-
+      steps.changelog.outputs.has_entries == 'false'
+      && steps.changelog.outputs.needs_entry == 'false'
+      && steps.changelog.outputs.invalid_fragments == '[]'
+    uses: marocchino/sticky-pull-request-comment@v3
+    with:
+      header: changelog
+      delete: true
+  - name: Fail if the check did
+    if: steps.changelog.outputs.ok != 'true'
+    run: exit 1
+```
+
+The comment appears when there is something to say — entries to preview, an
+entry missing, or a fragment that doesn't parse — and is deleted when there
+isn't, so a fixed PR doesn't keep a stale complaint. `ok` carries the verdict
+`continue-on-error` swallowed, and is empty if trellis could not run at all,
+which fails the job either way.
+
+`preview` is already the comment body, rendered from the same data as the
+`--format json` field of that name. `needs_entry_packages` and
+`invalid_fragments` are JSON arrays if you would rather compose your own:
+
+```yaml
+- run: echo "Missing: ${{ join(fromJSON(steps.changelog.outputs.needs_entry_packages), ', ') }}"
+```
+
+A workspace that wants the comment without the gate sets
+[`changelog.strictness`](/docs/configuration/#keys) to `warn`, which makes
+`ok` true even when `needs_entry` is — then drop both the
+`continue-on-error` line and the final step.
 
 ### Annotating the diff
 

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -129,6 +129,7 @@ their roots.
 | `changelog.*-format` | no | Minijinja templates for rendered changelog sections: `version_format`, `category_format`, `kind_format`, `change_format`. |
 | `changelog.dependency_kind` | no | Kind used for the entries generated when a workspace dependency bumps. Must name one of `kinds`. |
 | `changelog.dependency_body` | no | Minijinja template for one such entry's body. Context: `dependency`, `dependency_version`, `package` (also as `project`, deprecated). |
+| `changelog.strictness` | no | How `changelog check` treats a changed releasable package with no unreleased fragment: `error` (default, fails the run), `warn`, or `off`. An *invalid* fragment fails at every setting. |
 | `doctor.shared_dependencies` | no | How `doctor` treats packages disagreeing on a shared external dependency: `warn` (default), `error`, or `off`. |
 
 ## Package exclusions

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -51,7 +51,7 @@ commands pretty-print, some emit one line for shell-variable capture).
 | `graph --format json` | `trellis.graph/1`<br />`{schema, nodes[], edges[]}` |
 | `run <task> --json` | `trellis.run/1`<br />`{schema, ok, task, target?, results[]}` |
 | `exec -- <cmd> --json` | `trellis.exec/1`<br />`{schema, ok, command[], results[]}` |
-| `changelog check --json` | `trellis.changelog_check/1`<br />`{schema, has_entries, needs_entry, invalid_fragments[], packages[], preview}` |
+| `changelog check --format json` | `trellis.changelog_check/1`<br />`{schema, ok, strictness, has_entries, needs_entry, invalid_fragments[], packages[], preview}` |
 | `version plan --json` | `trellis.version_plan/1`<br />`{schema, bumped[], fragments_retained}` |
 | `version apply --json` | `trellis.version_apply/1`<br />`{schema, bumped[], lockfiles[], adopted[], fragments_retained}` |
 | `tag plan --json` | `trellis.tag_plan/1`<br />`{schema, tags[]}` |
@@ -72,7 +72,10 @@ Notes:
 - `ci tag-package` reports `tag_kind: exact` with `tag_version`, or
   `tag_kind: series` with `tag_series` — the other key is absent, not null.
 - `changelog check`'s `preview` field is always present and a string, but its
-  Markdown prose can change without a version bump.
+  Markdown prose can change without a version bump. `needs_entry` reports
+  whether an entry is missing; `ok` reports what
+  [`changelog.strictness`](/docs/configuration/#keys) made of that, and matches
+  the exit code. `--json` is a deprecated alias for `--format json`.
 
 <Callout>
   **`--json` moves package output to stderr.** `run`/`exec` normally stream
@@ -158,6 +161,11 @@ series_tags=[]
 ```
 
 `projects` duplicates `packages` and is deprecated; it goes away at 1.0.
+
+`changelog check --format github` emits the same style of lines — scalars
+plain, arrays as JSON, and the multi-line `preview` in GitHub's heredoc form.
+It is the `trellis.changelog_check/1` data in a shape the runner parses, not a
+payload of its own, so it carries no `schema` either.
 
 See [CI recipes](/docs/ci/) for how these are consumed.
 

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -215,7 +215,22 @@ Verify changed packages have changelog fragments; non-zero exit if not
 * `--head <HEAD>` — Head ref of the change range
 
   Default value: `HEAD`
-* `--json` — Emit JSON, including a Markdown `preview` for a PR comment
+* `--format <FORMAT>` — How to report: prose, the `trellis.changelog_check/1` JSON payload (including a Markdown `preview` for a PR comment), or `key=value` lines for $GITHUB_OUTPUT
+
+  Default value: `text`
+
+  Possible values:
+  - `text`
+  - `json`:
+    The `trellis.changelog_check/1` payload
+  - `github`:
+    `key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post, update, or delete a PR comment without a `jq` pipeline
+
+* `--strictness <STRICTNESS>` — Override the workspace's changelog.strictness for this run: fail on a missing entry, report it advisorily, or don't check
+
+  Possible values: `warn`, `error`, `off`
+
+* `--json` — Deprecated alias for `--format json`
 
 
 


### PR DESCRIPTION
`changelog check` was all-or-nothing. Any releasable package with a changed file in its directory needed a fragment or the run exited 1 — a README edit tripped the same gate as a behavior change — and the only escape was `exclude."@release"`, which also drops the package from versioning, tagging, and publishing.

## `changelog.strictness`

| Value | Effect |
| --- | --- |
| `error` | Default. Missing entry fails the run — today's behavior, unchanged. |
| `warn` | Reported, exit 0. |
| `off` | Not checked. Packages and fragment counts still reported. |

`--strictness error|warn|off` overrides it for one run, so a workflow can gate harder than the workspace default.

It defaults to `error` via its own default fn rather than `#[serde(default)]`: `Strictness`'s derived default is `Warn` (right for `doctor.shared_dependencies`), and inheriting it would have silently unlatched every existing PR gate on upgrade.

Strictness governs the missing-entry verdict only. An invalid fragment — unparseable, or naming an unknown package or kind — still fails at every setting including `off`, since that's malformed input rather than a policy call.

## `--format text|json|github`

`github` emits `key=value` lines for `$GITHUB_OUTPUT`, in the shape `ci outputs` already established (scalars plain, arrays as JSON):

```
ok=false
strictness=error
has_entries=true
needs_entry=true
needs_entry_packages=["lat_mid"]
invalid_fragments=[]
preview<<TRELLIS_PREVIEW
### Changelog check

| package | fragments |
| --- | --- |
| lat_core | ✅ 1 |
| lat_mid | ❌ needs an entry |

Add one with `trellis changelog new --package <name> --kind <kind> --body <text>`.
TRELLIS_PREVIEW
```

That's enough to drive the three-state sticky comment (post preview / post missing / delete) with no `jq` — the recipe is in [CI recipes](website/src/content/docs/docs/ci.mdx). The heredoc delimiter is derived so it can't occur in the value; one that did would end the block early and let the remainder parse as further keys.

`--json` stays as a deprecated alias for `--format json`; passing both is a usage error (exit 2).

## Payload

`trellis.changelog_check/1` gains `ok` (the verdict after strictness, matching the exit code) and `strictness`. Both additive, so the schema stays at `/1`.

## Testing

- `warn`/`off`/override/invalid-at-every-strictness cases, plus `--format github` output parsed the way the runner parses it, asserting `preview` matches the JSON field byte for byte
- `--json --format` conflict added to the exit-code contract suite
- unit tests for the delimiter helper and for the config default
- 306 tests pass; clippy clean at `-D warnings`; `just docs` regenerated the CLI reference and man page; the Astro site builds

Verified end-to-end against a scratch workspace, not just in tests. Two bugs came out of that and are fixed here: text output under `off` still said "needs a changelog entry" (derived from the fragment count instead of the verdict), and the documented workflow would have deleted the comment when the only problem was a broken fragment.

Not changed: this repo's own `.github/workflows/pr.yml`. Trellis is a Rust crate using changie for its own changelog, so `trellis changelog check` can't gate it.
