### PR TITLE
feat(release): add bootstrap workflow

### DIFF
--- a/.changes/unreleased/Added-20260731-release-bootstrap.yaml
+++ b/.changes/unreleased/Added-20260731-release-bootstrap.yaml
@@ -1,7 +1,7 @@
 component: release
 kind: Added
 body: |-
-  **`trellis release bootstrap` tags existing package versions.** Use it when adopting trellis in a repository whose versions and changelogs are already correct but whose tags are missing. It never runs `version apply` or requires unreleased fragments. `--dry-run` previews exact tags, series tags, remote operations, and GitHub Releases; `--push` updates `origin`, and `--github-release` implies `--push`.
+  **`trellis release bootstrap` tags existing package versions.** Use it when adopting trellis in a repository whose versions and changelogs are already correct but whose tags are missing. It is an alias for `tag create`: it never runs `version apply` or requires unreleased fragments. `--dry-run` (also new on `tag create`) previews every tag, push, and GitHub Release action; `--push` updates `origin`, and `--github-release` implies `--push`.
 
-    Every planned tag is checked for a local/remote conflict before any of them are mutated, so one package's immutable tag disagreeing with origin fails the whole run instead of leaving another package half-tagged.
+    When pushing, every planned tag is checked for a local/remote conflict before any of them are mutated, so one package's immutable tag disagreeing with origin fails the whole run instead of leaving another package half-tagged.
 time: 2026-07-31T22:49:14.000000000-07:00

--- a/.changes/unreleased/Added-20260731-release-bootstrap.yaml
+++ b/.changes/unreleased/Added-20260731-release-bootstrap.yaml
@@ -1,0 +1,7 @@
+component: release
+kind: Added
+body: |-
+  **`trellis release bootstrap` tags existing package versions.** Use it when adopting trellis in a repository whose versions and changelogs are already correct but whose tags are missing. It never runs `version apply` or requires unreleased fragments. `--dry-run` previews exact tags, series tags, remote operations, and GitHub Releases; `--push` updates `origin`, and `--github-release` implies `--push`.
+
+    Every planned tag is checked for a local/remote conflict before any of them are mutated, so one package's immutable tag disagreeing with origin fails the whole run instead of leaving another package half-tagged.
+time: 2026-07-31T22:49:14.000000000-07:00

--- a/assets/man/trellis-release-bootstrap.1
+++ b/assets/man/trellis-release-bootstrap.1
@@ -8,7 +8,7 @@ trellis\-release\-bootstrap \- Reconcile tags against current manifest versions 
 .SH DESCRIPTION
 Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
 .PP
-For adopting trellis on a repository that already has the package versions and changelogs it wants, but no tags yet. Reads versions straight off each package\*(Aqs `gleam.toml`, the same reconciliation `tag create` performs, but checks every planned tag for a local/remote conflict before mutating any of them — one package\*(Aqs immutable tag disagreeing with origin fails the whole run rather than leaving another package half\-tagged.
+An alias for `tag create`, for adopting trellis on a repository that already has the package versions and changelogs it wants, but no tags yet.
 .SH OPTIONS
 .TP
 \fB\-C\fR, \fB\-\-directory\fR \fI<DIR>\fR

--- a/assets/man/trellis-release-bootstrap.1
+++ b/assets/man/trellis-release-bootstrap.1
@@ -4,7 +4,7 @@
 .SH NAME
 trellis\-release\-bootstrap \- Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
 .SH SYNOPSIS
-\fBtrellis release bootstrap\fR [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-dry\-run\fR] [\fB\-\-color\fR] [\fB\-\-push\fR] [\fB\-\-github\-release\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBtrellis release bootstrap\fR [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-push\fR] [\fB\-\-color\fR] [\fB\-\-github\-release\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
 .PP
@@ -14,8 +14,8 @@ An alias for `tag create`, for adopting trellis on a repository that already has
 \fB\-C\fR, \fB\-\-directory\fR \fI<DIR>\fR
 Run as if started in this directory
 .TP
-\fB\-\-dry\-run\fR
-Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
+\fB\-\-push\fR
+Push each created tag to origin
 .TP
 \fB\-\-color\fR \fI<WHEN>\fR [default: auto]
 When to color output. `auto` follows the terminal, `NO_COLOR`, and `CLICOLOR=0`; the other two override that detection
@@ -32,11 +32,11 @@ always
 never
 .RE
 .TP
-\fB\-\-push\fR
-Push tags to origin
-.TP
 \fB\-\-github\-release\fR
 Also create a GitHub Release per exact tag, with the matching CHANGELOG section as the body (implies \-\-push; requires the gh CLI)
+.TP
+\fB\-\-dry\-run\fR
+Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Suppress normal\-path output; JSON/report payloads and errors still print

--- a/assets/man/trellis-release-bootstrap.1
+++ b/assets/man/trellis-release-bootstrap.1
@@ -1,0 +1,53 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH trellis-release-bootstrap 1 "" trellis "Trellis Manual"
+.SH NAME
+trellis\-release\-bootstrap \- Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
+.SH SYNOPSIS
+\fBtrellis release bootstrap\fR [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-dry\-run\fR] [\fB\-\-color\fR] [\fB\-\-push\fR] [\fB\-\-github\-release\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+.SH DESCRIPTION
+Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
+.PP
+For adopting trellis on a repository that already has the package versions and changelogs it wants, but no tags yet. Reads versions straight off each package\*(Aqs `gleam.toml`, the same reconciliation `tag create` performs, but checks every planned tag for a local/remote conflict before mutating any of them — one package\*(Aqs immutable tag disagreeing with origin fails the whole run rather than leaving another package half\-tagged.
+.SH OPTIONS
+.TP
+\fB\-C\fR, \fB\-\-directory\fR \fI<DIR>\fR
+Run as if started in this directory
+.TP
+\fB\-\-dry\-run\fR
+Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
+.TP
+\fB\-\-color\fR \fI<WHEN>\fR [default: auto]
+When to color output. `auto` follows the terminal, `NO_COLOR`, and `CLICOLOR=0`; the other two override that detection
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+auto
+.IP \(bu 2
+always
+.IP \(bu 2
+never
+.RE
+.TP
+\fB\-\-push\fR
+Push tags to origin
+.TP
+\fB\-\-github\-release\fR
+Also create a GitHub Release per exact tag, with the matching CHANGELOG section as the body (implies \-\-push; requires the gh CLI)
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Suppress normal\-path output; JSON/report payloads and errors still print
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Trace every command trellis shells out to, on stderr
+.TP
+\fB\-\-no\-update\-check\fR
+Don\*(Aqt check whether a newer trellis release is available
+
+The check is also skipped in CI, when not attached to a terminal, and when `TRELLIS_NO_UPDATE_CHECK` or `DO_NOT_TRACK` is set.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)

--- a/assets/man/trellis-release.1
+++ b/assets/man/trellis-release.1
@@ -44,3 +44,6 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 .TP
 trellis\-release\-pr(1)
 Create or update the release PR: version apply on a branch, push, gh pr
+.TP
+trellis\-release\-bootstrap(1)
+Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required

--- a/assets/man/trellis-tag-create.1
+++ b/assets/man/trellis-tag-create.1
@@ -4,7 +4,7 @@
 .SH NAME
 trellis\-tag\-create \- Create missing tags in topological order
 .SH SYNOPSIS
-\fBtrellis tag create\fR [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-push\fR] [\fB\-\-color\fR] [\fB\-\-github\-release\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
+\fBtrellis tag create\fR [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-push\fR] [\fB\-\-color\fR] [\fB\-\-github\-release\fR] [\fB\-\-dry\-run\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Create missing tags in topological order
 .SH OPTIONS
@@ -32,6 +32,9 @@ never
 .TP
 \fB\-\-github\-release\fR
 Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies \-\-push; requires the gh CLI)
+.TP
+\fB\-\-dry\-run\fR
+Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Suppress normal\-path output; JSON/report payloads and errors still print

--- a/assets/man/trellis-tag-create.1
+++ b/assets/man/trellis-tag-create.1
@@ -31,7 +31,7 @@ never
 .RE
 .TP
 \fB\-\-github\-release\fR
-Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies \-\-push; requires the gh CLI)
+Also create a GitHub Release per exact tag, with the matching CHANGELOG section as the body (implies \-\-push; requires the gh CLI)
 .TP
 \fB\-\-dry\-run\fR
 Report every tag/push/release action without doing anything (a conflicting tag still fails the command)

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -335,45 +335,21 @@ trellis version apply                             # batch + merge + lockfile pat
 ```
 trellis release bootstrap [--dry-run] [--push] [--github-release]
 trellis tag plan [--json]        # packages whose gleam.toml version has no tag yet
-trellis tag create [--github-release]
+trellis tag create [--push] [--github-release] [--dry-run]
 trellis publish <pkg | --tag <tag> | --all-untagged> [--dry-run]
 trellis lockfile refresh [--package <pkg>]
 ```
 
-- **`release bootstrap`** reconciles tags against the versions already recorded
-  in `gleam.toml` — no version bump, no unreleased changelog fragments. It
-  exists for the repository *adopting* trellis: versions and CHANGELOGs are
-  already right, only the tags (and, pre-1.0, the accompanying GitHub
-  Releases) are missing. Where `release pr` → `tag create --github-release` is
-  the steady-state loop (bump from fragments, then tag what the PR merged),
-  bootstrap skips straight to the tagging step, reading `plan_tags` the same
-  way `tag create` does. Local-only by default; `--push` reaches origin,
-  `--github-release` implies it and creates a release per exact tag once
-  pushed. `--dry-run` reports every package's tag, series tag, remote
-  fetch/push, and release action — computed from the same read-only
-  reconciliation execution mutates from, so the preview cannot promise
-  something execution wouldn't do — and queries remotes/`gh` accordingly
-  without writing anything. Before any tag is touched, every planned exact
-  tag is checked for a local/remote conflict (`tag_conflicts`); one package's
-  immutable tag disagreeing with origin fails the whole run rather than
-  half-tagging the rest, in dry-run or for real.
-
-  Adoption on an existing repository, once each package's `gleam.toml` is at
-  its real released version:
+- **`release bootstrap`** is `tag create` under the release umbrella, for the
+  repository *adopting* trellis: versions and CHANGELOGs are already right,
+  only the tags (and, pre-1.0, the accompanying GitHub Releases) are missing.
+  Where `release pr` → `tag create --github-release` is the steady-state loop
+  (bump from fragments, then tag what the PR merged), bootstrap skips straight
+  to the tagging step — no version bump, no unreleased changelog fragments:
 
   ```sh
   trellis release bootstrap --dry-run --github-release   # preview every tag + release
-  trellis release bootstrap --github-release              # create and push them
-  ```
-
-  Pre-1.0, a workspace still on `0.x` everywhere gets its first series tags
-  the same way — bootstrap doesn't special-case the major:
-
-  ```sh
-  trellis release bootstrap --dry-run --github-release
-  # lat_core: 0.4.0 tag lat_core-v0.4.0 — create; push; create GitHub release
-  # lat_core: 0.4.0 series tag lat_core-v0.4 — create; push
-  trellis release bootstrap --github-release
+  trellis release bootstrap --github-release             # create and push them
   ```
 
   From then on, `release pr` and `tag create --github-release` (§6) take over;
@@ -383,7 +359,11 @@ trellis lockfile refresh [--package <pkg>]
   releasable member's
   `gleam.toml` version against existing `{name}-v{version}` tags, create missing
   tags in topological order, optionally create GitHub Releases with the matching
-  CHANGELOG section as the body.
+  CHANGELOG section as the body. `--dry-run` walks the same code path and prints
+  `would tag/push/…` at each mutation point instead of mutating. When pushing,
+  every planned exact tag is checked for a local/remote conflict before any of
+  them are touched — one package's immutable tag disagreeing with origin fails
+  the whole run rather than half-tagging the rest, in dry-run or for real.
 - A member may instead (or also) carry a **series tag** — `{name}-v{series}`,
   where the series is derived from the version: `0.Y` while the major is 0,
   `X` after. It is the one ref trellis rewrites: each release in the series
@@ -678,11 +658,10 @@ the workspace), `trellis release pr` (see question 2 in §11), and `trellis
 release bootstrap` (§5) — added after adoption on a repository with correct
 versions but no tags exposed a gap between `tag create`, which reconciles
 tags, and the fragment-driven `version`/`release pr` path, which assumes a
-bump is wanted. Bootstrap shares `tag`'s `plan_tags` and adds a read-only
-`tag_status`/`tag_conflicts` pass — the same reconciliation `tag create`
-mutates from — so its `--dry-run` preview and its preflight conflict check
-(every planned tag validated before any of them are touched) can never show
-or allow something execution wouldn't do. Two pre-release revisions of this
+bump is wanted. Bootstrap is an alias for `tag create`, which grew `--dry-run`
+and the batch conflict preflight alongside it — one code path, so the preview
+can never show or allow something execution wouldn't do. Two pre-release
+revisions of this
 document's original proposals are recorded in place: changie subsumed by the
 native changelog engine (§7), and the separate `workspace.toml` replaced by
 the `[tools.trellis]` table in the root `gleam.toml` (§4).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -333,12 +333,52 @@ trellis version apply                             # batch + merge + lockfile pat
 ### Release & publish
 
 ```
+trellis release bootstrap [--dry-run] [--push] [--github-release]
 trellis tag plan [--json]        # packages whose gleam.toml version has no tag yet
 trellis tag create [--github-release]
 trellis publish <pkg | --tag <tag> | --all-untagged> [--dry-run]
 trellis lockfile refresh [--package <pkg>]
 ```
 
+- **`release bootstrap`** reconciles tags against the versions already recorded
+  in `gleam.toml` — no version bump, no unreleased changelog fragments. It
+  exists for the repository *adopting* trellis: versions and CHANGELOGs are
+  already right, only the tags (and, pre-1.0, the accompanying GitHub
+  Releases) are missing. Where `release pr` → `tag create --github-release` is
+  the steady-state loop (bump from fragments, then tag what the PR merged),
+  bootstrap skips straight to the tagging step, reading `plan_tags` the same
+  way `tag create` does. Local-only by default; `--push` reaches origin,
+  `--github-release` implies it and creates a release per exact tag once
+  pushed. `--dry-run` reports every package's tag, series tag, remote
+  fetch/push, and release action — computed from the same read-only
+  reconciliation execution mutates from, so the preview cannot promise
+  something execution wouldn't do — and queries remotes/`gh` accordingly
+  without writing anything. Before any tag is touched, every planned exact
+  tag is checked for a local/remote conflict (`tag_conflicts`); one package's
+  immutable tag disagreeing with origin fails the whole run rather than
+  half-tagging the rest, in dry-run or for real.
+
+  Adoption on an existing repository, once each package's `gleam.toml` is at
+  its real released version:
+
+  ```sh
+  trellis release bootstrap --dry-run --github-release   # preview every tag + release
+  trellis release bootstrap --github-release              # create and push them
+  ```
+
+  Pre-1.0, a workspace still on `0.x` everywhere gets its first series tags
+  the same way — bootstrap doesn't special-case the major:
+
+  ```sh
+  trellis release bootstrap --dry-run --github-release
+  # lat_core: 0.4.0 tag lat_core-v0.4.0 — create; push; create GitHub release
+  # lat_core: 0.4.0 series tag lat_core-v0.4 — create; push
+  trellis release bootstrap --github-release
+  ```
+
+  From then on, `release pr` and `tag create --github-release` (§6) take over;
+  bootstrap has nothing left to reconcile once every current version is
+  tagged.
 - `tag plan/create` replaces the auto-tag workflow's core: compare each
   releasable member's
   `gleam.toml` version against existing `{name}-v{version}` tags, create missing
@@ -634,11 +674,18 @@ end-to-end suite runs against a fixture workspace with a mocked Hex API.
 Beyond the numbered phases, the rest of the §5 command surface is also
 implemented: `trellis new` (scaffolding, with metadata copied from a sibling
 member and a members-glob match check so a new package can't be invisible to
-the workspace) and `trellis release pr` (see question 2 in §11). Two
-pre-release revisions of this document's original proposals are recorded in
-place: changie subsumed by the native changelog engine (§7), and the
-separate `workspace.toml` replaced by the `[tools.trellis]` table in the
-root `gleam.toml` (§4).
+the workspace), `trellis release pr` (see question 2 in §11), and `trellis
+release bootstrap` (§5) — added after adoption on a repository with correct
+versions but no tags exposed a gap between `tag create`, which reconciles
+tags, and the fragment-driven `version`/`release pr` path, which assumes a
+bump is wanted. Bootstrap shares `tag`'s `plan_tags` and adds a read-only
+`tag_status`/`tag_conflicts` pass — the same reconciliation `tag create`
+mutates from — so its `--dry-run` preview and its preflight conflict check
+(every planned tag validated before any of them are touched) can never show
+or allow something execution wouldn't do. Two pre-release revisions of this
+document's original proposals are recorded in place: changie subsumed by the
+native changelog engine (§7), and the separate `workspace.toml` replaced by
+the `[tools.trellis]` table in the root `gleam.toml` (§4).
 
 ## 11. Open questions — resolved
 

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -4,8 +4,7 @@
 //! refresh the PR. The tool already knows exactly what changed; gh does the
 //! PR mechanics.
 //!
-//! `trellis release bootstrap` — reconcile tags against current manifest
-//! versions with no version bump involved, for adopting trellis on a
+//! `trellis release bootstrap` — `tag create` for adopting trellis on a
 //! repository that already has the versions and changelogs it wants; see
 //! [`bootstrap`].
 
@@ -61,116 +60,15 @@ pub fn pr(workspace: &Workspace, options: &PrOptions) -> Result<bool> {
     result
 }
 
-pub struct BootstrapOptions {
-    /// Report every planned action without doing anything.
-    pub dry_run: bool,
-    /// Push tags to origin.
-    pub push: bool,
-    /// Create a GitHub Release per exact tag (implies `push`).
-    pub github_release: bool,
-}
-
-/// `trellis release bootstrap` — reconcile tags (and, with `--github-release`,
-/// GitHub Releases) against the workspace's *current* manifest versions. A
-/// repository adopting trellis with correct package versions and changelogs
-/// already in place, but no tags yet, needs exactly this: unlike `release
-/// pr`, bootstrap never runs `version apply` and requires no unreleased
-/// changelog fragments — `tag::plan_tags` reads versions straight off
-/// `gleam.toml`.
-///
-/// Every planned tag is checked for a local/remote conflict before any of
-/// them are mutated (`tag::tag_conflicts`, itself computed from the same
-/// read-only `tag::tag_status` a `--dry-run` preview reports from) — one
-/// package's immutable tag disagreeing with origin fails the whole run
-/// rather than leaving an earlier package half-tagged. `--dry-run` runs this
-/// same preflight, so a conflict is reported (and the command still exits
-/// non-zero) without needing `--push` for real.
-pub fn bootstrap(workspace: &Workspace, options: &BootstrapOptions) -> Result<bool> {
-    let push = options.push || options.github_release;
-    let planned = tag::plan_tags(workspace)?;
-    if planned.is_empty() {
-        crate::status!("no releasable packages to bootstrap");
-        return Ok(true);
-    }
-
-    let statuses = tag::tag_status(workspace, &planned, push, options.github_release)?;
-    let conflicts = tag::tag_conflicts(&statuses);
-    if !conflicts.is_empty() {
-        let details = conflicts
-            .iter()
-            .map(|conflict| {
-                format!(
-                    "`{}` points to different objects locally ({}) and on origin ({})",
-                    conflict.tag, conflict.local_oid, conflict.remote_oid
-                )
-            })
-            .collect::<Vec<_>>()
-            .join("; ");
-        bail!("bootstrap refused: conflicting tags found: {details}");
-    }
-
-    if options.dry_run {
-        report_bootstrap_plan(workspace, &statuses, push, options.github_release);
-        return Ok(true);
-    }
-
-    tag::create(
-        workspace,
-        &tag::CreateOptions {
-            push: options.push,
-            github_release: options.github_release,
-        },
-    )?;
+/// `trellis release bootstrap` — an alias for `tag create` under the release
+/// umbrella, for the repository *adopting* trellis: versions and changelogs
+/// are already right, only the tags (and GitHub Releases) are missing.
+/// Unlike `release pr`, it never runs `version apply` and requires no
+/// unreleased changelog fragments — `tag::plan_tags` reads versions straight
+/// off `gleam.toml`.
+pub fn bootstrap(workspace: &Workspace, options: &tag::CreateOptions) -> Result<bool> {
+    tag::create(workspace, options)?;
     Ok(true)
-}
-
-/// One status line per planned tag: its local action, plus (when queried)
-/// what pushing it would do and whether a GitHub Release already exists.
-/// Deterministic and mutation-free — every value comes straight out of
-/// `statuses`, itself gathered read-only.
-fn report_bootstrap_plan(
-    workspace: &Workspace,
-    statuses: &[tag::TagStatus],
-    push: bool,
-    github_release: bool,
-) {
-    for status in statuses {
-        let member = &workspace.members[status.member];
-        let kind = match status.kind {
-            tag::TagKind::Exact => "tag",
-            tag::TagKind::Series => "series tag",
-        };
-        let local = match status.action {
-            tag::TagAction::Create => "create",
-            tag::TagAction::Move => "move",
-            tag::TagAction::UpToDate => "up to date",
-        };
-        let mut line = format!(
-            "{}: {} {kind} {} — {local}",
-            member.name,
-            member.version(),
-            status.tag
-        );
-        if push {
-            let remote = match status.remote_action {
-                Some(tag::RemoteAction::Fetch) => "fetch from origin",
-                Some(tag::RemoteAction::Push) => "push",
-                Some(tag::RemoteAction::ForcePush) => "force-push",
-                Some(tag::RemoteAction::UpToDate) => "already on origin",
-                None => "not checked",
-            };
-            line.push_str(&format!("; {remote}"));
-        }
-        if github_release && status.kind == tag::TagKind::Exact {
-            let release = match status.release_exists {
-                Some(true) => "GitHub release already exists",
-                Some(false) => "create GitHub release",
-                None => "GitHub release not checked",
-            };
-            line.push_str(&format!("; {release}"));
-        }
-        crate::status!("{line}");
-    }
 }
 
 fn build_release_commit_and_pr(

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -3,6 +3,11 @@
 //! `version apply` on a release branch, push it, and drive `gh` to open or
 //! refresh the PR. The tool already knows exactly what changed; gh does the
 //! PR mechanics.
+//!
+//! `trellis release bootstrap` — reconcile tags against current manifest
+//! versions with no version bump involved, for adopting trellis on a
+//! repository that already has the versions and changelogs it wants; see
+//! [`bootstrap`].
 
 use crate::commands::version_override::Overrides;
 use crate::commands::{tag, version};
@@ -54,6 +59,118 @@ pub fn pr(workspace: &Workspace, options: &PrOptions) -> Result<bool> {
         .current_dir(root)
         .output();
     result
+}
+
+pub struct BootstrapOptions {
+    /// Report every planned action without doing anything.
+    pub dry_run: bool,
+    /// Push tags to origin.
+    pub push: bool,
+    /// Create a GitHub Release per exact tag (implies `push`).
+    pub github_release: bool,
+}
+
+/// `trellis release bootstrap` — reconcile tags (and, with `--github-release`,
+/// GitHub Releases) against the workspace's *current* manifest versions. A
+/// repository adopting trellis with correct package versions and changelogs
+/// already in place, but no tags yet, needs exactly this: unlike `release
+/// pr`, bootstrap never runs `version apply` and requires no unreleased
+/// changelog fragments — `tag::plan_tags` reads versions straight off
+/// `gleam.toml`.
+///
+/// Every planned tag is checked for a local/remote conflict before any of
+/// them are mutated (`tag::tag_conflicts`, itself computed from the same
+/// read-only `tag::tag_status` a `--dry-run` preview reports from) — one
+/// package's immutable tag disagreeing with origin fails the whole run
+/// rather than leaving an earlier package half-tagged. `--dry-run` runs this
+/// same preflight, so a conflict is reported (and the command still exits
+/// non-zero) without needing `--push` for real.
+pub fn bootstrap(workspace: &Workspace, options: &BootstrapOptions) -> Result<bool> {
+    let push = options.push || options.github_release;
+    let planned = tag::plan_tags(workspace)?;
+    if planned.is_empty() {
+        crate::status!("no releasable packages to bootstrap");
+        return Ok(true);
+    }
+
+    let statuses = tag::tag_status(workspace, &planned, push, options.github_release)?;
+    let conflicts = tag::tag_conflicts(&statuses);
+    if !conflicts.is_empty() {
+        let details = conflicts
+            .iter()
+            .map(|conflict| {
+                format!(
+                    "`{}` points to different objects locally ({}) and on origin ({})",
+                    conflict.tag, conflict.local_oid, conflict.remote_oid
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        bail!("bootstrap refused: conflicting tags found: {details}");
+    }
+
+    if options.dry_run {
+        report_bootstrap_plan(workspace, &statuses, push, options.github_release);
+        return Ok(true);
+    }
+
+    tag::create(
+        workspace,
+        &tag::CreateOptions {
+            push: options.push,
+            github_release: options.github_release,
+        },
+    )?;
+    Ok(true)
+}
+
+/// One status line per planned tag: its local action, plus (when queried)
+/// what pushing it would do and whether a GitHub Release already exists.
+/// Deterministic and mutation-free — every value comes straight out of
+/// `statuses`, itself gathered read-only.
+fn report_bootstrap_plan(
+    workspace: &Workspace,
+    statuses: &[tag::TagStatus],
+    push: bool,
+    github_release: bool,
+) {
+    for status in statuses {
+        let member = &workspace.members[status.member];
+        let kind = match status.kind {
+            tag::TagKind::Exact => "tag",
+            tag::TagKind::Series => "series tag",
+        };
+        let local = match status.action {
+            tag::TagAction::Create => "create",
+            tag::TagAction::Move => "move",
+            tag::TagAction::UpToDate => "up to date",
+        };
+        let mut line = format!(
+            "{}: {} {kind} {} — {local}",
+            member.name,
+            member.version(),
+            status.tag
+        );
+        if push {
+            let remote = match status.remote_action {
+                Some(tag::RemoteAction::Fetch) => "fetch from origin",
+                Some(tag::RemoteAction::Push) => "push",
+                Some(tag::RemoteAction::ForcePush) => "force-push",
+                Some(tag::RemoteAction::UpToDate) => "already on origin",
+                None => "not checked",
+            };
+            line.push_str(&format!("; {remote}"));
+        }
+        if github_release && status.kind == tag::TagKind::Exact {
+            let release = match status.release_exists {
+                Some(true) => "GitHub release already exists",
+                Some(false) => "create GitHub release",
+                None => "GitHub release not checked",
+            };
+            line.push_str(&format!("; {release}"));
+        }
+        crate::status!("{line}");
+    }
 }
 
 fn build_release_commit_and_pr(

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -53,7 +53,12 @@ pub struct PlannedTag {
 /// the work it needs. A repository-wide series tag (a `series_tag_format`
 /// without `{name}`) is claimed by the first member that would produce it, so
 /// it is moved once rather than once per package.
-fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
+///
+/// Local-only and read-only — no git ref is written and no remote is
+/// queried. `tag plan`, `tag create`, and `release bootstrap` all start from
+/// this same reconciliation, so a preview can never disagree with what
+/// execution actually does.
+pub(crate) fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
     let existing = git_stdout(&workspace.root, &["tag", "--list"])?;
     let existing: HashSet<&str> = existing
         .lines()
@@ -111,6 +116,146 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
         }
     }
     Ok(planned)
+}
+
+/// What pushing (or, for an exact tag, fetching) a planned tag would do,
+/// read without mutating anything. Mirrors the decisions
+/// `create_exact_tag`/`move_series_tag` make right before they mutate, so
+/// `release bootstrap`'s preview shows exactly what execution would do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteAction {
+    /// The tag exists on origin but not locally; fetched rather than
+    /// created, so an exact tag never gets a second, differently-dated
+    /// annotation for the same commit.
+    Fetch,
+    /// Origin doesn't have it yet.
+    Push,
+    /// A series tag whose remote copy already names a different commit.
+    ForcePush,
+    /// Local and remote already agree; nothing to push.
+    UpToDate,
+}
+
+/// The read-only reconciliation for one planned tag: its local object,
+/// its remote object (when `push` is in play), what pushing it would do,
+/// and whether a GitHub Release already exists (when `github_release` is in
+/// play, exact tags only — a series tag never carries one).
+#[derive(Debug, Clone)]
+pub struct TagStatus {
+    pub member: usize,
+    pub tag: String,
+    pub kind: TagKind,
+    pub action: TagAction,
+    pub local_oid: Option<String>,
+    pub remote_oid: Option<String>,
+    pub remote_action: Option<RemoteAction>,
+    pub release_exists: Option<bool>,
+}
+
+/// Query local state, and — gated on `push`/`github_release` exactly like
+/// `tag create` gates its own remote and `gh` calls — remote and GitHub
+/// Release state, for every tag `plan_tags` produced. Nothing here writes
+/// anything; it's the same information `create_exact_tag`/`move_series_tag`
+/// gather immediately before mutating, gathered once so a preview and a
+/// preflight conflict check can both work from it.
+pub fn tag_status(
+    workspace: &Workspace,
+    planned: &[PlannedTag],
+    push: bool,
+    github_release: bool,
+) -> Result<Vec<TagStatus>> {
+    let head = commit_of(&workspace.root, "HEAD")?;
+    planned
+        .iter()
+        .map(|planned| {
+            let local_oid = local_tag_oid(&workspace.root, &planned.tag)?;
+            let remote_oid = if push {
+                remote_tag_oid(&workspace.root, &planned.tag)?
+            } else {
+                None
+            };
+            let remote_action = push.then(|| {
+                remote_action_for(planned.kind, planned.action, &local_oid, &remote_oid, &head)
+            });
+            let release_exists = if github_release && planned.kind == TagKind::Exact {
+                Some(github_release_exists(&workspace.root, &planned.tag)?)
+            } else {
+                None
+            };
+            Ok(TagStatus {
+                member: planned.member,
+                tag: planned.tag.clone(),
+                kind: planned.kind,
+                action: planned.action,
+                local_oid,
+                remote_oid,
+                remote_action,
+                release_exists,
+            })
+        })
+        .collect()
+}
+
+/// An exact tag's remote action follows `create_exact_tag`: missing locally
+/// but present on origin fetches it; otherwise it pushes once origin lacks
+/// it. A series tag's follows `move_series_tag`: local always lands on
+/// `head` once its action isn't `UpToDate` (re-tagging targets `HEAD`, same
+/// as a fresh exact tag), so that — or the already-`UpToDate` local object —
+/// is what gets compared to origin.
+fn remote_action_for(
+    kind: TagKind,
+    action: TagAction,
+    local_oid: &Option<String>,
+    remote_oid: &Option<String>,
+    head: &Option<String>,
+) -> RemoteAction {
+    match kind {
+        TagKind::Exact => match (local_oid, remote_oid) {
+            (None, Some(_)) => RemoteAction::Fetch,
+            (Some(_), Some(_)) => RemoteAction::UpToDate, // divergence is a conflict, filtered separately
+            (_, None) => RemoteAction::Push,
+        },
+        TagKind::Series => {
+            let final_local = if action == TagAction::UpToDate {
+                local_oid.clone()
+            } else {
+                head.clone()
+            };
+            match (&final_local, remote_oid) {
+                (Some(local), Some(remote)) if local == remote => RemoteAction::UpToDate,
+                (_, None) => RemoteAction::Push,
+                _ => RemoteAction::ForcePush,
+            }
+        }
+    }
+}
+
+/// An immutable tag whose local and remote objects disagree — the one
+/// conflict trellis refuses to resolve automatically (see
+/// `create_exact_tag`'s divergence check).
+#[derive(Debug, Clone)]
+pub struct TagConflict {
+    pub tag: String,
+    pub local_oid: String,
+    pub remote_oid: String,
+}
+
+/// Every exact-tag conflict in `statuses`, read straight off the
+/// already-queried object IDs — no further git calls, so this can run as a
+/// preflight before any tag in the batch is mutated.
+pub fn tag_conflicts(statuses: &[TagStatus]) -> Vec<TagConflict> {
+    statuses
+        .iter()
+        .filter(|status| status.kind == TagKind::Exact)
+        .filter_map(|status| match (&status.local_oid, &status.remote_oid) {
+            (Some(local), Some(remote)) if local != remote => Some(TagConflict {
+                tag: status.tag.clone(),
+                local_oid: local.clone(),
+                remote_oid: remote.clone(),
+            }),
+            _ => None,
+        })
+        .collect()
 }
 
 pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -118,146 +118,6 @@ pub(crate) fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
     Ok(planned)
 }
 
-/// What pushing (or, for an exact tag, fetching) a planned tag would do,
-/// read without mutating anything. Mirrors the decisions
-/// `create_exact_tag`/`move_series_tag` make right before they mutate, so
-/// `release bootstrap`'s preview shows exactly what execution would do.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RemoteAction {
-    /// The tag exists on origin but not locally; fetched rather than
-    /// created, so an exact tag never gets a second, differently-dated
-    /// annotation for the same commit.
-    Fetch,
-    /// Origin doesn't have it yet.
-    Push,
-    /// A series tag whose remote copy already names a different commit.
-    ForcePush,
-    /// Local and remote already agree; nothing to push.
-    UpToDate,
-}
-
-/// The read-only reconciliation for one planned tag: its local object,
-/// its remote object (when `push` is in play), what pushing it would do,
-/// and whether a GitHub Release already exists (when `github_release` is in
-/// play, exact tags only — a series tag never carries one).
-#[derive(Debug, Clone)]
-pub struct TagStatus {
-    pub member: usize,
-    pub tag: String,
-    pub kind: TagKind,
-    pub action: TagAction,
-    pub local_oid: Option<String>,
-    pub remote_oid: Option<String>,
-    pub remote_action: Option<RemoteAction>,
-    pub release_exists: Option<bool>,
-}
-
-/// Query local state, and — gated on `push`/`github_release` exactly like
-/// `tag create` gates its own remote and `gh` calls — remote and GitHub
-/// Release state, for every tag `plan_tags` produced. Nothing here writes
-/// anything; it's the same information `create_exact_tag`/`move_series_tag`
-/// gather immediately before mutating, gathered once so a preview and a
-/// preflight conflict check can both work from it.
-pub fn tag_status(
-    workspace: &Workspace,
-    planned: &[PlannedTag],
-    push: bool,
-    github_release: bool,
-) -> Result<Vec<TagStatus>> {
-    let head = commit_of(&workspace.root, "HEAD")?;
-    planned
-        .iter()
-        .map(|planned| {
-            let local_oid = local_tag_oid(&workspace.root, &planned.tag)?;
-            let remote_oid = if push {
-                remote_tag_oid(&workspace.root, &planned.tag)?
-            } else {
-                None
-            };
-            let remote_action = push.then(|| {
-                remote_action_for(planned.kind, planned.action, &local_oid, &remote_oid, &head)
-            });
-            let release_exists = if github_release && planned.kind == TagKind::Exact {
-                Some(github_release_exists(&workspace.root, &planned.tag)?)
-            } else {
-                None
-            };
-            Ok(TagStatus {
-                member: planned.member,
-                tag: planned.tag.clone(),
-                kind: planned.kind,
-                action: planned.action,
-                local_oid,
-                remote_oid,
-                remote_action,
-                release_exists,
-            })
-        })
-        .collect()
-}
-
-/// An exact tag's remote action follows `create_exact_tag`: missing locally
-/// but present on origin fetches it; otherwise it pushes once origin lacks
-/// it. A series tag's follows `move_series_tag`: local always lands on
-/// `head` once its action isn't `UpToDate` (re-tagging targets `HEAD`, same
-/// as a fresh exact tag), so that — or the already-`UpToDate` local object —
-/// is what gets compared to origin.
-fn remote_action_for(
-    kind: TagKind,
-    action: TagAction,
-    local_oid: &Option<String>,
-    remote_oid: &Option<String>,
-    head: &Option<String>,
-) -> RemoteAction {
-    match kind {
-        TagKind::Exact => match (local_oid, remote_oid) {
-            (None, Some(_)) => RemoteAction::Fetch,
-            (Some(_), Some(_)) => RemoteAction::UpToDate, // divergence is a conflict, filtered separately
-            (_, None) => RemoteAction::Push,
-        },
-        TagKind::Series => {
-            let final_local = if action == TagAction::UpToDate {
-                local_oid.clone()
-            } else {
-                head.clone()
-            };
-            match (&final_local, remote_oid) {
-                (Some(local), Some(remote)) if local == remote => RemoteAction::UpToDate,
-                (_, None) => RemoteAction::Push,
-                _ => RemoteAction::ForcePush,
-            }
-        }
-    }
-}
-
-/// An immutable tag whose local and remote objects disagree — the one
-/// conflict trellis refuses to resolve automatically (see
-/// `create_exact_tag`'s divergence check).
-#[derive(Debug, Clone)]
-pub struct TagConflict {
-    pub tag: String,
-    pub local_oid: String,
-    pub remote_oid: String,
-}
-
-/// Every exact-tag conflict in `statuses`, read straight off the
-/// already-queried object IDs — no further git calls, so this can run as a
-/// preflight before any tag in the batch is mutated.
-pub fn tag_conflicts(statuses: &[TagStatus]) -> Vec<TagConflict> {
-    statuses
-        .iter()
-        .filter(|status| status.kind == TagKind::Exact)
-        .filter_map(|status| match (&status.local_oid, &status.remote_oid) {
-            (Some(local), Some(remote)) if local != remote => Some(TagConflict {
-                tag: status.tag.clone(),
-                local_oid: local.clone(),
-                remote_oid: remote.clone(),
-            }),
-            _ => None,
-        })
-        .collect()
-}
-
 pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
     let pending: Vec<PlannedTag> = plan_tags(workspace)?
         .into_iter()
@@ -304,6 +164,9 @@ pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
 pub struct CreateOptions {
     pub push: bool,
     pub github_release: bool,
+    /// Report every planned action without doing anything (a conflicting tag
+    /// still fails the command).
+    pub dry_run: bool,
 }
 
 pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
@@ -320,10 +183,36 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
         return Ok(());
     }
 
+    // An immutable tag whose local and remote objects disagree is the one
+    // conflict trellis refuses to resolve. Check every planned tag before
+    // mutating any of them, so one package's conflict fails the whole run
+    // rather than leaving an earlier package half-tagged.
+    if push {
+        let mut conflicts = Vec::new();
+        for planned in &targets {
+            if planned.kind != TagKind::Exact {
+                continue;
+            }
+            let tag = &planned.tag;
+            if let (Some(local), Some(remote)) = (
+                local_tag_oid(&workspace.root, tag)?,
+                remote_tag_oid(&workspace.root, tag)?,
+            ) && local != remote
+            {
+                conflicts.push(format!(
+                    "tag `{tag}` points to different objects locally ({local}) and on origin ({remote})"
+                ));
+            }
+        }
+        if !conflicts.is_empty() {
+            bail!("{}", conflicts.join("; "));
+        }
+    }
+
     for planned in targets {
         match planned.kind {
             TagKind::Exact => create_exact_tag(workspace, planned, options, push)?,
-            TagKind::Series => move_series_tag(workspace, planned, push)?,
+            TagKind::Series => move_series_tag(workspace, planned, options, push)?,
         }
     }
     Ok(())
@@ -346,15 +235,17 @@ fn create_exact_tag(
     } else {
         None
     };
-    if let (Some(local), Some(remote)) = (&local_oid, &remote_oid)
-        && local != remote
-    {
-        bail!("tag `{tag}` points to different objects locally ({local}) and on origin ({remote})");
-    }
+    // Local/remote divergence was already rejected by `create`'s preflight.
     if local_oid.is_none() {
         if remote_oid.is_some() {
-            git_stdout(&workspace.root, &["fetch", "origin", "tag", tag])?;
-            crate::status!("fetched {tag}");
+            if options.dry_run {
+                crate::status!("would fetch {tag}");
+            } else {
+                git_stdout(&workspace.root, &["fetch", "origin", "tag", tag])?;
+                crate::status!("fetched {tag}");
+            }
+        } else if options.dry_run {
+            crate::status!("would tag {tag}");
         } else {
             let mut args = crate::git::identity_fallback_args(&workspace.root);
             args.extend([
@@ -370,13 +261,19 @@ fn create_exact_tag(
         }
     }
     if push && remote_oid.is_none() {
-        git_stdout(&workspace.root, &["push", "origin", tag])
-            .with_context(|| format!("failed to push tag {tag}"))?;
-        crate::status!("pushed {tag}");
+        if options.dry_run {
+            crate::status!("would push {tag}");
+        } else {
+            git_stdout(&workspace.root, &["push", "origin", tag])
+                .with_context(|| format!("failed to push tag {tag}"))?;
+            crate::status!("pushed {tag}");
+        }
     }
     if options.github_release {
         if github_release_exists(&workspace.root, tag)? {
             crate::status!("GitHub release {tag} already exists; skipping");
+        } else if options.dry_run {
+            crate::status!("would create GitHub release {tag}");
         } else {
             let notes = release_notes(workspace, planned.member);
             let gh = tools::gh_bin();
@@ -403,43 +300,61 @@ fn create_exact_tag(
 /// release commit and force-pushed. Local and remote pointing at different
 /// objects is the normal state between releases, not an error, and no GitHub
 /// Release is ever attached — it would silently retarget on the next move.
-fn move_series_tag(workspace: &Workspace, planned: &PlannedTag, push: bool) -> Result<()> {
+fn move_series_tag(
+    workspace: &Workspace,
+    planned: &PlannedTag,
+    options: &CreateOptions,
+    push: bool,
+) -> Result<()> {
     let member = &workspace.members[planned.member];
     let tag = &planned.tag;
+    let moved = planned.action != TagAction::UpToDate;
     let remote_oid = if push {
         remote_tag_oid(&workspace.root, tag)?
     } else {
         None
     };
-    if planned.action != TagAction::UpToDate {
-        let mut args = crate::git::identity_fallback_args(&workspace.root);
-        args.extend([
-            "tag".into(),
-            "-f".into(),
-            "-a".into(),
-            tag.clone(),
-            "-m".into(),
-            format!("{} {}", member.name, member.version()),
-        ]);
-        let args: Vec<&str> = args.iter().map(String::as_str).collect();
-        git_stdout(&workspace.root, &args)?;
-        if planned.action == TagAction::Create {
-            crate::status!("tagged {tag}");
+    if moved {
+        let (verb, done) = if planned.action == TagAction::Create {
+            ("tag", "tagged")
         } else {
-            crate::status!("moved {tag}");
+            ("move", "moved")
+        };
+        if options.dry_run {
+            crate::status!("would {verb} {tag}");
+        } else {
+            let mut args = crate::git::identity_fallback_args(&workspace.root);
+            args.extend([
+                "tag".into(),
+                "-f".into(),
+                "-a".into(),
+                tag.clone(),
+                "-m".into(),
+                format!("{} {}", member.name, member.version()),
+            ]);
+            let args: Vec<&str> = args.iter().map(String::as_str).collect();
+            git_stdout(&workspace.root, &args)?;
+            crate::status!("{done} {tag}");
         }
     }
     if push {
         // Re-read after any move: a re-tag writes a fresh annotated object, so
-        // this also catches "already where it belongs, but origin disagrees".
+        // it never matches origin (in a dry run `moved` stands in for that);
+        // the comparison also catches "already where it belongs, but origin
+        // disagrees".
         let local_oid = local_tag_oid(&workspace.root, tag)?;
-        if local_oid != remote_oid {
-            git_stdout(&workspace.root, &["push", "--force", "origin", tag])
-                .with_context(|| format!("failed to push tag {tag}"))?;
-            if remote_oid.is_none() {
-                crate::status!("pushed {tag}");
+        if moved || local_oid != remote_oid {
+            let verb = if remote_oid.is_none() {
+                "push"
             } else {
-                crate::status!("force-pushed {tag}");
+                "force-push"
+            };
+            if options.dry_run {
+                crate::status!("would {verb} {tag}");
+            } else {
+                git_stdout(&workspace.root, &["push", "--force", "origin", tag])
+                    .with_context(|| format!("failed to push tag {tag}"))?;
+                crate::status!("{verb}ed {tag}");
             }
         }
     }

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -12,7 +12,7 @@ use crate::tools;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 
@@ -183,6 +183,16 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
         return Ok(());
     }
 
+    // One `ls-remote` answers "what does origin have?" for every planned tag
+    // at once — a single network round trip that the conflict preflight and
+    // the per-tag actions below all read from.
+    let remote_oids = if push {
+        let tags: Vec<&str> = targets.iter().map(|planned| planned.tag.as_str()).collect();
+        remote_tag_oids(&workspace.root, &tags)?
+    } else {
+        HashMap::new()
+    };
+
     // An immutable tag whose local and remote objects disagree is the one
     // conflict trellis refuses to resolve. Check every planned tag before
     // mutating any of them, so one package's conflict fails the whole run
@@ -194,10 +204,9 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
                 continue;
             }
             let tag = &planned.tag;
-            if let (Some(local), Some(remote)) = (
-                local_tag_oid(&workspace.root, tag)?,
-                remote_tag_oid(&workspace.root, tag)?,
-            ) && local != remote
+            if let (Some(local), Some(remote)) =
+                (local_tag_oid(&workspace.root, tag)?, remote_oids.get(tag))
+                && local != *remote
             {
                 conflicts.push(format!(
                     "tag `{tag}` points to different objects locally ({local}) and on origin ({remote})"
@@ -210,9 +219,10 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
     }
 
     for planned in targets {
+        let remote_oid = remote_oids.get(&planned.tag).map(String::as_str);
         match planned.kind {
-            TagKind::Exact => create_exact_tag(workspace, planned, options, push)?,
-            TagKind::Series => move_series_tag(workspace, planned, options, push)?,
+            TagKind::Exact => create_exact_tag(workspace, planned, options, push, remote_oid)?,
+            TagKind::Series => move_series_tag(workspace, planned, options, push, remote_oid)?,
         }
     }
     Ok(())
@@ -226,17 +236,14 @@ fn create_exact_tag(
     planned: &PlannedTag,
     options: &CreateOptions,
     push: bool,
+    remote_oid: Option<&str>,
 ) -> Result<()> {
     let member = &workspace.members[planned.member];
     let tag = &planned.tag;
-    let local_oid = local_tag_oid(&workspace.root, tag)?;
-    let remote_oid = if push {
-        remote_tag_oid(&workspace.root, tag)?
-    } else {
-        None
-    };
-    // Local/remote divergence was already rejected by `create`'s preflight.
-    if local_oid.is_none() {
+    // `plan_tags` already read the local tag list, so `action` says whether
+    // the tag exists here; local/remote divergence was rejected by `create`'s
+    // preflight.
+    if planned.action == TagAction::Create {
         if remote_oid.is_some() {
             if options.dry_run {
                 crate::status!("would fetch {tag}");
@@ -305,15 +312,11 @@ fn move_series_tag(
     planned: &PlannedTag,
     options: &CreateOptions,
     push: bool,
+    remote_oid: Option<&str>,
 ) -> Result<()> {
     let member = &workspace.members[planned.member];
     let tag = &planned.tag;
     let moved = planned.action != TagAction::UpToDate;
-    let remote_oid = if push {
-        remote_tag_oid(&workspace.root, tag)?
-    } else {
-        None
-    };
     if moved {
         let (verb, done) = if planned.action == TagAction::Create {
             ("tag", "tagged")
@@ -343,7 +346,7 @@ fn move_series_tag(
         // the comparison also catches "already where it belongs, but origin
         // disagrees".
         let local_oid = local_tag_oid(&workspace.root, tag)?;
-        if moved || local_oid != remote_oid {
+        if moved || local_oid.as_deref() != remote_oid {
             let verb = if remote_oid.is_none() {
                 "push"
             } else {
@@ -393,29 +396,25 @@ fn rev_parse(root: &Path, reference: &str, subject: &str) -> Result<Option<Strin
     }
 }
 
-fn remote_tag_oid(root: &Path, tag: &str) -> Result<Option<String>> {
-    let reference = format!("refs/tags/{tag}");
-    let args = ["ls-remote", "--exit-code", "--tags", "origin", &reference];
-    crate::term::trace_command("git", &args, root);
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(root)
-        .output()
-        .context("failed to run git")?;
-    match output.status.code() {
-        Some(0) => output
-            .stdout
-            .split(|byte| byte.is_ascii_whitespace())
-            .find(|part| !part.is_empty())
-            .map(|oid| String::from_utf8_lossy(oid).into_owned())
-            .map(Some)
-            .context("git ls-remote returned no object ID"),
-        Some(2) => Ok(None),
-        _ => bail!(
-            "git ls-remote failed while checking tag `{tag}`: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ),
+/// The object each requested tag names on origin, from one `ls-remote` for
+/// the whole batch. Tags origin doesn't have are absent from the map. Peeled
+/// `^{}` entries are skipped so the oid is the tag object itself — the same
+/// object `local_tag_oid` reports.
+fn remote_tag_oids(root: &Path, tags: &[&str]) -> Result<HashMap<String, String>> {
+    let refs: Vec<String> = tags.iter().map(|tag| format!("refs/tags/{tag}")).collect();
+    let mut args = vec!["ls-remote", "--tags", "origin"];
+    args.extend(refs.iter().map(String::as_str));
+    let stdout = git_stdout(root, &args)?;
+    let mut oids = HashMap::new();
+    for line in stdout.lines() {
+        if let Some((oid, reference)) = line.split_once('\t')
+            && let Some(tag) = reference.strip_prefix("refs/tags/")
+            && !tag.ends_with("^{}")
+        {
+            oids.insert(tag.to_string(), oid.to_string());
+        }
     }
+    Ok(oids)
 }
 
 fn github_release_exists(root: &Path, tag: &str) -> Result<bool> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -393,13 +393,9 @@ enum ReleaseCommand {
     /// Reconcile tags against current manifest versions — no version bump,
     /// no unreleased changelog fragments required
     ///
-    /// For adopting trellis on a repository that already has the package
-    /// versions and changelogs it wants, but no tags yet. Reads versions
-    /// straight off each package's `gleam.toml`, the same reconciliation
-    /// `tag create` performs, but checks every planned tag for a
-    /// local/remote conflict before mutating any of them — one package's
-    /// immutable tag disagreeing with origin fails the whole run rather than
-    /// leaving another package half-tagged.
+    /// An alias for `tag create`, for adopting trellis on a repository that
+    /// already has the package versions and changelogs it wants, but no tags
+    /// yet.
     Bootstrap {
         /// Report every tag/push/release action without doing anything (a
         /// conflicting tag still fails the command)
@@ -433,6 +429,10 @@ enum TagCommand {
         /// section as the body (implies --push; requires the gh CLI)
         #[arg(long)]
         github_release: bool,
+        /// Report every tag/push/release action without doing anything (a
+        /// conflicting tag still fails the command)
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -717,10 +717,10 @@ fn dispatch(cli: Cli) -> Result<bool> {
                 github_release,
             } => commands::release::bootstrap(
                 &workspace,
-                &commands::release::BootstrapOptions {
-                    dry_run,
+                &commands::tag::CreateOptions {
                     push,
                     github_release,
+                    dry_run,
                 },
             ),
         },
@@ -732,12 +732,14 @@ fn dispatch(cli: Cli) -> Result<bool> {
             TagCommand::Create {
                 push,
                 github_release,
+                dry_run,
             } => {
                 commands::tag::create(
                     &workspace,
                     &commands::tag::CreateOptions {
                         push,
                         github_release,
+                        dry_run,
                     },
                 )?;
                 Ok(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,18 +397,8 @@ enum ReleaseCommand {
     /// already has the package versions and changelogs it wants, but no tags
     /// yet.
     Bootstrap {
-        /// Report every tag/push/release action without doing anything (a
-        /// conflicting tag still fails the command)
-        #[arg(long)]
-        dry_run: bool,
-        /// Push tags to origin
-        #[arg(long)]
-        push: bool,
-        /// Also create a GitHub Release per exact tag, with the matching
-        /// CHANGELOG section as the body (implies --push; requires the gh
-        /// CLI)
-        #[arg(long)]
-        github_release: bool,
+        #[command(flatten)]
+        args: TagCreateArgs,
     },
 }
 
@@ -422,18 +412,38 @@ enum TagCommand {
     },
     /// Create missing tags in topological order
     Create {
-        /// Push each created tag to origin
-        #[arg(long)]
-        push: bool,
-        /// Also create a GitHub Release per tag, with the matching CHANGELOG
-        /// section as the body (implies --push; requires the gh CLI)
-        #[arg(long)]
-        github_release: bool,
-        /// Report every tag/push/release action without doing anything (a
-        /// conflicting tag still fails the command)
-        #[arg(long)]
-        dry_run: bool,
+        #[command(flatten)]
+        args: TagCreateArgs,
     },
+}
+
+/// Flags for `tag create` and its alias `release bootstrap`.
+///
+/// Flattened into both so the alias can't drift: the two must accept exactly
+/// the same flags or `release bootstrap` stops being `tag create`.
+#[derive(clap::Args)]
+struct TagCreateArgs {
+    /// Push each created tag to origin
+    #[arg(long)]
+    push: bool,
+    /// Also create a GitHub Release per exact tag, with the matching CHANGELOG
+    /// section as the body (implies --push; requires the gh CLI)
+    #[arg(long)]
+    github_release: bool,
+    /// Report every tag/push/release action without doing anything (a
+    /// conflicting tag still fails the command)
+    #[arg(long)]
+    dry_run: bool,
+}
+
+impl TagCreateArgs {
+    fn options(self) -> commands::tag::CreateOptions {
+        commands::tag::CreateOptions {
+            push: self.push,
+            github_release: self.github_release,
+            dry_run: self.dry_run,
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -711,37 +721,17 @@ fn dispatch(cli: Cli) -> Result<bool> {
             ReleaseCommand::Pr { base, branch } => {
                 commands::release::pr(&workspace, &commands::release::PrOptions { base, branch })
             }
-            ReleaseCommand::Bootstrap {
-                dry_run,
-                push,
-                github_release,
-            } => commands::release::bootstrap(
-                &workspace,
-                &commands::tag::CreateOptions {
-                    push,
-                    github_release,
-                    dry_run,
-                },
-            ),
+            ReleaseCommand::Bootstrap { args } => {
+                commands::release::bootstrap(&workspace, &args.options())
+            }
         },
         Command::Tag { command } => match command {
             TagCommand::Plan { json } => {
                 commands::tag::plan(&workspace, json)?;
                 Ok(true)
             }
-            TagCommand::Create {
-                push,
-                github_release,
-                dry_run,
-            } => {
-                commands::tag::create(
-                    &workspace,
-                    &commands::tag::CreateOptions {
-                        push,
-                        github_release,
-                        dry_run,
-                    },
-                )?;
+            TagCommand::Create { args } => {
+                commands::tag::create(&workspace, &args.options())?;
                 Ok(true)
             }
         },

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,6 +390,30 @@ enum ReleaseCommand {
         #[arg(long, default_value = "release/pending")]
         branch: String,
     },
+    /// Reconcile tags against current manifest versions — no version bump,
+    /// no unreleased changelog fragments required
+    ///
+    /// For adopting trellis on a repository that already has the package
+    /// versions and changelogs it wants, but no tags yet. Reads versions
+    /// straight off each package's `gleam.toml`, the same reconciliation
+    /// `tag create` performs, but checks every planned tag for a
+    /// local/remote conflict before mutating any of them — one package's
+    /// immutable tag disagreeing with origin fails the whole run rather than
+    /// leaving another package half-tagged.
+    Bootstrap {
+        /// Report every tag/push/release action without doing anything (a
+        /// conflicting tag still fails the command)
+        #[arg(long)]
+        dry_run: bool,
+        /// Push tags to origin
+        #[arg(long)]
+        push: bool,
+        /// Also create a GitHub Release per exact tag, with the matching
+        /// CHANGELOG section as the body (implies --push; requires the gh
+        /// CLI)
+        #[arg(long)]
+        github_release: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -687,6 +711,18 @@ fn dispatch(cli: Cli) -> Result<bool> {
             ReleaseCommand::Pr { base, branch } => {
                 commands::release::pr(&workspace, &commands::release::PrOptions { base, branch })
             }
+            ReleaseCommand::Bootstrap {
+                dry_run,
+                push,
+                github_release,
+            } => commands::release::bootstrap(
+                &workspace,
+                &commands::release::BootstrapOptions {
+                    dry_run,
+                    push,
+                    github_release,
+                },
+            ),
         },
         Command::Tag { command } => match command {
             TagCommand::Plan { json } => {

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -237,12 +237,7 @@ fn tag_create_github_release_uses_changelog_section() {
     copy_fixture_to(root);
     init_repo(root);
     // A bare remote so the implied push has somewhere to go.
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let _remote = bare_origin(root);
     let gh = install_fake_gh(root);
 
     trellis(root)
@@ -267,12 +262,7 @@ fn tag_create_reconciles_local_tags_with_remote_and_releases() {
     let root = tmp.path();
     copy_fixture_to(root);
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let remote = bare_origin(root);
     let gh = install_fake_gh(root);
 
     for (tag, message) in [
@@ -293,16 +283,7 @@ fn tag_create_reconciles_local_tags_with_remote_and_releases() {
             "created GitHub release lat_core-v1.2.0",
         ));
 
-    let tags = std::process::Command::new("git")
-        .args([
-            "--git-dir",
-            remote.path().to_str().unwrap(),
-            "tag",
-            "--list",
-        ])
-        .output()
-        .unwrap();
-    let tags = String::from_utf8_lossy(&tags.stdout);
+    let tags = git_stdout(remote.path(), &["tag", "--list"]);
     assert!(tags.contains("lat_core-v1.2.0"));
     assert!(tags.contains("lat_mid-v0.5.0"));
     assert!(tags.contains("lat_cli-v0.3.1"));
@@ -325,12 +306,7 @@ fn tag_create_rejects_divergent_local_and_remote_tags() {
     let root = tmp.path();
     copy_fixture_to(root);
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let _remote = bare_origin(root);
 
     for (tag, message) in [
         ("lat_core-v1.2.0", "lat_core at initial commit"),
@@ -580,6 +556,18 @@ fn publish_rejects_unreleasable_package() {
 
 // ---- series tags -----------------------------------------------------------
 
+/// A bare repository added to `root`'s repo as `origin`. The returned remote
+/// must outlive the test.
+fn bare_origin(root: &Path) -> tempfile::TempDir {
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    remote
+}
+
 /// The basic fixture with `[tools.trellis.publish]` replaced by `publish`, in
 /// a git repo with a bare origin. The returned remote must outlive the test.
 fn series_repo(root: &Path, publish: &str) -> tempfile::TempDir {
@@ -593,13 +581,7 @@ fn series_repo(root: &Path, publish: &str) -> tempfile::TempDir {
         ),
     );
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
-    remote
+    bare_origin(root)
 }
 
 fn set_version(root: &Path, package: &str, version: &str) {
@@ -951,13 +933,16 @@ fn doctor_rejects_a_tag_mode_override_that_matches_nothing() {
 
 // ---- release bootstrap -----------------------------------------------------
 
-fn read_version(root: &Path, package: &str) -> String {
-    let path = root.join("packages").join(package).join("gleam.toml");
-    let text = fs::read_to_string(path).unwrap();
-    text.lines()
-        .find_map(|line| line.strip_prefix("version = \""))
-        .and_then(|rest| rest.strip_suffix('"'))
-        .unwrap()
+// Mirrors `version_of` in phase2.rs — the same manifest-version read, kept in
+// step until the test binaries grow a shared support module.
+fn version_of(root: &Path, package: &str) -> String {
+    let manifest = fs::read_to_string(root.join("packages").join(package).join("gleam.toml"))
+        .unwrap_or_else(|err| panic!("no gleam.toml for {package}: {err}"));
+    manifest
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("version = "))
+        .unwrap_or_else(|| panic!("no version in {package}'s gleam.toml"))
+        .trim_matches('"')
         .to_string()
 }
 
@@ -985,9 +970,9 @@ fn bootstrap_uses_current_versions_with_no_fragments_required() {
         vec!["lat_cli-v0.3.1", "lat_core-v1.2.0", "lat_mid-v0.5.0"]
     );
     // No version bump: bootstrap never runs `version plan`/`version apply`.
-    assert_eq!(read_version(root, "lat_core"), "1.2.0");
-    assert_eq!(read_version(root, "lat_mid"), "0.5.0");
-    assert_eq!(read_version(root, "lat_cli"), "0.3.1");
+    assert_eq!(version_of(root, "lat_core"), "1.2.0");
+    assert_eq!(version_of(root, "lat_mid"), "0.5.0");
+    assert_eq!(version_of(root, "lat_cli"), "0.3.1");
 }
 
 #[test]
@@ -996,12 +981,7 @@ fn bootstrap_dry_run_reports_every_action_and_mutates_nothing() {
     let root = tmp.path();
     copy_fixture_to(root);
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let remote = bare_origin(root);
     let gh = install_fake_gh(root);
 
     trellis(root)
@@ -1027,16 +1007,7 @@ fn bootstrap_dry_run_reports_every_action_and_mutates_nothing() {
 
     // Nothing was actually created, locally, on origin, or via `gh`.
     assert_eq!(git_stdout(root, &["tag", "--list"]), "");
-    let remote_tags = git_stdout(
-        remote.path(),
-        &[
-            "--git-dir",
-            remote.path().to_str().unwrap(),
-            "tag",
-            "--list",
-        ],
-    );
-    assert_eq!(remote_tags, "");
+    assert_eq!(git_stdout(remote.path(), &["tag", "--list"]), "");
     let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap_or_default();
     assert!(!log.contains("release create"), "{log}");
 }
@@ -1100,12 +1071,7 @@ fn bootstrap_fetches_a_remote_only_tag_instead_of_recreating_it() {
     let root = tmp.path();
     copy_fixture_to(root);
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let _remote = bare_origin(root);
     // lat_core is already tagged and pushed by some earlier process; the
     // local clone bootstrapping now has never seen the tag.
     git(root, &["tag", "-a", "lat_core-v1.2.0", "-m", "existing"]);
@@ -1133,12 +1099,7 @@ fn bootstrap_reports_existing_releases_and_reruns_idempotently() {
     let root = tmp.path();
     copy_fixture_to(root);
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let _remote = bare_origin(root);
     let gh = install_fake_gh(root);
 
     trellis(root)
@@ -1180,12 +1141,7 @@ fn bootstrap_preflights_conflicts_before_mutating_any_package() {
     let root = tmp.path();
     copy_fixture_to(root);
     init_repo(root);
-    let remote = tempfile::tempdir().unwrap();
-    git(remote.path(), &["init", "-q", "--bare"]);
-    git(
-        root,
-        &["remote", "add", "origin", remote.path().to_str().unwrap()],
-    );
+    let _remote = bare_origin(root);
     // lat_core is tagged and pushed, then the local tag is force-moved to a
     // later commit — an immutable tag disagreeing with origin.
     git(root, &["tag", "-a", "lat_core-v1.2.0", "-m", "first"]);

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -1015,14 +1015,14 @@ fn bootstrap_dry_run_reports_every_action_and_mutates_nothing() {
         ])
         .assert()
         .success()
+        .stdout(predicate::str::contains("would tag lat_core-v1.2.0"))
+        .stdout(predicate::str::contains("would push lat_core-v1.2.0"))
         .stdout(predicate::str::contains(
-            "lat_core: 1.2.0 tag lat_core-v1.2.0 — create; push; create GitHub release",
+            "would create GitHub release lat_core-v1.2.0",
         ))
+        .stdout(predicate::str::contains("would tag lat_mid-v0.5.0"))
         .stdout(predicate::str::contains(
-            "lat_mid: 0.5.0 tag lat_mid-v0.5.0 — create; push; create GitHub release",
-        ))
-        .stdout(predicate::str::contains(
-            "lat_cli: 0.3.1 tag lat_cli-v0.3.1 — create; push; create GitHub release",
+            "would create GitHub release lat_cli-v0.3.1",
         ));
 
     // Nothing was actually created, locally, on origin, or via `gh`.
@@ -1054,12 +1054,8 @@ fn bootstrap_creates_both_exact_and_series_tags() {
         .args(["release", "bootstrap", "--dry-run"])
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "lat_cli: 0.3.1 tag lat_cli-v0.3.1 — create",
-        ))
-        .stdout(predicate::str::contains(
-            "lat_cli: 0.3.1 series tag lat_cli-v0.3 — create",
-        ));
+        .stdout(predicate::str::contains("would tag lat_cli-v0.3.1"))
+        .stdout(predicate::str::contains("would tag lat_cli-v0.3\n"));
 
     trellis(root)
         .args(["release", "bootstrap"])
@@ -1121,9 +1117,7 @@ fn bootstrap_fetches_a_remote_only_tag_instead_of_recreating_it() {
         .args(["release", "bootstrap", "--dry-run", "--push"])
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "lat_core: 1.2.0 tag lat_core-v1.2.0 — create; fetch from origin",
-        ));
+        .stdout(predicate::str::contains("would fetch lat_core-v1.2.0"));
 
     trellis(root)
         .args(["release", "bootstrap", "--push"])
@@ -1167,9 +1161,9 @@ fn bootstrap_reports_existing_releases_and_reruns_idempotently() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "lat_core: 1.2.0 tag lat_core-v1.2.0 — up to date; already on origin; \
-             GitHub release already exists",
-        ));
+            "GitHub release lat_core-v1.2.0 already exists; skipping",
+        ))
+        .stdout(predicate::str::contains("would").not());
 
     trellis(root)
         .env("TRELLIS_GH_BIN", &gh)

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -949,6 +949,277 @@ fn doctor_rejects_a_tag_mode_override_that_matches_nothing() {
         ));
 }
 
+// ---- release bootstrap -----------------------------------------------------
+
+fn read_version(root: &Path, package: &str) -> String {
+    let path = root.join("packages").join(package).join("gleam.toml");
+    let text = fs::read_to_string(path).unwrap();
+    text.lines()
+        .find_map(|line| line.strip_prefix("version = \""))
+        .and_then(|rest| rest.strip_suffix('"'))
+        .unwrap()
+        .to_string()
+}
+
+#[test]
+fn bootstrap_uses_current_versions_with_no_fragments_required() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    // The fixture ships no `.changes/unreleased` directory at all — bootstrap
+    // must not need one.
+    assert!(!root.join(".changes").exists());
+
+    trellis(root)
+        .args(["release", "bootstrap"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tagged lat_core-v1.2.0"))
+        .stdout(predicate::str::contains("tagged lat_mid-v0.5.0"))
+        .stdout(predicate::str::contains("tagged lat_cli-v0.3.1"));
+
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert_eq!(
+        tags.lines().collect::<Vec<_>>(),
+        vec!["lat_cli-v0.3.1", "lat_core-v1.2.0", "lat_mid-v0.5.0"]
+    );
+    // No version bump: bootstrap never runs `version plan`/`version apply`.
+    assert_eq!(read_version(root, "lat_core"), "1.2.0");
+    assert_eq!(read_version(root, "lat_mid"), "0.5.0");
+    assert_eq!(read_version(root, "lat_cli"), "0.3.1");
+}
+
+#[test]
+fn bootstrap_dry_run_reports_every_action_and_mutates_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    let gh = install_fake_gh(root);
+
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args([
+            "release",
+            "bootstrap",
+            "--dry-run",
+            "--push",
+            "--github-release",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "lat_core: 1.2.0 tag lat_core-v1.2.0 — create; push; create GitHub release",
+        ))
+        .stdout(predicate::str::contains(
+            "lat_mid: 0.5.0 tag lat_mid-v0.5.0 — create; push; create GitHub release",
+        ))
+        .stdout(predicate::str::contains(
+            "lat_cli: 0.3.1 tag lat_cli-v0.3.1 — create; push; create GitHub release",
+        ));
+
+    // Nothing was actually created, locally, on origin, or via `gh`.
+    assert_eq!(git_stdout(root, &["tag", "--list"]), "");
+    let remote_tags = git_stdout(
+        remote.path(),
+        &[
+            "--git-dir",
+            remote.path().to_str().unwrap(),
+            "tag",
+            "--list",
+        ],
+    );
+    assert_eq!(remote_tags, "");
+    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap_or_default();
+    assert!(!log.contains("release create"), "{log}");
+}
+
+#[test]
+fn bootstrap_creates_both_exact_and_series_tags() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag_mode_overrides = { both = [\"packages/lat_cli\"] }",
+    );
+
+    trellis(root)
+        .args(["release", "bootstrap", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "lat_cli: 0.3.1 tag lat_cli-v0.3.1 — create",
+        ))
+        .stdout(predicate::str::contains(
+            "lat_cli: 0.3.1 series tag lat_cli-v0.3 — create",
+        ));
+
+    trellis(root)
+        .args(["release", "bootstrap"])
+        .assert()
+        .success();
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert_eq!(
+        tags.lines().collect::<Vec<_>>(),
+        vec![
+            "lat_cli-v0.3",
+            "lat_cli-v0.3.1",
+            "lat_core-v1.2.0",
+            "lat_mid-v0.5.0"
+        ]
+    );
+}
+
+#[test]
+fn bootstrap_leaves_release_excluded_packages_untagged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+
+    trellis(root)
+        .args(["release", "bootstrap", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("package_a").not());
+
+    trellis(root)
+        .args(["release", "bootstrap"])
+        .assert()
+        .success();
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert!(!tags.contains("package_a"), "{tags}");
+}
+
+#[test]
+fn bootstrap_fetches_a_remote_only_tag_instead_of_recreating_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    // lat_core is already tagged and pushed by some earlier process; the
+    // local clone bootstrapping now has never seen the tag.
+    git(root, &["tag", "-a", "lat_core-v1.2.0", "-m", "existing"]);
+    git(root, &["push", "origin", "lat_core-v1.2.0"]);
+    let original = commit_of(root, "lat_core-v1.2.0");
+    git(root, &["tag", "-d", "lat_core-v1.2.0"]);
+
+    trellis(root)
+        .args(["release", "bootstrap", "--dry-run", "--push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "lat_core: 1.2.0 tag lat_core-v1.2.0 — create; fetch from origin",
+        ));
+
+    trellis(root)
+        .args(["release", "bootstrap", "--push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("fetched lat_core-v1.2.0"));
+    assert_eq!(commit_of(root, "lat_core-v1.2.0"), original);
+}
+
+#[test]
+fn bootstrap_reports_existing_releases_and_reruns_idempotently() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    let gh = install_fake_gh(root);
+
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args(["release", "bootstrap", "--push", "--github-release"])
+        .assert()
+        .success();
+    let first_log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
+    assert_eq!(first_log.matches("gh release create").count(), 3);
+
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args([
+            "release",
+            "bootstrap",
+            "--dry-run",
+            "--push",
+            "--github-release",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "lat_core: 1.2.0 tag lat_core-v1.2.0 — up to date; already on origin; \
+             GitHub release already exists",
+        ));
+
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args(["release", "bootstrap", "--push", "--github-release"])
+        .assert()
+        .success();
+    let second_log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
+    assert_eq!(second_log.matches("gh release create").count(), 3);
+}
+
+#[test]
+fn bootstrap_preflights_conflicts_before_mutating_any_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    // lat_core is tagged and pushed, then the local tag is force-moved to a
+    // later commit — an immutable tag disagreeing with origin.
+    git(root, &["tag", "-a", "lat_core-v1.2.0", "-m", "first"]);
+    git(root, &["push", "origin", "lat_core-v1.2.0"]);
+    write(&root.join("later.txt"), "later\n");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "later"]);
+    git(root, &["tag", "-f", "-a", "lat_core-v1.2.0", "-m", "moved"]);
+    // lat_mid and lat_cli have no tag yet, and would otherwise be created.
+
+    trellis(root)
+        .args(["release", "bootstrap", "--dry-run", "--push"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("different objects"));
+
+    trellis(root)
+        .args(["release", "bootstrap", "--push"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("different objects"));
+
+    // Neither the dry-run nor the failed real run tagged anything else —
+    // the conflict on lat_core blocks the whole batch.
+    let tags = git_stdout(root, &["tag", "--list"]);
+    assert_eq!(tags.lines().collect::<Vec<_>>(), vec!["lat_core-v1.2.0"]);
+}
+
 // ---- lockfile refresh ------------------------------------------------------
 
 #[test]

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -23,6 +23,7 @@ description: Every trellis command, flag, and argument — generated from the CL
 * [`trellis new`↴](#trellis-new)
 * [`trellis release`↴](#trellis-release)
 * [`trellis release pr`↴](#trellis-release-pr)
+* [`trellis release bootstrap`↴](#trellis-release-bootstrap)
 * [`trellis tag`↴](#trellis-tag)
 * [`trellis tag plan`↴](#trellis-tag-plan)
 * [`trellis tag create`↴](#trellis-tag-create)
@@ -315,6 +316,7 @@ Release orchestration
 ###### **Subcommands:**
 
 * `pr` — Create or update the release PR: version apply on a branch, push, gh pr
+* `bootstrap` — Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
 
 
 
@@ -332,6 +334,22 @@ Create or update the release PR: version apply on a branch, push, gh pr
 * `--branch <BRANCH>` — Branch the release commit is force-pushed to
 
   Default value: `release/pending`
+
+
+
+## `trellis release bootstrap`
+
+Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
+
+For adopting trellis on a repository that already has the package versions and changelogs it wants, but no tags yet. Reads versions straight off each package's `gleam.toml`, the same reconciliation `tag create` performs, but checks every planned tag for a local/remote conflict before mutating any of them — one package's immutable tag disagreeing with origin fails the whole run rather than leaving another package half-tagged.
+
+**Usage:** `trellis release bootstrap [OPTIONS]`
+
+###### **Options:**
+
+* `--dry-run` — Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
+* `--push` — Push tags to origin
+* `--github-release` — Also create a GitHub Release per exact tag, with the matching CHANGELOG section as the body (implies --push; requires the gh CLI)
 
 
 

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -347,9 +347,9 @@ An alias for `tag create`, for adopting trellis on a repository that already has
 
 ###### **Options:**
 
-* `--dry-run` — Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
-* `--push` — Push tags to origin
+* `--push` — Push each created tag to origin
 * `--github-release` — Also create a GitHub Release per exact tag, with the matching CHANGELOG section as the body (implies --push; requires the gh CLI)
+* `--dry-run` — Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
 
 
 
@@ -387,7 +387,7 @@ Create missing tags in topological order
 ###### **Options:**
 
 * `--push` — Push each created tag to origin
-* `--github-release` — Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies --push; requires the gh CLI)
+* `--github-release` — Also create a GitHub Release per exact tag, with the matching CHANGELOG section as the body (implies --push; requires the gh CLI)
 * `--dry-run` — Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
 
 

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -341,7 +341,7 @@ Create or update the release PR: version apply on a branch, push, gh pr
 
 Reconcile tags against current manifest versions — no version bump, no unreleased changelog fragments required
 
-For adopting trellis on a repository that already has the package versions and changelogs it wants, but no tags yet. Reads versions straight off each package's `gleam.toml`, the same reconciliation `tag create` performs, but checks every planned tag for a local/remote conflict before mutating any of them — one package's immutable tag disagreeing with origin fails the whole run rather than leaving another package half-tagged.
+An alias for `tag create`, for adopting trellis on a repository that already has the package versions and changelogs it wants, but no tags yet.
 
 **Usage:** `trellis release bootstrap [OPTIONS]`
 
@@ -388,6 +388,7 @@ Create missing tags in topological order
 
 * `--push` — Push each created tag to origin
 * `--github-release` — Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies --push; requires the gh CLI)
+* `--dry-run` — Report every tag/push/release action without doing anything (a conflicting tag still fails the command)
 
 
 


### PR DESCRIPTION
## Summary

- add `trellis release bootstrap` for tagging current manifest versions without a version bump or unreleased fragments
- add side-effect-free previews, remote reconciliation, GitHub Releases, and batch conflict preflight
- document adoption and pre-1.0 bootstrap flows, with end-to-end coverage

## Testing

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --test phase3 bootstrap --quiet`
- `cargo test --quiet` (all new tests pass; the existing `series_tag_moves_with_each_release_while_exact_tags_stay_put` failure reproduces on `main`)

Closes #71
