### PR TITLE
feat(tag): add repository series tags

### DIFF
--- a/.changes/unreleased/Added-20260731-repository-series-tags.yaml
+++ b/.changes/unreleased/Added-20260731-repository-series-tags.yaml
@@ -1,0 +1,5 @@
+component: tag
+kind: Added
+body: |-
+  **Repository series tags track one anchor package across a monorepo.** Configure `[tools.trellis.publish.repository_series]` with `package` and `format` to expose a mutable tag for Gleam git path dependencies. It moves only when the anchor manifest version changes, preserves tags from earlier series, creates no GitHub Release, and stays out of package tag resolution.
+time: 2026-07-31T22:57:57.462-07:00

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ tag_format = "{name}-v{version}"
 series_tag_format = "{name}-v{series}"
 tag_mode = "exact"
 tag_mode_overrides = { both = ["packages/lat_cli"] }
+
+# Optional repository-wide moving tag, independent of package tag modes.
+[tools.trellis.publish.repository_series]
+package = "lat_cli"
+format = "v{series}"
 ```
 
 Each member is a directory with a `gleam.toml`. Path dependencies between
@@ -440,6 +445,14 @@ release commit and force-pushes it. Because a moving tag names no particular
 version, it never carries a GitHub Release and `publish --tag` refuses it;
 `ci tag-package` still resolves it, and a `series`-only workspace publishes
 with `--all-untagged`.
+
+An optional `[tools.trellis.publish.repository_series]` tag is separate from
+both package lifecycles. Its `package` is the anchor: trellis creates
+`format` for the anchor's stable series and moves it only when the anchor's
+manifest version differs from the version stored at that tag. A new series
+creates a new tag and leaves the old series intact. Repository series tags are
+mutable, never get GitHub Releases, and cannot be passed to `publish --tag` or
+`ci tag-package`.
 
 `publish` runs, per package and in dependency order: an idempotency check
 against the Hex API (already-published versions are skipped, so re-running a

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -186,6 +186,10 @@ tag_mode_overrides = { both = ["packages/lattice_cli"] }
 path_dep_requirement = "minor"
 retry = { attempts = 5, initial_delay = "30s", multiplier = 2 }
 
+[tools.trellis.publish.repository_series]
+package = "lattice_cli"
+format = "v{series}"
+
 [tools.trellis.changelog]
 # Native engine (§7): fragments in <dir>/unreleased/, version sections in
 # <dir>/<package>/, per-package CHANGELOG.md assembled from them. All
@@ -356,6 +360,15 @@ trellis lockfile refresh [--package <pkg>]
   resolves it, so CI can route on it), and a `series`-only workspace releases
   through `--all-untagged` rather than a tag-push trigger. `tag_mode` sets the
   lifecycle for the workspace; `tag_mode_overrides` sets it per member.
+- A **repository series tag** is separate repository metadata, anchored to one
+  releasable package and independent of package `tag_mode`. Its current series
+  comes from the anchor's stable manifest version. An existing tag moves only
+  when that manifest version differs from the anchor manifest stored at the
+  tag; exact package tags are not a release signal. Entering a new series
+  creates a new tag and preserves the old one. Repository tags are mutable,
+  get no GitHub Release, and never participate in `publish --tag` or
+  `ci tag-package` resolution. The `{name}`-less `series_tag_format` remains a
+  legacy package-series behavior with its ambiguity warning.
 - `publish` performs, per package:
   1. **Idempotency check** — query Hex once; skip if this exact version is already
      published (makes re-runs of a partially failed release safe).

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -571,23 +571,49 @@ fn check_member_glob(workspace: &Workspace, label: &str, pattern: &str, report: 
 /// of what they're versioned at. Warning only on a version collision would go
 /// quiet on exactly the configurations `trellis ci tag-package` still fails on.
 fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
-    let mut seen: std::collections::HashMap<String, &str> = std::collections::HashMap::new();
+    fn insert(
+        seen: &mut std::collections::HashMap<String, (String, bool)>,
+        findings: &mut Vec<Finding>,
+        tag: String,
+        owner: String,
+        legacy_shared: bool,
+        member: Option<&crate::workspace::Member>,
+    ) {
+        if let Some((other, other_legacy_shared)) = seen.get(&tag) {
+            // Preserve the intentionally shared legacy `{name}`-less package
+            // series tag. Its separate ambiguity warning remains below.
+            if legacy_shared && *other_legacy_shared {
+                return;
+            }
+            let mut finding = Finding::error(
+                Check::TagCollision,
+                format!("tag collision: {other} and {owner} both produce tag `{tag}`"),
+            )
+            .at(crate::workspace::GLEAM_TOML);
+            if let Some(member) = member {
+                finding = finding.in_package(&member.name);
+            }
+            findings.push(finding);
+        } else {
+            seen.insert(tag, (owner, legacy_shared));
+        }
+    }
+
+    let mut seen: std::collections::HashMap<String, (String, bool)> =
+        std::collections::HashMap::new();
+    let mut findings = Vec::new();
+
     for member in workspace.members.iter().filter(|m| m.releasable) {
         if member.tag_mode.includes_exact() {
             let tag = workspace.config.format_tag(&member.name, member.version());
-            if let Some(other) = seen.insert(tag.clone(), &member.name) {
-                report.push(
-                    Finding::error(
-                        Check::TagCollision,
-                        format!(
-                            "tag collision: `{other}` and `{}` both produce tag `{tag}`",
-                            member.name
-                        ),
-                    )
-                    .at(format!("{}/gleam.toml", member.rel_path))
-                    .in_package(member.name.clone()),
-                );
-            }
+            insert(
+                &mut seen,
+                &mut findings,
+                tag,
+                format!("package `{}` exact tag", member.name),
+                false,
+                Some(member),
+            );
         }
     }
 
@@ -605,27 +631,22 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
             .join(", ")
     };
 
-    if workspace.config.series_tag_is_repo_wide() {
-        if series_members.len() > 1 {
-            report.push(
-                Finding::warning(
-                    Check::TagCollision,
-                    format!(
-                        "`series_tag_format` `{}` has no {{name}}, so one repository-wide series \
-                         tag covers {}; `trellis ci tag-package` cannot resolve such a tag to one \
-                         package",
-                        workspace.config.publish.series_tag_format,
-                        names(&series_members)
-                    ),
-                )
-                .at(crate::workspace::GLEAM_TOML),
-            );
-        }
-        return;
+    if workspace.config.series_tag_is_repo_wide() && series_members.len() > 1 {
+        findings.push(
+            Finding::warning(
+                Check::TagCollision,
+                format!(
+                    "`series_tag_format` `{}` has no {{name}}, so one repository-wide series \
+                     tag covers {}; `trellis ci tag-package` cannot resolve such a tag to one \
+                     package",
+                    workspace.config.publish.series_tag_format,
+                    names(&series_members)
+                ),
+            )
+            .at(crate::workspace::GLEAM_TOML),
+        );
     }
 
-    let mut sharing: std::collections::BTreeMap<String, Vec<&str>> =
-        std::collections::BTreeMap::new();
     for member in workspace
         .members
         .iter()
@@ -635,22 +656,40 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
             .config
             .format_series_tag(&member.name, member.version())
         {
-            sharing.entry(tag).or_default().push(&member.name);
-        }
-    }
-    for (tag, members) in sharing {
-        if members.len() > 1 {
-            report.push(
-                Finding::error(
-                    Check::TagCollision,
-                    format!(
-                        "series tag collision: {} all produce tag `{tag}`",
-                        names(&members)
-                    ),
-                )
-                .at(crate::workspace::GLEAM_TOML),
+            insert(
+                &mut seen,
+                &mut findings,
+                tag,
+                format!("package `{}` series tag", member.name),
+                workspace.config.series_tag_is_repo_wide(),
+                Some(member),
             );
         }
+    }
+
+    if let Some(repository_series) = &workspace.config.publish.repository_series
+        && let Some(anchor) = workspace
+            .members
+            .iter()
+            .find(|member| member.name == repository_series.package && member.releasable)
+        && let Some(tag) = workspace
+            .config
+            .format_repository_series_tag(anchor.version())
+    {
+        insert(
+            &mut seen,
+            &mut findings,
+            tag,
+            format!(
+                "repository series tag anchored to `{}`",
+                repository_series.package
+            ),
+            false,
+            Some(anchor),
+        );
+    }
+    for finding in findings {
+        report.push(finding);
     }
 }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -573,11 +573,11 @@ fn check_member_glob(workspace: &Workspace, label: &str, pattern: &str, report: 
 fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     fn insert(
         seen: &mut std::collections::HashMap<String, (String, bool)>,
-        findings: &mut Vec<Finding>,
+        report: &mut Report,
         tag: String,
         owner: String,
         legacy_shared: bool,
-        member: Option<&crate::workspace::Member>,
+        member: &crate::workspace::Member,
     ) {
         if let Some((other, other_legacy_shared)) = seen.get(&tag) {
             // Preserve the intentionally shared legacy `{name}`-less package
@@ -585,15 +585,14 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
             if legacy_shared && *other_legacy_shared {
                 return;
             }
-            let mut finding = Finding::error(
-                Check::TagCollision,
-                format!("tag collision: {other} and {owner} both produce tag `{tag}`"),
-            )
-            .at(crate::workspace::GLEAM_TOML);
-            if let Some(member) = member {
-                finding = finding.in_package(&member.name);
-            }
-            findings.push(finding);
+            report.push(
+                Finding::error(
+                    Check::TagCollision,
+                    format!("tag collision: {other} and {owner} both produce tag `{tag}`"),
+                )
+                .at(crate::workspace::GLEAM_TOML)
+                .in_package(&member.name),
+            );
         } else {
             seen.insert(tag, (owner, legacy_shared));
         }
@@ -601,18 +600,17 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
 
     let mut seen: std::collections::HashMap<String, (String, bool)> =
         std::collections::HashMap::new();
-    let mut findings = Vec::new();
 
     for member in workspace.members.iter().filter(|m| m.releasable) {
         if member.tag_mode.includes_exact() {
             let tag = workspace.config.format_tag(&member.name, member.version());
             insert(
                 &mut seen,
-                &mut findings,
+                report,
                 tag,
                 format!("package `{}` exact tag", member.name),
                 false,
-                Some(member),
+                member,
             );
         }
     }
@@ -632,7 +630,7 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     };
 
     if workspace.config.series_tag_is_repo_wide() && series_members.len() > 1 {
-        findings.push(
+        report.push(
             Finding::warning(
                 Check::TagCollision,
                 format!(
@@ -658,11 +656,11 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
         {
             insert(
                 &mut seen,
-                &mut findings,
+                report,
                 tag,
                 format!("package `{}` series tag", member.name),
                 workspace.config.series_tag_is_repo_wide(),
-                Some(member),
+                member,
             );
         }
     }
@@ -678,18 +676,15 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     {
         insert(
             &mut seen,
-            &mut findings,
+            report,
             tag,
             format!(
                 "repository series tag anchored to `{}`",
                 repository_series.package
             ),
             false,
-            Some(anchor),
+            anchor,
         );
-    }
-    for finding in findings {
-        report.push(finding);
     }
 }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -572,19 +572,13 @@ fn check_member_glob(workspace: &Workspace, label: &str, pattern: &str, report: 
 /// quiet on exactly the configurations `trellis ci tag-package` still fails on.
 fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     fn insert(
-        seen: &mut std::collections::HashMap<String, (String, bool)>,
+        seen: &mut std::collections::HashMap<String, String>,
         report: &mut Report,
         tag: String,
         owner: String,
-        legacy_shared: bool,
         member: &crate::workspace::Member,
     ) {
-        if let Some((other, other_legacy_shared)) = seen.get(&tag) {
-            // Preserve the intentionally shared legacy `{name}`-less package
-            // series tag. Its separate ambiguity warning remains below.
-            if legacy_shared && *other_legacy_shared {
-                return;
-            }
+        if let Some(other) = seen.get(&tag) {
             report.push(
                 Finding::error(
                     Check::TagCollision,
@@ -594,12 +588,11 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
                 .in_package(&member.name),
             );
         } else {
-            seen.insert(tag, (owner, legacy_shared));
+            seen.insert(tag, owner);
         }
     }
 
-    let mut seen: std::collections::HashMap<String, (String, bool)> =
-        std::collections::HashMap::new();
+    let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
     for member in workspace.members.iter().filter(|m| m.releasable) {
         if member.tag_mode.includes_exact() {
@@ -609,7 +602,6 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
                 report,
                 tag,
                 format!("package `{}` exact tag", member.name),
-                false,
                 member,
             );
         }
@@ -629,7 +621,8 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
             .join(", ")
     };
 
-    if workspace.config.series_tag_is_repo_wide() && series_members.len() > 1 {
+    let repo_wide = workspace.config.series_tag_is_repo_wide();
+    if repo_wide && series_members.len() > 1 {
         report.push(
             Finding::warning(
                 Check::TagCollision,
@@ -645,6 +638,9 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
         );
     }
 
+    // Members sharing a legacy `{name}`-less series tag is intentional — the
+    // ambiguity warning above covers it — so claim each such tag only once.
+    let mut legacy_claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
     for member in workspace
         .members
         .iter()
@@ -654,37 +650,44 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
             .config
             .format_series_tag(&member.name, member.version())
         {
+            if repo_wide && !legacy_claimed.insert(tag.clone()) {
+                continue;
+            }
             insert(
                 &mut seen,
                 report,
                 tag,
                 format!("package `{}` series tag", member.name),
-                workspace.config.series_tag_is_repo_wide(),
                 member,
             );
         }
     }
 
-    if let Some(repository_series) = &workspace.config.publish.repository_series
-        && let Some(anchor) = workspace
-            .members
-            .iter()
-            .find(|member| member.name == repository_series.package && member.releasable)
-        && let Some(tag) = workspace
+    // The repository tag's collision rule is `tag create`'s namespace check:
+    // it must not look like any package's tag at any version, not merely avoid
+    // the tag strings today's versions happen to produce.
+    if let Some(index) = workspace.repository_series_anchor {
+        let anchor = &workspace.members[index];
+        if let Some(tag) = workspace
             .config
             .format_repository_series_tag(anchor.version())
-    {
-        insert(
-            &mut seen,
-            report,
-            tag,
-            format!(
-                "repository series tag anchored to `{}`",
-                repository_series.package
-            ),
-            false,
-            anchor,
-        );
+            && crate::commands::tag::repository_tag_collides_with_packages(workspace, &tag)
+                .unwrap_or(false)
+        {
+            report.push(
+                Finding::error(
+                    Check::TagCollision,
+                    format!(
+                        "tag collision: repository series tag `{tag}` (anchored to `{}`) \
+                         occupies a package tag namespace; choose a distinct \
+                         `repository_series.format`",
+                        anchor.name
+                    ),
+                )
+                .at(crate::workspace::GLEAM_TOML)
+                .in_package(&anchor.name),
+            );
+        }
     }
 }
 

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -117,17 +117,7 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
         }
     }
     if let Some(repository_series) = &workspace.config.publish.repository_series {
-        let (index, anchor) = workspace
-            .members
-            .iter()
-            .enumerate()
-            .find(|(_, member)| member.name == repository_series.package)
-            .with_context(|| {
-                format!(
-                    "repository series anchor package `{}` is not a workspace member",
-                    repository_series.package
-                )
-            })?;
+        let (index, anchor) = anchor_member(workspace, repository_series)?;
         let anchor_version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
         if let Some(tag) = workspace
             .config
@@ -151,6 +141,24 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
         }
     }
     Ok(planned)
+}
+
+/// The workspace member the repository series tag is anchored to.
+fn anchor_member<'a>(
+    workspace: &'a Workspace,
+    repository_series: &crate::config::RepositorySeriesConfig,
+) -> Result<(usize, &'a crate::workspace::Member)> {
+    workspace
+        .members
+        .iter()
+        .enumerate()
+        .find(|(_, member)| member.name == repository_series.package)
+        .with_context(|| {
+            format!(
+                "repository series anchor package `{}` is not a workspace member",
+                repository_series.package
+            )
+        })
 }
 
 /// A repository tag must never occupy a package-tag namespace. `doctor`
@@ -287,17 +295,7 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
         let Some(repository_series) = &workspace.config.publish.repository_series else {
             return Ok(());
         };
-        let (_, anchor) = workspace
-            .members
-            .iter()
-            .enumerate()
-            .find(|(_, member)| member.name == repository_series.package)
-            .with_context(|| {
-                format!(
-                    "repository series anchor package `{}` is not a workspace member",
-                    repository_series.package
-                )
-            })?;
+        let (_, anchor) = anchor_member(workspace, repository_series)?;
         let anchor_version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
         let Some(tag) = workspace
             .config
@@ -626,11 +624,7 @@ impl ResolvedTag {
 /// series), so `lat_core-v0.3` doesn't resolve as version "0.3".
 pub fn resolve_tag(workspace: &Workspace, tag: &str) -> Result<ResolvedTag> {
     if let Some(repository_series) = &workspace.config.publish.repository_series {
-        let anchor = workspace
-            .members
-            .iter()
-            .enumerate()
-            .find(|(_, member)| member.name == repository_series.package)
+        let anchor = anchor_member(workspace, repository_series)
             .map(|(index, member)| vec![(index, member.name.as_str())])
             .unwrap_or_default();
         if !match_tag_template(

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -116,62 +116,46 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
             }
         }
     }
-    if let Some(repository_series) = &workspace.config.publish.repository_series {
-        let (index, anchor) = anchor_member(workspace, repository_series)?;
-        let anchor_version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
-        if let Some(tag) = workspace
-            .config
-            .format_repository_series_tag(&anchor_version)
-        {
-            reject_repository_tag_package_collision(workspace, &tag)?;
-            let action = if !existing.contains(tag.as_str()) {
-                TagAction::Create
-            } else if manifest_version_at_revision(workspace, anchor, &tag)? == anchor_version {
-                TagAction::UpToDate
-            } else {
-                TagAction::Move
-            };
-            planned.push(PlannedTag {
-                member: index,
-                version: anchor_version,
-                tag,
-                kind: TagKind::RepositorySeries,
-                action,
-            });
-        }
+    if let Some((index, anchor_version, tag)) = repository_series_target(workspace)? {
+        reject_repository_tag_package_collision(workspace, &tag)?;
+        let anchor = &workspace.members[index];
+        let action = if !existing.contains(tag.as_str()) {
+            TagAction::Create
+        } else if manifest_version_at_revision(workspace, anchor, &tag)? == anchor_version {
+            TagAction::UpToDate
+        } else {
+            TagAction::Move
+        };
+        planned.push(PlannedTag {
+            member: index,
+            version: anchor_version,
+            tag,
+            kind: TagKind::RepositorySeries,
+            action,
+        });
     }
     Ok(planned)
 }
 
-/// The workspace member the repository series tag is anchored to.
-fn anchor_member<'a>(
-    workspace: &'a Workspace,
-    repository_series: &crate::config::RepositorySeriesConfig,
-) -> Result<(usize, &'a crate::workspace::Member)> {
-    workspace
-        .members
-        .iter()
-        .enumerate()
-        .find(|(_, member)| member.name == repository_series.package)
-        .with_context(|| {
-            format!(
-                "repository series anchor package `{}` is not a workspace member",
-                repository_series.package
-            )
-        })
+/// The anchor member's index, its committed (HEAD) version, and the repository
+/// tag that version calls for. `None` when the feature is unconfigured or the
+/// anchor is on a prerelease.
+fn repository_series_target(workspace: &Workspace) -> Result<Option<(usize, String, String)>> {
+    let Some(index) = workspace.repository_series_anchor else {
+        return Ok(None);
+    };
+    let anchor = &workspace.members[index];
+    let version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
+    Ok(workspace
+        .config
+        .format_repository_series_tag(&version)
+        .map(|tag| (index, version, tag)))
 }
 
-/// A repository tag must never occupy a package-tag namespace. `doctor`
-/// reports the same configuration mistake, but mutating commands defend the
-/// immutable package tags even when users have not run it first.
-fn reject_repository_tag_package_collision(workspace: &Workspace, tag: &str) -> Result<()> {
-    let all_packages: Vec<(usize, &str)> = workspace
-        .members
-        .iter()
-        .enumerate()
-        .filter(|(_, member)| member.releasable)
-        .map(|(index, member)| (index, member.name.as_str()))
-        .collect();
+/// Does `tag` fall inside the exact or series tag namespace of any releasable
+/// package, for any version it could ever be released at?
+pub fn repository_tag_collides_with_packages(workspace: &Workspace, tag: &str) -> Result<bool> {
+    let all_packages = candidates(workspace, |_| true);
     let exact = match_tag_template(
         &all_packages,
         tag,
@@ -186,7 +170,14 @@ fn reject_repository_tag_package_collision(workspace: &Workspace, tag: &str) -> 
         "{series}",
         is_series,
     )?;
-    if !exact.is_empty() || !series.is_empty() {
+    Ok(!exact.is_empty() || !series.is_empty())
+}
+
+/// A repository tag must never occupy a package-tag namespace. `doctor`
+/// reports the same configuration mistake, but mutating commands defend the
+/// immutable package tags even when users have not run it first.
+fn reject_repository_tag_package_collision(workspace: &Workspace, tag: &str) -> Result<()> {
+    if repository_tag_collides_with_packages(workspace, tag)? {
         bail!(
             "repository series tag `{tag}` collides with a package tag namespace; \
              choose a distinct `repository_series.format`"
@@ -288,60 +279,6 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
         return Ok(());
     }
 
-    /// Reconcile the repository series tag from origin before planning a push.
-    /// The remote anchor version is authoritative: a stale clone may advance it,
-    /// but may never move it backward.
-    fn reconcile_remote_repository_series_tag(workspace: &Workspace) -> Result<()> {
-        let Some(repository_series) = &workspace.config.publish.repository_series else {
-            return Ok(());
-        };
-        let (_, anchor) = anchor_member(workspace, repository_series)?;
-        let anchor_version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
-        let Some(tag) = workspace
-            .config
-            .format_repository_series_tag(&anchor_version)
-        else {
-            return Ok(());
-        };
-        if remote_tag_oid(&workspace.root, &tag)?.is_none() {
-            return Ok(());
-        }
-
-        const REMOTE_REF: &str = "refs/trellis/repository-series";
-        let source = format!("refs/tags/{tag}:{REMOTE_REF}");
-        git_stdout(&workspace.root, &["fetch", "--force", "origin", &source])?;
-        let reconcile = (|| {
-            let remote_version = manifest_version_at_revision(workspace, anchor, REMOTE_REF)?;
-            let head_version = semver::Version::parse(&anchor_version).with_context(|| {
-                format!("invalid anchor package version `{anchor_version}` at HEAD")
-            })?;
-            let remote_version_parsed =
-                semver::Version::parse(&remote_version).with_context(|| {
-                    format!(
-                        "invalid anchor package version `{remote_version}` at remote tag `{tag}`"
-                    )
-                })?;
-            if remote_version_parsed > head_version {
-                bail!(
-                    "repository series tag `{tag}` on origin is anchored at newer {} version \
-                     `{remote_version}`; refusing to move it backward to `{anchor_version}`",
-                    anchor.name
-                );
-            }
-
-            let remote_oid = rev_parse(&workspace.root, REMOTE_REF, REMOTE_REF)?
-                .context("fetched repository series tag has no object ID")?;
-            if local_tag_oid(&workspace.root, &tag)?.as_deref() != Some(remote_oid.as_str()) {
-                let local_ref = format!("refs/tags/{tag}");
-                git_stdout(&workspace.root, &["update-ref", &local_ref, &remote_oid])?;
-                crate::status!("fetched {tag}");
-            }
-            Ok(())
-        })();
-        let cleanup = git_stdout(&workspace.root, &["update-ref", "-d", REMOTE_REF]);
-        reconcile.and(cleanup.map(|_| ()))
-    }
-
     for planned in targets {
         match planned.kind {
             TagKind::Exact => create_exact_tag(workspace, planned, options, push)?,
@@ -349,6 +286,42 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
                 move_series_tag(workspace, planned, push)?
             }
         }
+    }
+    Ok(())
+}
+
+/// Reconcile the repository series tag from origin before planning a push.
+/// The remote anchor version is authoritative: a stale clone may advance it,
+/// but may never move it backward.
+fn reconcile_remote_repository_series_tag(workspace: &Workspace) -> Result<()> {
+    let Some((index, anchor_version, tag)) = repository_series_target(workspace)? else {
+        return Ok(());
+    };
+    let anchor = &workspace.members[index];
+    let Some(remote_oid) = remote_tag_oid(&workspace.root, &tag)? else {
+        return Ok(());
+    };
+
+    // A source-only refspec fetches the tag object into FETCH_HEAD without
+    // touching a diverged local tag.
+    let reference = format!("refs/tags/{tag}");
+    git_stdout(&workspace.root, &["fetch", "origin", &reference])?;
+    let remote_version = manifest_version_at_revision(workspace, anchor, "FETCH_HEAD")?;
+    let head_version = semver::Version::parse(&anchor_version)
+        .with_context(|| format!("invalid anchor package version `{anchor_version}` at HEAD"))?;
+    let remote_version_parsed = semver::Version::parse(&remote_version).with_context(|| {
+        format!("invalid anchor package version `{remote_version}` at remote tag `{tag}`")
+    })?;
+    if remote_version_parsed > head_version {
+        bail!(
+            "repository series tag `{tag}` on origin is anchored at newer {} version \
+             `{remote_version}`; refusing to move it backward to `{anchor_version}`",
+            anchor.name
+        );
+    }
+    if local_tag_oid(&workspace.root, &tag)?.as_deref() != Some(remote_oid.as_str()) {
+        git_stdout(&workspace.root, &["update-ref", &reference, &remote_oid])?;
+        crate::status!("fetched {tag}");
     }
     Ok(())
 }
@@ -624,11 +597,11 @@ impl ResolvedTag {
 /// series), so `lat_core-v0.3` doesn't resolve as version "0.3".
 pub fn resolve_tag(workspace: &Workspace, tag: &str) -> Result<ResolvedTag> {
     if let Some(repository_series) = &workspace.config.publish.repository_series {
-        let anchor = anchor_member(workspace, repository_series)
-            .map(|(index, member)| vec![(index, member.name.as_str())])
-            .unwrap_or_default();
+        let anchor = workspace
+            .repository_series_anchor
+            .map(|index| (index, workspace.members[index].name.as_str()));
         if !match_tag_template(
-            &anchor,
+            anchor.as_slice(),
             tag,
             &repository_series.format,
             "{series}",

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -4,9 +4,11 @@
 //! A member tags in one of two lifecycles, chosen by `tag_mode`: immutable
 //! `{name}-v{version}` tags, created once and never touched again, and moving
 //! `{name}-v{series}` tags, force-moved to the release commit every time that
-//! series releases. Only the immutable ones can carry a GitHub Release — a
-//! release bound to a moving tag would silently retarget.
+//! series releases. An optional repository series tag follows one anchor
+//! package's manifest version independently of those modes. Only immutable
+//! tags can carry a GitHub Release.
 
+use crate::gleam::GleamManifest;
 use crate::json::TagPlanDocument;
 use crate::tools;
 use crate::workspace::Workspace;
@@ -25,6 +27,8 @@ pub enum TagKind {
     Exact,
     /// A moving `series_tag_format` tag naming a release series.
     Series,
+    /// A moving repository tag whose lifecycle is anchored to one package.
+    RepositorySeries,
 }
 
 /// The work `tag create` would do for a planned tag, from local state alone.
@@ -44,15 +48,15 @@ pub enum TagAction {
 pub struct PlannedTag {
     /// Index into `workspace.members`.
     pub member: usize,
+    pub version: String,
     pub tag: String,
     pub kind: TagKind,
     pub action: TagAction,
 }
 
 /// Every tag the current versions call for, in topological order, each with
-/// the work it needs. A repository-wide series tag (a `series_tag_format`
-/// without `{name}`) is claimed by the first member that would produce it, so
-/// it is moved once rather than once per package.
+/// the work it needs. A legacy repository-wide package series tag (a
+/// `series_tag_format` without `{name}`) is still claimed only once.
 fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
     let existing = git_stdout(&workspace.root, &["tag", "--list"])?;
     let existing: HashSet<&str> = existing
@@ -81,6 +85,7 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
             if claimed.insert(tag.clone()) {
                 planned.push(PlannedTag {
                     member: index,
+                    version: member.version().to_string(),
                     tag,
                     kind: TagKind::Exact,
                     action,
@@ -103,6 +108,7 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
             if claimed.insert(tag.clone()) {
                 planned.push(PlannedTag {
                     member: index,
+                    version: member.version().to_string(),
                     tag,
                     kind: TagKind::Series,
                     action,
@@ -110,7 +116,103 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
             }
         }
     }
+    if let Some(repository_series) = &workspace.config.publish.repository_series {
+        let (index, anchor) = workspace
+            .members
+            .iter()
+            .enumerate()
+            .find(|(_, member)| member.name == repository_series.package)
+            .with_context(|| {
+                format!(
+                    "repository series anchor package `{}` is not a workspace member",
+                    repository_series.package
+                )
+            })?;
+        let anchor_version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
+        if let Some(tag) = workspace
+            .config
+            .format_repository_series_tag(&anchor_version)
+        {
+            reject_repository_tag_package_collision(workspace, &tag)?;
+            let action = if !existing.contains(tag.as_str()) {
+                TagAction::Create
+            } else if manifest_version_at_revision(workspace, anchor, &tag)? == anchor_version {
+                TagAction::UpToDate
+            } else {
+                TagAction::Move
+            };
+            planned.push(PlannedTag {
+                member: index,
+                version: anchor_version,
+                tag,
+                kind: TagKind::RepositorySeries,
+                action,
+            });
+        }
+    }
     Ok(planned)
+}
+
+/// A repository tag must never occupy a package-tag namespace. `doctor`
+/// reports the same configuration mistake, but mutating commands defend the
+/// immutable package tags even when users have not run it first.
+fn reject_repository_tag_package_collision(workspace: &Workspace, tag: &str) -> Result<()> {
+    let all_packages: Vec<(usize, &str)> = workspace
+        .members
+        .iter()
+        .enumerate()
+        .filter(|(_, member)| member.releasable)
+        .map(|(index, member)| (index, member.name.as_str()))
+        .collect();
+    let exact = match_tag_template(
+        &all_packages,
+        tag,
+        &workspace.config.publish.tag_format,
+        "{version}",
+        |captured| semver::Version::parse(captured).is_ok(),
+    )?;
+    let series = match_tag_template(
+        &all_packages,
+        tag,
+        &workspace.config.publish.series_tag_format,
+        "{series}",
+        is_series,
+    )?;
+    if !exact.is_empty() || !series.is_empty() {
+        bail!(
+            "repository series tag `{tag}` collides with a package tag namespace; \
+             choose a distinct `repository_series.format`"
+        );
+    }
+    Ok(())
+}
+
+/// Read the anchor's manifest from the commit named by an existing repository
+/// tag. The version in that file — not package exact tags or `tag_mode` — is
+/// the repository tag's release signal.
+fn manifest_version_at_revision(
+    workspace: &Workspace,
+    anchor: &crate::workspace::Member,
+    revision: &str,
+) -> Result<String> {
+    let manifest = if anchor.rel_path == "." {
+        crate::workspace::GLEAM_TOML.to_string()
+    } else {
+        format!("{}/{}", anchor.rel_path, crate::workspace::GLEAM_TOML)
+    };
+    let object = format!("{revision}:{manifest}");
+    let text = git_stdout(&workspace.root, &["show", &object]).with_context(|| {
+        format!(
+            "cannot read repository series anchor manifest `{manifest}` at revision `{revision}`"
+        )
+    })?;
+    GleamManifest::parse(&text)
+        .with_context(|| {
+            format!(
+                "cannot parse repository series anchor manifest `{manifest}` at revision `{revision}`"
+            )
+        })
+        .map(|manifest| manifest.version)
 }
 
 pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
@@ -127,7 +229,7 @@ pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
                     let member = &workspace.members[planned.member];
                     crate::json::PlannedTag {
                         name: &member.name,
-                        version: member.version(),
+                        version: &planned.version,
                         tag: &planned.tag,
                         kind: planned.kind,
                         action: planned.action,
@@ -148,7 +250,7 @@ pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
             crate::status!(
                 "{}: {} {verb} {}",
                 member.name,
-                member.version(),
+                planned.version,
                 planned.tag
             );
         }
@@ -163,6 +265,9 @@ pub struct CreateOptions {
 
 pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
     let push = options.push || options.github_release;
+    if push {
+        reconcile_remote_repository_series_tag(workspace)?;
+    }
     let planned = plan_tags(workspace)?;
     // Without a remote to reconcile, a tag that already points where it
     // should is nothing to do; with one, it may still be missing from origin.
@@ -175,10 +280,76 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
         return Ok(());
     }
 
+    /// Reconcile the repository series tag from origin before planning a push.
+    /// The remote anchor version is authoritative: a stale clone may advance it,
+    /// but may never move it backward.
+    fn reconcile_remote_repository_series_tag(workspace: &Workspace) -> Result<()> {
+        let Some(repository_series) = &workspace.config.publish.repository_series else {
+            return Ok(());
+        };
+        let (_, anchor) = workspace
+            .members
+            .iter()
+            .enumerate()
+            .find(|(_, member)| member.name == repository_series.package)
+            .with_context(|| {
+                format!(
+                    "repository series anchor package `{}` is not a workspace member",
+                    repository_series.package
+                )
+            })?;
+        let anchor_version = manifest_version_at_revision(workspace, anchor, "HEAD")?;
+        let Some(tag) = workspace
+            .config
+            .format_repository_series_tag(&anchor_version)
+        else {
+            return Ok(());
+        };
+        if remote_tag_oid(&workspace.root, &tag)?.is_none() {
+            return Ok(());
+        }
+
+        const REMOTE_REF: &str = "refs/trellis/repository-series";
+        let source = format!("refs/tags/{tag}:{REMOTE_REF}");
+        git_stdout(&workspace.root, &["fetch", "--force", "origin", &source])?;
+        let reconcile = (|| {
+            let remote_version = manifest_version_at_revision(workspace, anchor, REMOTE_REF)?;
+            let head_version = semver::Version::parse(&anchor_version).with_context(|| {
+                format!("invalid anchor package version `{anchor_version}` at HEAD")
+            })?;
+            let remote_version_parsed =
+                semver::Version::parse(&remote_version).with_context(|| {
+                    format!(
+                        "invalid anchor package version `{remote_version}` at remote tag `{tag}`"
+                    )
+                })?;
+            if remote_version_parsed > head_version {
+                bail!(
+                    "repository series tag `{tag}` on origin is anchored at newer {} version \
+                     `{remote_version}`; refusing to move it backward to `{anchor_version}`",
+                    anchor.name
+                );
+            }
+
+            let remote_oid = rev_parse(&workspace.root, REMOTE_REF, REMOTE_REF)?
+                .context("fetched repository series tag has no object ID")?;
+            if local_tag_oid(&workspace.root, &tag)?.as_deref() != Some(remote_oid.as_str()) {
+                let local_ref = format!("refs/tags/{tag}");
+                git_stdout(&workspace.root, &["update-ref", &local_ref, &remote_oid])?;
+                crate::status!("fetched {tag}");
+            }
+            Ok(())
+        })();
+        let cleanup = git_stdout(&workspace.root, &["update-ref", "-d", REMOTE_REF]);
+        reconcile.and(cleanup.map(|_| ()))
+    }
+
     for planned in targets {
         match planned.kind {
             TagKind::Exact => create_exact_tag(workspace, planned, options, push)?,
-            TagKind::Series => move_series_tag(workspace, planned, push)?,
+            TagKind::Series | TagKind::RepositorySeries => {
+                move_series_tag(workspace, planned, push)?
+            }
         }
     }
     Ok(())
@@ -217,7 +388,7 @@ fn create_exact_tag(
                 "-a".into(),
                 tag.clone(),
                 "-m".into(),
-                format!("{} {}", member.name, member.version()),
+                format!("{} {}", member.name, planned.version),
             ]);
             let args: Vec<&str> = args.iter().map(String::as_str).collect();
             git_stdout(&workspace.root, &args)?;
@@ -274,7 +445,7 @@ fn move_series_tag(workspace: &Workspace, planned: &PlannedTag, push: bool) -> R
             "-a".into(),
             tag.clone(),
             "-m".into(),
-            format!("{} {}", member.name, member.version()),
+            format!("{} {}", member.name, planned.version),
         ]);
         let args: Vec<&str> = args.iter().map(String::as_str).collect();
         git_stdout(&workspace.root, &args)?;
@@ -289,8 +460,17 @@ fn move_series_tag(workspace: &Workspace, planned: &PlannedTag, push: bool) -> R
         // this also catches "already where it belongs, but origin disagrees".
         let local_oid = local_tag_oid(&workspace.root, tag)?;
         if local_oid != remote_oid {
-            git_stdout(&workspace.root, &["push", "--force", "origin", tag])
-                .with_context(|| format!("failed to push tag {tag}"))?;
+            if planned.kind == TagKind::RepositorySeries {
+                let lease = format!(
+                    "--force-with-lease=refs/tags/{tag}:{}",
+                    remote_oid.as_deref().unwrap_or("")
+                );
+                git_stdout(&workspace.root, &["push", &lease, "origin", tag])
+                    .with_context(|| format!("failed to push tag {tag}"))?;
+            } else {
+                git_stdout(&workspace.root, &["push", "--force", "origin", tag])
+                    .with_context(|| format!("failed to push tag {tag}"))?;
+            }
             if remote_oid.is_none() {
                 crate::status!("pushed {tag}");
             } else {
@@ -445,6 +625,26 @@ impl ResolvedTag {
 /// if what the template captured is actually a version (or, for series tags, a
 /// series), so `lat_core-v0.3` doesn't resolve as version "0.3".
 pub fn resolve_tag(workspace: &Workspace, tag: &str) -> Result<ResolvedTag> {
+    if let Some(repository_series) = &workspace.config.publish.repository_series {
+        let anchor = workspace
+            .members
+            .iter()
+            .enumerate()
+            .find(|(_, member)| member.name == repository_series.package)
+            .map(|(index, member)| vec![(index, member.name.as_str())])
+            .unwrap_or_default();
+        if !match_tag_template(
+            &anchor,
+            tag,
+            &repository_series.format,
+            "{series}",
+            is_series,
+        )?
+        .is_empty()
+        {
+            bail!("tag `{tag}` is a repository series tag and does not identify a package release");
+        }
+    }
     let exact = match_tag_template(
         &candidates(workspace, |mode| mode.includes_exact()),
         tag,

--- a/src/config.rs
+++ b/src/config.rs
@@ -641,13 +641,22 @@ impl ConfigFile {
                 self.publish.series_tag_format
             );
         }
-        if let Some(repository_series) = &self.publish.repository_series
-            && !repository_series.format.contains("{series}")
-        {
-            bail!(
-                "`repository_series.format` `{}` has no {{series}} placeholder",
-                repository_series.format
-            );
+        if let Some(repository_series) = &self.publish.repository_series {
+            if !repository_series.format.contains("{series}") {
+                bail!(
+                    "`repository_series.format` `{}` has no {{series}} placeholder",
+                    repository_series.format
+                );
+            }
+            // `{series}` is the template's only placeholder; a `{name}` would
+            // be written into the tag literally.
+            if repository_series.format.contains("{name}") {
+                bail!(
+                    "`repository_series.format` `{}` cannot contain {{name}}; \
+                     the tag is repository-wide, not per-package",
+                    repository_series.format
+                );
+            }
         }
         let dependency_kind = &self.changelog.dependency_kind;
         if !self
@@ -1282,6 +1291,21 @@ mod tests {
         let message = format!("{err:#}");
         assert!(message.contains("`repository_series.format`"), "{message}");
         assert!(message.contains("{series}"), "{message}");
+    }
+
+    #[test]
+    fn repository_series_format_rejects_the_name_placeholder() {
+        let err = ConfigFile::from_gleam_toml(
+            r#"
+            [tools.trellis.publish.repository_series]
+            package = "core"
+            format = "{name}-v{series}"
+            "#,
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("`repository_series.format`"), "{message}");
+        assert!(message.contains("{name}"), "{message}");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,6 +224,9 @@ pub struct PublishConfig {
     /// member matching globs under two different modes is an error.
     #[serde(default, alias = "tag-mode-overrides")]
     pub tag_mode_overrides: BTreeMap<String, Vec<String>>,
+    /// One moving repository tag, with its series and release signal taken
+    /// from the named package. Independent of package tag modes.
+    pub repository_series: Option<RepositorySeriesConfig>,
     /// How a path dep is rewritten to a Hex requirement at publish time.
     #[serde(default, alias = "path-dep-requirement")]
     pub path_dep_requirement: PathDepRequirement,
@@ -239,10 +242,20 @@ impl Default for PublishConfig {
             series_tag_format: default_series_tag_format(),
             tag_mode: TagMode::default(),
             tag_mode_overrides: BTreeMap::new(),
+            repository_series: None,
             path_dep_requirement: PathDepRequirement::default(),
             retry: RetryConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RepositorySeriesConfig {
+    /// Package whose stable manifest version determines the repository series.
+    pub package: String,
+    /// Repository tag template; `{series}` is substituted.
+    pub format: String,
 }
 
 fn default_tag_format() -> String {
@@ -628,6 +641,14 @@ impl ConfigFile {
                 self.publish.series_tag_format
             );
         }
+        if let Some(repository_series) = &self.publish.repository_series
+            && !repository_series.format.contains("{series}")
+        {
+            bail!(
+                "`repository_series.format` `{}` has no {{series}} placeholder",
+                repository_series.format
+            );
+        }
         let dependency_kind = &self.changelog.dependency_kind;
         if !self
             .changelog
@@ -677,6 +698,13 @@ impl ConfigFile {
     /// series-mode member rather than one per package.
     pub fn series_tag_is_repo_wide(&self) -> bool {
         !self.publish.series_tag_format.contains("{name}")
+    }
+
+    /// The anchored repository tag for `version`, or `None` when the feature
+    /// is unconfigured or the anchor is on a prerelease.
+    pub fn format_repository_series_tag(&self, version: &str) -> Option<String> {
+        let repository_series = self.publish.repository_series.as_ref()?;
+        series_of(version).map(|series| repository_series.format.replace("{series}", &series))
     }
 }
 
@@ -1212,6 +1240,48 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err:#}").contains("{series}"), "{err:#}");
+    }
+
+    #[test]
+    fn parses_and_formats_repository_series() {
+        let config = ConfigFile::from_gleam_toml(
+            r#"
+            [tools.trellis.publish.repository_series]
+            package = "core"
+            format = "v{series}"
+            "#,
+        )
+        .unwrap();
+        let repository_series = config.publish.repository_series.as_ref().unwrap();
+        assert_eq!(repository_series.package, "core");
+        assert_eq!(repository_series.format, "v{series}");
+        assert_eq!(
+            config.format_repository_series_tag("0.4.3").as_deref(),
+            Some("v0.4")
+        );
+        assert_eq!(config.format_repository_series_tag("0.4.3-rc.1"), None);
+    }
+
+    #[test]
+    fn repository_series_is_optional() {
+        let config = ConfigFile::from_gleam_toml("[tools.trellis]").unwrap();
+        assert!(config.publish.repository_series.is_none());
+        assert_eq!(config.format_repository_series_tag("1.2.3"), None);
+    }
+
+    #[test]
+    fn repository_series_format_must_carry_the_series_placeholder() {
+        let err = ConfigFile::from_gleam_toml(
+            r#"
+            [tools.trellis.publish.repository_series]
+            package = "core"
+            format = "latest"
+            "#,
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+        assert!(message.contains("`repository_series.format`"), "{message}");
+        assert!(message.contains("{series}"), "{message}");
     }
 
     #[test]

--- a/src/json.rs
+++ b/src/json.rs
@@ -595,7 +595,7 @@ pub struct TagPlanDocument<'a> {
 }
 
 impl TagPlanDocument<'_> {
-    pub const SCHEMA: &'static str = "trellis.tag_plan/1";
+    pub const SCHEMA: &'static str = "trellis.tag_plan/2";
 }
 
 /// `trellis ci tag-package --json`.

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -343,6 +343,36 @@ impl Workspace {
             }
         }
 
+        if let Some(repository_series) = &config.publish.repository_series {
+            match members
+                .iter()
+                .find(|member| member.name == repository_series.package)
+            {
+                None => diagnostics.push(
+                    Finding::error(
+                        Check::WorkspaceConfig,
+                        format!(
+                            "repository series anchor package `{}` is not a workspace member",
+                            repository_series.package
+                        ),
+                    )
+                    .at(GLEAM_TOML),
+                ),
+                Some(member) if !member.releasable => diagnostics.push(
+                    Finding::error(
+                        Check::ReleaseBoundary,
+                        format!(
+                            "repository series anchor package `{}` is excluded from release",
+                            repository_series.package
+                        ),
+                    )
+                    .at(GLEAM_TOML)
+                    .in_package(&member.name),
+                ),
+                Some(_) => {}
+            }
+        }
+
         // Resolve path dependencies between members into graph edges.
         let path_to_idx: HashMap<PathBuf, usize> = members
             .iter()

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -41,6 +41,11 @@ pub struct Workspace {
     pub configless: bool,
     /// Members in topological order (dependencies before dependents).
     pub members: Vec<Member>,
+    /// Index of the repository series anchor member. `None` when the feature
+    /// is unconfigured — or, under doctor's lenient load, when the configured
+    /// anchor is missing or unreleasable (an error diagnostic either way, so
+    /// strict-loading commands never run without it).
+    pub repository_series_anchor: Option<usize>,
     /// Direct workspace dependencies, indexed like `members`.
     deps: Vec<Vec<usize>>,
     /// Direct workspace dependents, indexed like `members`.
@@ -459,11 +464,22 @@ impl Workspace {
             list.sort_unstable();
         }
 
+        let repository_series_anchor =
+            config
+                .publish
+                .repository_series
+                .as_ref()
+                .and_then(|series| {
+                    members
+                        .iter()
+                        .position(|member| member.name == series.package && member.releasable)
+                });
         let workspace = Workspace {
             root: root.to_path_buf(),
             config,
             configless,
             members,
+            repository_series_anchor,
             deps,
             dependents,
         };

--- a/tests/json_contract.rs
+++ b/tests/json_contract.rs
@@ -197,6 +197,14 @@ fn tag_plan_json_contract() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
     copy_fixture_to(root);
+    let manifest = root.join("gleam.toml");
+    let mut config = fs::read_to_string(&manifest).unwrap();
+    config.push_str(
+        "\n[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\n\
+         format = \"repo-v{series}\"\n",
+    );
+    fs::write(manifest, config).unwrap();
     init_repo(root);
     // lat_core is already tagged, so it drops out of the plan.
     git(root, &["tag", "-a", "lat_core-v1.2.0", "-m", "existing"]);

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -580,6 +580,11 @@ fn publish_rejects_unreleasable_package() {
 
 // ---- series tags -----------------------------------------------------------
 
+/// The repository-series config the tag tests share: `lat_cli` anchoring
+/// `repo-v{series}`.
+const REPO_SERIES: &str = "[tools.trellis.publish.repository_series]\n\
+     package = \"lat_cli\"\nformat = \"repo-v{series}\"";
+
 /// The basic fixture with `[tools.trellis.publish]` replaced by `publish`, in
 /// a git repo with a bare origin. The returned remote must outlive the test.
 fn series_repo(root: &Path, publish: &str) -> tempfile::TempDir {
@@ -913,12 +918,7 @@ fn doctor_warns_about_a_repo_wide_series_tag_whatever_the_versions() {
 fn repository_series_moves_only_when_the_anchor_manifest_version_changes() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let _remote = series_repo(
-        root,
-        "tag_mode = \"exact\"\n\
-         [tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let _remote = series_repo(root, &format!("tag_mode = \"exact\"\n{REPO_SERIES}"));
 
     trellis(root)
         .args(["tag", "create"])
@@ -961,11 +961,7 @@ fn repository_series_moves_only_when_the_anchor_manifest_version_changes() {
 fn repository_series_transition_keeps_the_old_tag_and_skips_prereleases() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let _remote = series_repo(
-        root,
-        "[tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let _remote = series_repo(root, REPO_SERIES);
     trellis(root).args(["tag", "create"]).assert().success();
     let old = commit_of(root, "repo-v0.3");
 
@@ -985,11 +981,7 @@ fn repository_series_transition_keeps_the_old_tag_and_skips_prereleases() {
 fn repository_series_uses_committed_anchor_version_not_worktree_edits() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let _remote = series_repo(
-        root,
-        "[tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let _remote = series_repo(root, REPO_SERIES);
     trellis(root).args(["tag", "create"]).assert().success();
     let tagged = commit_of(root, "repo-v0.3");
 
@@ -1006,11 +998,7 @@ fn repository_series_uses_committed_anchor_version_not_worktree_edits() {
 fn repository_series_fetches_a_remote_only_tag_before_planning_a_push() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let remote = series_repo(
-        root,
-        "[tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let remote = series_repo(root, REPO_SERIES);
     trellis(root)
         .args(["tag", "create", "--push"])
         .assert()
@@ -1039,11 +1027,7 @@ fn repository_series_fetches_a_remote_only_tag_before_planning_a_push() {
 fn repository_series_refuses_to_move_a_newer_remote_tag_backward() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let _remote = series_repo(
-        root,
-        "[tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let _remote = series_repo(root, REPO_SERIES);
     trellis(root)
         .args(["tag", "create", "--push"])
         .assert()
@@ -1161,11 +1145,7 @@ fn repository_series_anchor_and_namespace_are_validated_by_doctor() {
 fn repository_series_is_force_pushed_and_gets_no_github_release() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let _remote = series_repo(
-        root,
-        "[tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let _remote = series_repo(root, REPO_SERIES);
     let gh = install_fake_gh(root);
     trellis(root)
         .env("TRELLIS_GH_BIN", &gh)
@@ -1196,11 +1176,7 @@ fn repository_series_is_force_pushed_and_gets_no_github_release() {
 fn repository_series_reports_an_unreadable_historical_anchor_manifest() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
-    let _remote = series_repo(
-        root,
-        "[tools.trellis.publish.repository_series]\n\
-         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
-    );
+    let _remote = series_repo(root, REPO_SERIES);
     git(root, &["checkout", "-q", "-b", "missing-anchor"]);
     git(root, &["rm", "-q", "packages/lat_cli/gleam.toml"]);
     git(root, &["commit", "-qm", "remove anchor manifest"]);

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -199,7 +199,7 @@ fn tag_plan_lists_untagged_versions_and_create_tags_them() {
         .unwrap();
     assert!(output.status.success());
     let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(document["schema"], "trellis.tag_plan/1");
+    assert_eq!(document["schema"], "trellis.tag_plan/2");
     let plan = document["tags"].as_array().unwrap();
     let names: Vec<&str> = plan.iter().map(|p| p["name"].as_str().unwrap()).collect();
     // package_a is @release-excluded; lat_core already tagged.
@@ -624,12 +624,29 @@ fn git_stdout(dir: &Path, args: &[&str]) -> String {
         .current_dir(dir)
         .output()
         .unwrap();
-    assert!(output.status.success(), "git {args:?} failed");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}: {}",
+        dir.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
 fn commit_of(dir: &Path, revision: &str) -> String {
     git_stdout(dir, &["rev-parse", &format!("{revision}^{{commit}}")])
+}
+
+fn commit_of_bare(dir: &Path, revision: &str) -> String {
+    git_stdout(
+        Path::new("/"),
+        &[
+            "--git-dir",
+            dir.to_str().unwrap(),
+            "rev-parse",
+            &format!("{revision}^{{commit}}"),
+        ],
+    )
 }
 
 #[test]
@@ -640,7 +657,7 @@ fn series_tag_moves_with_each_release_while_exact_tags_stay_put() {
         root,
         "tag_mode_overrides = { both = [\"packages/lat_cli\"] }",
     );
-    let remote = remote.path();
+    let remote_path = remote.path().to_path_buf();
     set_version(root, "lat_cli", "0.0.1");
     git(root, &["commit", "-qam", "lat_cli 0.0.1"]);
 
@@ -679,8 +696,8 @@ fn series_tag_moves_with_each_release_while_exact_tags_stay_put() {
     );
     assert_eq!(commit_of(root, "lat_cli-v0.0.2"), second);
     // Origin has the move too, not just the local repo.
-    assert_eq!(commit_of(remote, "lat_cli-v0.0"), second);
-    assert_eq!(commit_of(remote, "lat_cli-v0.0.1"), first);
+    assert_eq!(commit_of_bare(&remote_path, "lat_cli-v0.0"), second);
+    assert_eq!(commit_of_bare(&remote_path, "lat_cli-v0.0.1"), first);
 
     // Re-running moves nothing.
     trellis(root)
@@ -902,6 +919,314 @@ fn doctor_warns_about_a_repo_wide_series_tag_whatever_the_versions() {
         .assert()
         .success()
         .stdout(predicate::str::contains("has no {name}"));
+}
+
+#[test]
+fn repository_series_moves_only_when_the_anchor_manifest_version_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag_mode = \"exact\"\n\
+         [tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+
+    trellis(root)
+        .args(["tag", "create"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tagged repo-v0.3"));
+    let first = commit_of(root, "repo-v0.3");
+
+    set_version(root, "lat_mid", "0.5.1");
+    git(root, &["commit", "-qam", "release only lat_mid"]);
+    trellis(root)
+        .args(["tag", "plan"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("repo-v0.3").not());
+    trellis(root).args(["tag", "create"]).assert().success();
+    assert_eq!(commit_of(root, "repo-v0.3"), first);
+
+    set_version(root, "lat_cli", "0.3.2");
+    git(root, &["commit", "-qam", "release anchor"]);
+    let output = trellis(root)
+        .args(["tag", "plan", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let repository = document["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|tag| tag["tag"] == "repo-v0.3")
+        .unwrap();
+    assert_eq!(repository["name"], "lat_cli");
+    assert_eq!(repository["version"], "0.3.2");
+    assert_eq!(repository["kind"], "repository_series");
+    assert_eq!(repository["action"], "move");
+}
+
+#[test]
+fn repository_series_transition_keeps_the_old_tag_and_skips_prereleases() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+    trellis(root).args(["tag", "create"]).assert().success();
+    let old = commit_of(root, "repo-v0.3");
+
+    set_version(root, "lat_cli", "0.4.0-rc.1");
+    git(root, &["commit", "-qam", "anchor prerelease"]);
+    trellis(root).args(["tag", "create"]).assert().success();
+    assert!(!git_stdout(root, &["tag", "--list"]).contains("repo-v0.4"));
+
+    set_version(root, "lat_cli", "0.4.0");
+    git(root, &["commit", "-qam", "anchor stable"]);
+    trellis(root).args(["tag", "create"]).assert().success();
+    assert_eq!(commit_of(root, "repo-v0.3"), old);
+    assert_eq!(commit_of(root, "repo-v0.4"), commit_of(root, "HEAD"));
+}
+
+#[test]
+fn repository_series_uses_committed_anchor_version_not_worktree_edits() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+    trellis(root).args(["tag", "create"]).assert().success();
+    let tagged = commit_of(root, "repo-v0.3");
+
+    set_version(root, "lat_cli", "0.4.0");
+    trellis(root)
+        .args(["tag", "plan"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("repo-v0.4").not());
+    assert_eq!(commit_of(root, "repo-v0.3"), tagged);
+}
+
+#[test]
+fn repository_series_fetches_a_remote_only_tag_before_planning_a_push() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success();
+    let original = git_stdout(root, &["ls-remote", "origin", "refs/tags/repo-v0.3^{}"]);
+    git(root, &["tag", "-d", "repo-v0.3"]);
+    git(root, &["commit", "-q", "--allow-empty", "-m", "unrelated"]);
+
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("force-pushed repo-v0.3").not());
+    assert!(
+        original.starts_with(&commit_of(root, "repo-v0.3")),
+        "{original}"
+    );
+    assert_eq!(
+        git_stdout(root, &["ls-remote", "origin", "refs/tags/repo-v0.3^{}"]),
+        original
+    );
+    drop(remote);
+}
+
+#[test]
+fn repository_series_refuses_to_move_a_newer_remote_tag_backward() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success();
+    let old_commit = commit_of(root, "HEAD");
+
+    set_version(root, "lat_cli", "0.3.2");
+    git(root, &["commit", "-qam", "anchor 0.3.2"]);
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .success();
+    let remote_new = git_stdout(root, &["ls-remote", "origin", "refs/tags/repo-v0.3^{}"]);
+
+    git(root, &["checkout", "-q", &old_commit]);
+    git(root, &["tag", "-f", "repo-v0.3", &old_commit]);
+    trellis(root)
+        .args(["tag", "create", "--push"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "origin is anchored at newer lat_cli version `0.3.2`",
+        ))
+        .stderr(predicate::str::contains(
+            "refusing to move it backward to `0.3.1`",
+        ));
+    assert_eq!(
+        git_stdout(root, &["ls-remote", "origin", "refs/tags/repo-v0.3^{}"]),
+        remote_new
+    );
+}
+
+#[test]
+fn repository_series_is_independent_of_tag_mode_and_never_resolves_as_a_package_tag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "tag_mode = \"exact\"\n\
+         [tools.trellis.publish.repository_series]\n\
+         package = \"lat_core\"\nformat = \"repo-v{series}\"",
+    );
+    trellis(root).args(["tag", "create"]).assert().success();
+    assert!(git_stdout(root, &["tag", "--list"]).contains("repo-v1"));
+
+    trellis(root)
+        .args(["ci", "tag-package", "repo-v1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repository series tag"));
+    trellis(root)
+        .args(["publish", "--tag", "repo-v1"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("repository series tag"));
+}
+
+#[test]
+fn repository_series_anchor_and_namespace_are_validated_by_doctor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"missing\"\nformat = \"repo-v{series}\"",
+    );
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "repository series anchor package `missing` is not a workspace member",
+        ));
+
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\", \"examples/*\"]\n\
+         exclude = { \"@release\" = [\"examples/*\"] }\n\
+         [tools.trellis.publish.repository_series]\n\
+         package = \"package_a\"\nformat = \"repo-v{series}\"\n",
+    );
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "repository series anchor package `package_a` is excluded from release",
+        ));
+
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\", \"examples/*\"]\n\
+         exclude = { \"@release\" = [\"examples/*\"] }\n\
+         [tools.trellis.publish]\ntag_format = \"repo-v{version}\"\n\
+         [tools.trellis.publish.repository_series]\n\
+         package = \"lat_core\"\nformat = \"repo-v{series}.0.0\"\n",
+    );
+    set_version(root, "lat_core", "1.0.0");
+    trellis(root)
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("tag collision"))
+        .stdout(predicate::str::contains("repo-v1.0.0"));
+    trellis(root)
+        .args(["tag", "create"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "collides with a package tag namespace",
+        ));
+}
+
+#[test]
+fn repository_series_is_force_pushed_and_gets_no_github_release() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+    let gh = install_fake_gh(root);
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args(["tag", "create", "--github-release"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("pushed repo-v0.3"));
+
+    set_version(root, "lat_cli", "0.3.2");
+    git(root, &["commit", "-qam", "anchor release"]);
+    trellis(root)
+        .env("TRELLIS_GH_BIN", &gh)
+        .args(["tag", "create", "--github-release"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("force-pushed repo-v0.3"));
+    let remote_peeled = git_stdout(root, &["ls-remote", "origin", "refs/tags/repo-v0.3^{}"]);
+    assert!(
+        remote_peeled.starts_with(&commit_of(root, "HEAD")),
+        "{remote_peeled}"
+    );
+    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
+    assert!(!log.contains("release view repo-v0.3"), "{log}");
+    assert!(!log.contains("release create repo-v0.3"), "{log}");
+}
+
+#[test]
+fn repository_series_reports_an_unreadable_historical_anchor_manifest() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let _remote = series_repo(
+        root,
+        "[tools.trellis.publish.repository_series]\n\
+         package = \"lat_cli\"\nformat = \"repo-v{series}\"",
+    );
+    git(root, &["checkout", "-q", "-b", "missing-anchor"]);
+    git(root, &["rm", "-q", "packages/lat_cli/gleam.toml"]);
+    git(root, &["commit", "-qm", "remove anchor manifest"]);
+    git(root, &["tag", "-a", "repo-v0.3", "-m", "broken history"]);
+    git(root, &["checkout", "-q", "main"]);
+
+    trellis(root)
+        .args(["tag", "plan"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "cannot read repository series anchor manifest \
+             `packages/lat_cli/gleam.toml` at revision `repo-v0.3`",
+        ));
 }
 
 #[test]

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -637,18 +637,6 @@ fn commit_of(dir: &Path, revision: &str) -> String {
     git_stdout(dir, &["rev-parse", &format!("{revision}^{{commit}}")])
 }
 
-fn commit_of_bare(dir: &Path, revision: &str) -> String {
-    git_stdout(
-        Path::new("/"),
-        &[
-            "--git-dir",
-            dir.to_str().unwrap(),
-            "rev-parse",
-            &format!("{revision}^{{commit}}"),
-        ],
-    )
-}
-
 #[test]
 fn series_tag_moves_with_each_release_while_exact_tags_stay_put() {
     let tmp = tempfile::tempdir().unwrap();
@@ -657,7 +645,7 @@ fn series_tag_moves_with_each_release_while_exact_tags_stay_put() {
         root,
         "tag_mode_overrides = { both = [\"packages/lat_cli\"] }",
     );
-    let remote_path = remote.path().to_path_buf();
+    let remote = remote.path();
     set_version(root, "lat_cli", "0.0.1");
     git(root, &["commit", "-qam", "lat_cli 0.0.1"]);
 
@@ -696,8 +684,8 @@ fn series_tag_moves_with_each_release_while_exact_tags_stay_put() {
     );
     assert_eq!(commit_of(root, "lat_cli-v0.0.2"), second);
     // Origin has the move too, not just the local repo.
-    assert_eq!(commit_of_bare(&remote_path, "lat_cli-v0.0"), second);
-    assert_eq!(commit_of_bare(&remote_path, "lat_cli-v0.0.1"), first);
+    assert_eq!(commit_of(remote, "lat_cli-v0.0"), second);
+    assert_eq!(commit_of(remote, "lat_cli-v0.0.1"), first);
 
     // Re-running moves nothing.
     trellis(root)

--- a/tests/snapshots/json_contract__tag_plan_json_contract.snap
+++ b/tests/snapshots/json_contract__tag_plan_json_contract.snap
@@ -3,7 +3,7 @@ source: tests/json_contract.rs
 expression: "json_output(root, &[\"tag\", \"plan\", \"--json\"], true)"
 ---
 {
-  "schema": "trellis.tag_plan/1",
+  "schema": "trellis.tag_plan/2",
   "tags": [
     {
       "action": "create",
@@ -17,6 +17,13 @@ expression: "json_output(root, &[\"tag\", \"plan\", \"--json\"], true)"
       "kind": "exact",
       "name": "lat_cli",
       "tag": "lat_cli-v0.3.1",
+      "version": "0.3.1"
+    },
+    {
+      "action": "create",
+      "kind": "repository_series",
+      "name": "lat_cli",
+      "tag": "repo-v0.3",
       "version": "0.3.1"
     }
   ]

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -87,7 +87,8 @@ Read `packages`; the alias goes away at 1.0.
 `tags` lists the immutable per-version tags and `series_tags` the moving ones,
 each covering only the packages whose
 [`tag_mode`](/docs/configuration/#series-tags) creates that kind — so a
-`series`-only workspace reports an empty `tags`.
+`series`-only workspace reports an empty `tags`. Repository series tags are
+deliberately absent from both outputs because they do not identify packages.
 
 Both `ci matrix` and `ci outputs` are shaped by GitHub rather than by trellis,
 which is why neither carries the `schema` field every other payload does — see

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -120,6 +120,8 @@ their roots.
 | `tasks.<name>` | no | Custom tasks for `trellis run`. A task with a built-in's name (`build`, `test`, …) overrides it. `needs_deps = true` downloads dependencies first. |
 | `publish.tag_format` | no | Template for per-package git tags. Default: `{name}-v{version}`. |
 | `publish.series_tag_format` | no | Template for the moving series tag, substituting `{name}` and `{series}`. Omit `{name}` for one repository-wide tag. Default: `{name}-v{series}`. |
+| `publish.repository_series.package` | no | Anchor package for one repository-wide moving series tag. The anchor must be releasable. |
+| `publish.repository_series.format` | with `package` | Repository tag template; must contain `{series}`. |
 | `publish.tag_mode` | no | Which tags a release creates: `exact` (default), `series`, or `both`. |
 | `publish.tag_mode_overrides` | no | Per-package tag modes: a map of mode name to member-path globs. A package matching globs under two modes is an error. |
 | `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial_delay, multiplier }`. |
@@ -246,6 +248,35 @@ Release: the release would silently retarget on the next move. See
 [Publishing](/docs/publishing/#tags) for how the two lifecycles differ.
 
 </Callout>
+
+### Repository series tags
+
+For a multi-package repository consumed through Gleam 1.18 git path
+dependencies, configure one first-class repository tag instead of overloading
+the legacy `{name}`-less package format:
+
+```toml title="gleam.toml"
+[tools.trellis.publish.repository_series]
+package = "vestibule"
+format = "v{series}"
+```
+
+The anchor package determines both the series and whether the tag moves.
+Trellis compares the anchor's manifest version at `HEAD` with its manifest
+version at the existing repository tag. Changes to other packages do not move
+the tag, and package exact tags and `tag_mode` do not affect that decision. A
+series transition creates the new tag while preserving the old one;
+prereleases create no repository tag.
+
+```toml title="gleam.toml"
+[dependencies]
+vestibule = { git = "https://github.com/example/monorepo.git", ref = "v0.4", path = "packages/vestibule" }
+```
+
+Repository series tags are mutable repository metadata. They are force-pushed,
+never receive GitHub Releases, and never resolve through `publish --tag` or
+`ci tag-package`. The legacy `{name}`-less `series_tag_format` remains
+supported with its ambiguity warning.
 
 ## Changelog configuration
 

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -121,7 +121,7 @@ their roots.
 | `publish.tag_format` | no | Template for per-package git tags. Default: `{name}-v{version}`. |
 | `publish.series_tag_format` | no | Template for the moving series tag, substituting `{name}` and `{series}`. Omit `{name}` for one repository-wide tag. Default: `{name}-v{series}`. |
 | `publish.repository_series.package` | no | Anchor package for one repository-wide moving series tag. The anchor must be releasable. |
-| `publish.repository_series.format` | with `package` | Repository tag template; must contain `{series}`. |
+| `publish.repository_series.format` | with `package` | Repository tag template; must contain `{series}` and no `{name}`. |
 | `publish.tag_mode` | no | Which tags a release creates: `exact` (default), `series`, or `both`. |
 | `publish.tag_mode_overrides` | no | Per-package tag modes: a map of mode name to member-path globs. A package matching globs under two modes is an error. |
 | `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial_delay, multiplier }`. |

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -54,7 +54,7 @@ commands pretty-print, some emit one line for shell-variable capture).
 | `changelog check --format json` | `trellis.changelog_check/1`<br />`{schema, ok, strictness, has_entries, needs_entry, invalid_fragments[], packages[], preview}` |
 | `version plan --json` | `trellis.version_plan/1`<br />`{schema, bumped[], fragments_retained}` |
 | `version apply --json` | `trellis.version_apply/1`<br />`{schema, bumped[], lockfiles[], adopted[], fragments_retained}` |
-| `tag plan --json` | `trellis.tag_plan/1`<br />`{schema, tags[]}` |
+| `tag plan --json` | `trellis.tag_plan/2`<br />`{schema, tags[]}` |
 | `ci tag-package --json` | `trellis.ci_tag_package/1`<br />`{schema, name, path, version, tag_kind, tag_version \| tag_series}` |
 | `doctor --format json` | `trellis.doctor/1`<br />`{schema, ok, packages, configless, auto_members, findings[], fixes[], applied[]}` |
 
@@ -71,6 +71,11 @@ Notes:
   value isn't.
 - `ci tag-package` reports `tag_kind: exact` with `tag_version`, or
   `tag_kind: series` with `tag_series` — the other key is absent, not null.
+- `tag plan` entries use `kind: repository_series` for an anchored repository
+  tag. The entry retains the anchor package's `name` and `version`; this kind
+  is never returned by package-oriented `ci tag-package`. Adding this
+  documented enum value advanced the payload from `trellis.tag_plan/1` to
+  `trellis.tag_plan/2`.
 - `changelog check`'s `preview` field is always present and a string, but its
   Markdown prose can change without a version bump. `needs_entry` reports
   whether an entry is missing; `ok` reports what

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -41,6 +41,10 @@ tag_mode_overrides = { both = ["packages/lat_cli"] }
 #   exact  → "== X.Y.Z"
 path_dep_requirement = "minor"
 retry = { attempts = 5, initial_delay = "30s", multiplier = 2 }
+
+[tools.trellis.publish.repository_series]
+package = "lat_cli"                       # anchor package
+format = "repo-v{series}"                 # repo-v0.4
 ```
 
 ## The release PR
@@ -70,6 +74,10 @@ A package tags in one of two lifecycles, chosen by `tag_mode`:
   can pin `lat_cli-v0.4` and follow the series instead of chasing patch tags.
   The series is derived from the version — see
   [series tags](/docs/configuration/#series-tags).
+- **Repository series tags** are independent of `tag_mode`. Trellis moves the
+  configured tag only when the anchor package's manifest version differs from
+  the version at that tag. A series change creates a new tag and leaves the
+  prior series tag intact.
 
 ```console
 $ trellis tag plan
@@ -87,15 +95,18 @@ force-pushed lat_cli-v0.4
 ```
 
 <Callout>
-`--github-release` skips series tags. A release attached to a moving tag would
-silently retarget on the next release, so only the immutable per-version tags
-carry one.
+`--github-release` skips package and repository series tags. A release attached
+to a moving tag would silently retarget on the next release, so only immutable
+per-version tags carry one.
 </Callout>
 
 Under `tag_mode = "series"` a package has no per-version tags at all, so there
 is no tag to trigger a publish from: run `trellis publish --all-untagged` on
 release-PR merge instead. Passing a series tag to `publish --tag` is an error
 — it names a package, but no particular version.
+
+Repository series tags identify repository snapshots rather than package
+releases, so neither `publish --tag` nor `ci tag-package` resolves them.
 
 ## Publishing to Hex
 


### PR DESCRIPTION
Adds an optional repository-wide moving tag for monorepos consumed through Gleam 1.18 git path dependencies — consumers pin one `ref = "v0.4"` for the whole repository instead of chasing per-package tags:

```toml
[tools.trellis.publish.repository_series]
package = "lat_cli"    # anchor
format  = "v{series}"
```

## Behavior

- The anchor package's **committed** (HEAD) manifest version determines the series; worktree edits and releases of other packages never move the tag.
- The tag moves only when the anchor's manifest version differs from the version stored at the existing tag. A series transition creates a new tag and preserves the old one; prereleases create nothing.
- Fully independent of package `tag_mode`. It never gets a GitHub Release, and `publish --tag` / `ci tag-package` refuse it — it names a repository snapshot, not a package release.
- Before a push, the tag is reconciled from origin: a stale clone may advance it but never move it backward, and the push uses `--force-with-lease`.
- `tag plan --json` reports the new `kind: repository_series`, advancing the payload to `trellis.tag_plan/2`.

## Guardrails

- Config validation requires `{series}` and rejects `{name}` in `repository_series.format`.
- The anchor must be a releasable workspace member, validated at workspace load and reported by `doctor`.
- The tag may never occupy a package tag namespace; `doctor` and `tag create` enforce this through one shared check.

## Internals

The anchor is resolved once at workspace load and stored on `Workspace` (replacing three per-command name lookups), doctor's collision check shares `tag create`'s namespace check, and the remote reconcile uses a plain source-only refspec fetch via `FETCH_HEAD` instead of a temporary ref. The legacy `{name}`-less `series_tag_format` remains supported with its existing ambiguity warning.

Docs updated across README, DESIGN, and the website (configuration, publishing, ci, json-output).
