### PR TITLE
feat(release): add package lifecycle states

### DIFF
--- a/.changes/unreleased/Added-20260731-changelog-lifecycle-selection.yaml
+++ b/.changes/unreleased/Added-20260731-changelog-lifecycle-selection.yaml
@@ -1,0 +1,5 @@
+component: changelog
+kind: Added
+body: |-
+  **`trellis changelog` now follows each package's resolved release lifecycle.** Packages in `git_only` and `hex` accept fragments and participate in `changelog check`; `workspace` packages do neither. Errors for explicitly selecting a `workspace` package name its lifecycle instead of describing every exclusion as an `exclude.@release` match.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-ci-lifecycle-selection.yaml
+++ b/.changes/unreleased/Added-20260731-ci-lifecycle-selection.yaml
@@ -1,0 +1,5 @@
+component: ci
+kind: Added
+body: |-
+  **`trellis ci` treats `git_only` and `hex` packages as releasable and excludes `workspace` packages from release outputs.** `ci matrix --releasable`, `releasable`, `version_files`, exact tags, series tags, and tag-to-package resolution now follow the resolved lifecycle without changing their existing output shapes.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-doctor-lifecycle-validation.yaml
+++ b/.changes/unreleased/Added-20260731-doctor-lifecycle-validation.yaml
@@ -1,0 +1,7 @@
+component: doctor
+kind: Added
+body: |-
+  **`doctor` validates dependency availability against each package's release lifecycle, not just a binary releasable/excluded split.** The `release_boundary` check now enforces that a runtime (`[dependencies]`, not `[dev-dependencies]`) path dependency is at least as capable as its dependent: a `hex` package may depend only on `hex`; `git_only` may depend on `git_only` or `hex`; `workspace` may depend on anything. The message names both packages' lifecycles and why the dependency would be unavailable.
+
+    `--format json` gains an additive `package_lifecycles` array of `{name, lifecycle}`, one per member in workspace order, alongside the retained numeric `packages` count; text mode prints the same data as compact counts, e.g. `ok: 4 package(s) (1 workspace, 0 git_only, 3 hex), 0 warning(s)`. `publish.lifecycle.packages` globs are checked for typos the same way `exclude` and `tag_mode_overrides` globs already are.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-graph-lifecycle-field.yaml
+++ b/.changes/unreleased/Added-20260731-graph-lifecycle-field.yaml
@@ -1,0 +1,5 @@
+component: graph
+kind: Added
+body: |-
+  **`trellis graph --format json` nodes carry the resolved release lifecycle.** Each node's additive `lifecycle` field (`workspace`, `git_only`, or `hex`) sits alongside the existing `releasable` boolean, matching `list`/`info`.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-info-lifecycle-field.yaml
+++ b/.changes/unreleased/Added-20260731-info-lifecycle-field.yaml
@@ -1,0 +1,5 @@
+component: info
+kind: Added
+body: |-
+  **`trellis info` reports a package's resolved release lifecycle.** Text mode gains a `lifecycle:` line alongside `releasable:`; `--json` gains the same additive `lifecycle` field `list --json` carries.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-publish-lifecycle-config.yaml
+++ b/.changes/unreleased/Added-20260731-publish-lifecycle-config.yaml
@@ -1,0 +1,7 @@
+component: publish
+kind: Added
+body: |-
+  **`[tools.trellis.publish.lifecycle]` gives each package a release lifecycle: `workspace`, `git_only`, or `hex` (the default).** `workspace` packages never get a changelog entry, a version bump, a git tag, or a Hex publish; `git_only` packages get all of those except the Hex publish; `hex` packages get the full pipeline. Configure a `default` and per-package `packages = { "glob/**" = "state" }` overrides, matched against member paths — a member matched by globs resolving to different states is a doctor error, but globs agreeing on the same state are fine.
+
+    The legacy `exclude.@release` key keeps working: a match there still resolves to `workspace`, unless an explicit `publish.lifecycle.packages` rule for that member says otherwise, which lets a package graduate from `workspace` to `git_only` to `hex` without moving directories or rewriting the exclusion. `--releasable` keeps meaning `git_only` **or** `hex`; `publish` alone narrows further, since only `hex` packages ever reach Hex — naming a `workspace` or `git_only` package with `--package` or `--tag`, or leaving one out of the path-dependency rewrite map, now fails with a message naming the package's actual lifecycle instead of a generic `@release` exclusion.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-tag-lifecycle-selection.yaml
+++ b/.changes/unreleased/Added-20260731-tag-lifecycle-selection.yaml
@@ -1,0 +1,5 @@
+component: tag
+kind: Added
+body: |-
+  **`trellis tag` creates git tags and GitHub Releases for both `git_only` and `hex` packages.** `workspace` packages produce no exact or series tags, while each participating package continues to follow its resolved `tag_mode`.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Added-20260731-version-lifecycle-selection.yaml
+++ b/.changes/unreleased/Added-20260731-version-lifecycle-selection.yaml
@@ -1,0 +1,5 @@
+component: version
+kind: Added
+body: |-
+  **`trellis version` now plans and applies bumps for `git_only` and `hex` packages while leaving `workspace` packages unchanged.** Dependency ripple still stops at a non-versioned `workspace` boundary, and `--bump` or `--set` reports the resolved lifecycle when a named package cannot participate.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/.changes/unreleased/Changed-20260731-list-lifecycle-column.yaml
+++ b/.changes/unreleased/Changed-20260731-list-lifecycle-column.yaml
@@ -1,0 +1,5 @@
+component: list
+kind: Changed
+body: |-
+  **`trellis list`'s default text output is now two columns, name and resolved release lifecycle, instead of names alone.** `--json` gains an additive `lifecycle` field (`workspace`, `git_only`, or `hex`) on every package alongside the retained `releasable` boolean. Human-readable output was never a stable contract — script against `--json` if you're parsing.
+time: 2026-07-31T23:03:32.015056000-07:00

--- a/README.md
+++ b/README.md
@@ -275,10 +275,37 @@ docs = ["examples/*", "packages/internal-*"]
 ```
 
 The reserved `@release` key defines the package set used by changelog,
-version, tag, and publish commands, and `@members` removes directories from
-workspace membership entirely (in both auto-discovered and explicit-members
-modes). Special keys use a `@` prefix so they can never collide with a task
-name — trellis rejects any task named with that prefix.
+version, tag, and publish commands — read as the `workspace` state of the
+finer-grained release lifecycle described next — and `@members` removes
+directories from workspace membership entirely (in both auto-discovered and
+explicit-members modes). Special keys use a `@` prefix so they can never
+collide with a task name — trellis rejects any task named with that prefix.
+
+### Release lifecycle
+
+```toml
+[tools.trellis.publish.lifecycle]
+default = "hex"
+packages = { "packages/experimental/**" = "workspace", "packages/providers/**" = "git_only" }
+```
+
+Each member resolves to one of three lifecycles: `workspace` (build and test
+only — no changelog, version, tag, or publish), `git_only` (changelog,
+version, and git tags/releases, but never published to Hex), or `hex` (the
+full pipeline, and the default). `default` sets the workspace-wide fallback;
+`packages` overrides it per member, keyed by member-path glob — a member
+matched by globs resolving to different lifecycles is a `doctor` error, but
+globs agreeing on the same lifecycle are fine. `exclude.@release` keeps
+resolving matching packages to `workspace`, but an explicit `packages` rule
+for the same member takes precedence, so a package can graduate from
+`workspace` to `git_only` to `hex` without moving directories.
+
+`--releasable` (on `list`, `ci matrix`, and elsewhere) still means `git_only`
+**or** `hex`; `publish` narrows further, since only `hex` packages ever reach
+Hex. `doctor` additionally enforces that a runtime path dependency is at
+least as capable as its dependent — `hex` may depend only on `hex`, `git_only`
+may depend on `git_only` or `hex`, and `workspace` may depend on anything —
+exempting dev-only path deps, which never ship in any distribution.
 
 ### Changelog & versioning
 
@@ -468,8 +495,8 @@ trellis doctor [--fix] [--dry-run] [--format text|json|github]
 
 Checks every workspace invariant and reports all problems at once: member
 globs resolve and parse, path deps stay inside the workspace, the graph is
-acyclic, task exclusion globs match real members, no releasable package
-depends on an unreleasable one, tag formats don't collide, `manifest.toml`
+acyclic, task exclusion globs match real members, every package's runtime
+path deps are available at its release lifecycle, tag formats don't collide, `manifest.toml`
 locked versions match workspace-internal `gleam.toml` versions, no package's
 version is behind its CHANGELOG, and every unreleased changelog fragment
 parses and references a valid package and kind. When `.tool-versions` pins

--- a/assets/man/trellis-list.1
+++ b/assets/man/trellis-list.1
@@ -13,7 +13,7 @@ List packages in topological order (dependencies first)
 Run as if started in this directory
 .TP
 \fB\-\-json\fR
-Emit JSON instead of names
+Emit JSON instead of name/lifecycle columns
 .TP
 \fB\-\-color\fR \fI<WHEN>\fR [default: auto]
 When to color output. `auto` follows the terminal, `NO_COLOR`, and `CLICOLOR=0`; the other two override that detection
@@ -40,7 +40,7 @@ Suppress normal\-path output; JSON/report payloads and errors still print
 Add the reverse\-dependency closure of the selection
 .TP
 \fB\-\-releasable\fR
-Only packages that participate in releases (excludes `@release` matches)
+Only packages whose release lifecycle is `git_only` or `hex`
 .TP
 \fB\-v\fR, \fB\-\-verbose\fR
 Trace every command trellis shells out to, on stderr

--- a/assets/man/trellis-publish.1
+++ b/assets/man/trellis-publish.1
@@ -16,7 +16,7 @@ Run as if started in this directory
 Resolve a pushed tag (e.g. lat_core\-v1.2.0) to its package
 .TP
 \fB\-\-all\-untagged\fR
-Every releasable package whose version isn\*(Aqt on Hex yet
+Every `hex`\-lifecycle package whose version isn\*(Aqt on Hex yet
 .TP
 \fB\-\-color\fR \fI<WHEN>\fR [default: auto]
 When to color output. `auto` follows the terminal, `NO_COLOR`, and `CLICOLOR=0`; the other two override that detection

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -185,6 +185,11 @@ tag_mode_overrides = { both = ["packages/lattice_cli"] }
 #   exact  → "== X.Y.Z"
 path_dep_requirement = "minor"
 retry = { attempts = 5, initial_delay = "30s", multiplier = 2 }
+# Per-package release lifecycle (§4.1): which of changelog/version, git
+# tags/releases, and Hex publish a member participates in.
+[tools.trellis.publish.lifecycle]
+default = "hex"
+packages = { "packages/experimental/**" = "workspace", "packages/providers/**" = "git_only" }
 
 [tools.trellis.changelog]
 # Native engine (§7): fragments in <dir>/unreleased/, version sections in
@@ -221,6 +226,50 @@ category_format = "### {{ category }}"
 uncategorized_label = "Other"
 ```
 
+### 4.1 Release lifecycle
+
+A member's release lifecycle decides how much of the release pipeline it
+participates in — resolved to one of three states, from least to most
+capable:
+
+| Lifecycle | Changelog/version | Git tags/releases | Hex publish |
+| --- | --- | --- | --- |
+| `workspace` | no | no | no |
+| `git_only` | yes | yes | no |
+| `hex` | yes | yes | yes |
+
+Resolution, per member, in order:
+
+1. Start from `publish.lifecycle.default` (itself defaulting to `hex`).
+2. Apply the legacy `exclude.@release` mapping to `workspace`, when the member
+   matches one of those globs — the same boundary trellis has always drawn,
+   read as the lifecycle model's most restrictive state.
+3. Apply an explicit `publish.lifecycle.packages` glob, when matched — this
+   takes precedence over both of the above, which is what lets a package
+   graduate from `workspace` to `git_only` to `hex` without moving directories
+   or rewriting exclusions. A member matched by explicit globs resolving to
+   more than one distinct lifecycle is a deterministic `doctor` error;
+   matching several globs that agree on the same lifecycle is fine.
+
+`Member.lifecycle` is the resolved value; `Member.releasable` remains a
+derived compatibility boolean (`lifecycle != workspace`) so the existing
+changelog/version/tag/release call sites, and the `--releasable` selection
+filter, need no change — `git_only` and `hex` both count. `publish` alone
+needs the finer distinction, since only `hex` ever reaches Hex; it selects
+`lifecycle == hex` directly, and the path-dependency rewrite's version map is
+built from `hex` members only, so a Hex package referencing a non-Hex runtime
+dependency fails safely rather than publishing something unresolvable.
+
+**Dependency availability** replaces the old binary "no releasable member
+depends on an unreleasable one" rule with an ordered capability check on
+runtime (`[dependencies]`, not `[dev-dependencies]`) path deps: a dependency
+must be at least as capable as its dependent — `hex` may depend only on `hex`;
+`git_only` may depend on `git_only` or `hex`; `workspace` may depend on
+anything. Dev-only path deps are exempt, since a dev dependency never ships in
+any distribution regardless of lifecycle. `doctor`'s `release_boundary` check
+keeps its identifier, reporting both packages' lifecycles and why the
+dependency would be unavailable in the dependent's distribution.
+
 Wildcard discovery honors repository `.gitignore` files at every level and
 `.git/info/exclude`, but only when the workspace is in a Git repository. It
 ignores global `core.excludesFile` rules, for reproducibility, and generic
@@ -245,8 +294,10 @@ trellis info <package> [--json]
 ```
 
 - `list` prints members in topological order — this alone replaces `justfile:18`.
-  `--releasable` filters out `@release` matches, i.e. the set that
-  changelog/tag/publish commands operate on.
+  Text output is two columns, name and resolved lifecycle; `--releasable`
+  filters to `git_only` and `hex` members, i.e. the set that
+  changelog/version/tag commands operate on (`publish` narrows further, to
+  `hex` alone).
 - `--since origin/main` filters to packages owning changed files (diff paths mapped
   to package directories); `--with-dependents` adds the reverse-dependency closure.
   This is the primitive behind "only test what a PR touched."
@@ -407,9 +458,12 @@ Checks, each of which is an unenforced invariant in lattice today:
    and each has a changelog file where expected.
 5. `manifest.toml` locked versions of workspace-internal deps match those deps'
    actual `gleam.toml` versions (catches a missed lockfile patch).
-6. Every task exclusion glob matches at least one member (catches typos), and
-   no releasable member path-depends on a release-excluded member — a published
-   package cannot require a project that will never exist on Hex.
+6. Every task exclusion glob and `publish.lifecycle.packages` glob matches at
+   least one member (catches typos), and every member's runtime
+   (`[dependencies]`) path deps are available at its release lifecycle: a
+   dependency must be at least as capable as its dependent (§4.1) — a `hex`
+   package cannot require a package that will never exist on Hex, and neither
+   `hex` nor `git_only` may depend on a `workspace`-only one.
 7. Tag-format collisions (two members whose names would produce ambiguous tags),
    for series tags as well as exact ones — except a `series_tag_format` without
    `{name}`, which warns instead once the workspace has more than one series

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -8,12 +8,22 @@
 //! rendered shape is configurable without a second tool.
 
 use crate::config::{Bump, ChangelogConfig, KindConfig};
-use crate::workspace::Workspace;
+use crate::workspace::{Member, Workspace};
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use std::path::PathBuf;
 
 // ---- fragments -------------------------------------------------------------
+
+/// Why a non-releasable member can never take a changelog entry — quoted by
+/// both `changelog new` and fragment validation, so the wording stays one.
+pub fn no_changelog_reason(member: &Member) -> String {
+    format!(
+        "package `{}` has release lifecycle `{}`, so it never gets a changelog entry",
+        member.name,
+        member.lifecycle.key()
+    )
+}
 
 #[derive(Debug, Clone)]
 pub struct Fragment {
@@ -145,10 +155,8 @@ pub fn load_fragments(workspace: &Workspace) -> Result<Fragments> {
             Some(idx) if workspace.members[idx].releasable() => {}
             Some(idx) => {
                 result.problems.push(blame(format!(
-                    "fragment `{display}`: package `{}` has release lifecycle `{}`, so it \
-                     never gets a changelog entry",
-                    raw.package,
-                    workspace.members[idx].lifecycle.key()
+                    "fragment `{display}`: {}",
+                    no_changelog_reason(&workspace.members[idx])
                 )));
                 continue;
             }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -142,7 +142,7 @@ pub fn load_fragments(workspace: &Workspace) -> Result<Fragments> {
             package: Some(raw.package.clone()),
         };
         match workspace.member_index(&raw.package) {
-            Some(idx) if workspace.members[idx].releasable => {}
+            Some(idx) if workspace.members[idx].releasable() => {}
             Some(idx) => {
                 result.problems.push(blame(format!(
                     "fragment `{display}`: package `{}` has release lifecycle `{}`, so it \

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -143,10 +143,12 @@ pub fn load_fragments(workspace: &Workspace) -> Result<Fragments> {
         };
         match workspace.member_index(&raw.package) {
             Some(idx) if workspace.members[idx].releasable => {}
-            Some(_) => {
+            Some(idx) => {
                 result.problems.push(blame(format!(
-                    "fragment `{display}`: package `{}` is excluded from release by `@release`",
-                    raw.package
+                    "fragment `{display}`: package `{}` has release lifecycle `{}`, so it \
+                     never gets a changelog entry",
+                    raw.package,
+                    workspace.members[idx].lifecycle.key()
                 )));
                 continue;
             }

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -30,7 +30,11 @@ pub fn new_fragment(
                 .member_index(name)
                 .with_context(|| format!("unknown package `{name}`"))?;
             if !workspace.members[idx].releasable {
-                bail!("package `{name}` is excluded from release by `@release`");
+                bail!(
+                    "package `{name}` has release lifecycle `{}`, so it never gets a changelog \
+                     entry",
+                    workspace.members[idx].lifecycle.key()
+                );
             }
             name
         }

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -31,9 +31,8 @@ pub fn new_fragment(
                 .with_context(|| format!("unknown package `{name}`"))?;
             if !workspace.members[idx].releasable() {
                 bail!(
-                    "package `{name}` has release lifecycle `{}`, so it never gets a changelog \
-                     entry",
-                    workspace.members[idx].lifecycle.key()
+                    "{}",
+                    changelog::no_changelog_reason(&workspace.members[idx])
                 );
             }
             name

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -21,7 +21,7 @@ pub fn new_fragment(
     let releasable: Vec<&str> = workspace
         .members
         .iter()
-        .filter(|m| m.releasable)
+        .filter(|m| m.releasable())
         .map(|m| m.name.as_str())
         .collect();
     let project = match package {
@@ -29,7 +29,7 @@ pub fn new_fragment(
             let idx = workspace
                 .member_index(name)
                 .with_context(|| format!("unknown package `{name}`"))?;
-            if !workspace.members[idx].releasable {
+            if !workspace.members[idx].releasable() {
                 bail!(
                     "package `{name}` has release lifecycle `{}`, so it never gets a changelog \
                      entry",
@@ -128,7 +128,7 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
         .members
         .iter()
         .enumerate()
-        .filter(|(idx, member)| changed.contains(idx) && member.releasable)
+        .filter(|(idx, member)| changed.contains(idx) && member.releasable())
         .map(|(_, member)| PackageStatus {
             name: member.name.clone(),
             fragments: fragments.count_for(&member.name),

--- a/src/commands/ci.rs
+++ b/src/commands/ci.rs
@@ -53,19 +53,19 @@ pub fn outputs(workspace: &Workspace) -> Result<()> {
     let releasable: Vec<&str> = workspace
         .members
         .iter()
-        .filter(|m| m.releasable)
+        .filter(|m| m.releasable())
         .map(|m| m.name.as_str())
         .collect();
     let version_files: Vec<String> = workspace
         .members
         .iter()
-        .filter(|m| m.releasable)
+        .filter(|m| m.releasable())
         .map(|m| format!("{}/gleam.toml", m.rel_path))
         .collect();
     let tags: Vec<String> = workspace
         .members
         .iter()
-        .filter(|m| m.releasable && m.tag_mode.includes_exact())
+        .filter(|m| m.releasable() && m.tag_mode.includes_exact())
         .map(|m| workspace.config.format_tag(&m.name, m.version()))
         .collect();
     // Deduplicated: a repository-wide series tag is one tag, however many
@@ -74,7 +74,7 @@ pub fn outputs(workspace: &Workspace) -> Result<()> {
     for member in workspace
         .members
         .iter()
-        .filter(|m| m.releasable && m.tag_mode.includes_series())
+        .filter(|m| m.releasable() && m.tag_mode.includes_series())
     {
         if let Some(tag) = workspace
             .config

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -171,25 +171,6 @@ impl Report {
     fn count(&self, severity: Severity) -> usize {
         self.of_severity(severity).count()
     }
-    /// How many members resolved to each lifecycle, in the fixed order
-    /// `workspace, git_only, hex` — the order the text summary prints them.
-    fn lifecycle_counts(&self) -> [(crate::config::ReleaseLifecycle, usize); 3] {
-        use crate::config::ReleaseLifecycle;
-        let count = |lifecycle: ReleaseLifecycle| {
-            self.package_lifecycles
-                .iter()
-                .filter(|(_, l)| *l == lifecycle)
-                .count()
-        };
-        [
-            (
-                ReleaseLifecycle::Workspace,
-                count(ReleaseLifecycle::Workspace),
-            ),
-            (ReleaseLifecycle::GitOnly, count(ReleaseLifecycle::GitOnly)),
-            (ReleaseLifecycle::Hex, count(ReleaseLifecycle::Hex)),
-        ]
-    }
 }
 
 /// Load the workspace and run every check, collecting findings and the fixes
@@ -345,15 +326,24 @@ fn finish(report: &Report, applied: &[Fix], format: DoctorFormat) -> Result<bool
 
 fn print_summary(report: &Report, ok: bool) {
     let warnings = report.count(Severity::Warning);
-    // Compact lifecycle counts, e.g. "3 hex, 1 git_only, 0 workspace" — always
-    // in `workspace, git_only, hex` order, so a reader can scan the same
-    // position across workspaces rather than parsing which label is which.
-    let lifecycles = report
-        .lifecycle_counts()
-        .into_iter()
-        .map(|(lifecycle, count)| format!("{count} {}", lifecycle.key()))
-        .collect::<Vec<_>>()
-        .join(", ");
+    // Compact lifecycle counts, always in `workspace, git_only, hex` order,
+    // so a reader can scan the same position across workspaces rather than
+    // parsing which label is which.
+    use crate::config::ReleaseLifecycle;
+    let lifecycles = [
+        ReleaseLifecycle::Workspace,
+        ReleaseLifecycle::GitOnly,
+        ReleaseLifecycle::Hex,
+    ]
+    .map(|lifecycle| {
+        let count = report
+            .package_lifecycles
+            .iter()
+            .filter(|(_, l)| *l == lifecycle)
+            .count();
+        format!("{count} {}", lifecycle.key())
+    })
+    .join(", ");
     if ok {
         // The JSON field behind this count is still `members` — renaming a
         // stable key would bump `trellis.doctor/1`, so it waits for 1.0.
@@ -632,7 +622,7 @@ fn check_member_glob(workspace: &Workspace, label: &str, pattern: &str, report: 
 /// quiet on exactly the configurations `trellis ci tag-package` still fails on.
 fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     let mut seen: std::collections::HashMap<String, &str> = std::collections::HashMap::new();
-    for member in workspace.members.iter().filter(|m| m.releasable) {
+    for member in workspace.members.iter().filter(|m| m.releasable()) {
         if member.tag_mode.includes_exact() {
             let tag = workspace.config.format_tag(&member.name, member.version());
             if let Some(other) = seen.insert(tag.clone(), &member.name) {
@@ -654,7 +644,7 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     let series_members: Vec<&str> = workspace
         .members
         .iter()
-        .filter(|m| m.releasable && m.tag_mode.includes_series())
+        .filter(|m| m.releasable() && m.tag_mode.includes_series())
         .map(|m| m.name.as_str())
         .collect();
     let names = |members: &[&str]| {
@@ -689,7 +679,7 @@ fn check_tag_collisions(workspace: &Workspace, report: &mut Report) {
     for member in workspace
         .members
         .iter()
-        .filter(|m| m.releasable && m.tag_mode.includes_series())
+        .filter(|m| m.releasable() && m.tag_mode.includes_series())
     {
         if let Some(tag) = workspace
             .config
@@ -791,7 +781,7 @@ fn check_lockfiles(workspace: &Workspace, report: &mut Report) {
 /// member should have a CHANGELOG.md, and its gleam.toml version must not be
 /// behind the newest version mentioned in it.
 fn check_changelogs(workspace: &Workspace, report: &mut Report) {
-    for member in workspace.members.iter().filter(|m| m.releasable) {
+    for member in workspace.members.iter().filter(|m| m.releasable()) {
         let changelog = member.path.join("CHANGELOG.md");
         let rel_changelog = format!("{}/CHANGELOG.md", member.rel_path);
         if !changelog.is_file() {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -144,15 +144,14 @@ struct Report {
     /// severity when printing; the JSON payload preserves this order.
     findings: Vec<Finding>,
     fixes: Vec<Fix>,
-    packages: usize,
     /// No [tools.trellis] anywhere; the root was inferred from git.
     configless: bool,
     /// `members` is not configured; the member list came from git.
     auto_members: bool,
     /// Every member's resolved lifecycle, in workspace (topological) order —
-    /// the source for both the text summary's counts and the JSON payload's
-    /// `package_lifecycles`.
-    package_lifecycles: Vec<(String, crate::config::ReleaseLifecycle)>,
+    /// the source for the text summary's counts, the JSON payload's
+    /// `package_lifecycles`, and the package count.
+    package_lifecycles: Vec<PackageLifecycleRecord>,
 }
 
 impl Report {
@@ -171,6 +170,9 @@ impl Report {
     fn count(&self, severity: Severity) -> usize {
         self.of_severity(severity).count()
     }
+    fn packages(&self) -> usize {
+        self.package_lifecycles.len()
+    }
 }
 
 /// Load the workspace and run every check, collecting findings and the fixes
@@ -183,13 +185,15 @@ fn inspect(root: &Path) -> Result<Report> {
     };
 
     if let Some(workspace) = &workspace {
-        report.packages = workspace.members.len();
         report.configless = workspace.configless;
         report.auto_members = workspace.config.members.is_none();
         report.package_lifecycles = workspace
             .members
             .iter()
-            .map(|member| (member.name.clone(), member.lifecycle))
+            .map(|member| PackageLifecycleRecord {
+                name: member.name.clone(),
+                lifecycle: member.lifecycle,
+            })
             .collect();
         check_exclusions(workspace, &mut report);
         check_tag_collisions(workspace, &mut report);
@@ -276,12 +280,12 @@ fn print_findings(report: &Report) {
         crate::status!(
             "note: no [tools.trellis] configuration found; workspace root inferred from git, \
              {} member(s) auto-discovered",
-            report.packages
+            report.packages()
         );
     } else if report.auto_members {
         crate::status!(
             "note: `members` is not configured; {} member(s) auto-discovered from git",
-            report.packages
+            report.packages()
         );
     }
     for warning in report.of_severity(Severity::Warning) {
@@ -302,20 +306,13 @@ fn finish(report: &Report, applied: &[Fix], format: DoctorFormat) -> Result<bool
             let document = DoctorDocument {
                 schema: DoctorDocument::SCHEMA,
                 ok,
-                packages: report.packages,
+                packages: report.packages(),
                 configless: report.configless,
                 auto_members: report.auto_members,
                 findings: &report.findings,
                 fixes: report.fixes.iter().map(Fix::record).collect(),
                 applied: applied.iter().map(Fix::record).collect(),
-                package_lifecycles: report
-                    .package_lifecycles
-                    .iter()
-                    .map(|(name, lifecycle)| PackageLifecycleRecord {
-                        name,
-                        lifecycle: *lifecycle,
-                    })
-                    .collect(),
+                package_lifecycles: &report.package_lifecycles,
             };
             println!("{}", serde_json::to_string_pretty(&document)?);
         }
@@ -326,30 +323,25 @@ fn finish(report: &Report, applied: &[Fix], format: DoctorFormat) -> Result<bool
 
 fn print_summary(report: &Report, ok: bool) {
     let warnings = report.count(Severity::Warning);
-    // Compact lifecycle counts, always in `workspace, git_only, hex` order,
-    // so a reader can scan the same position across workspaces rather than
-    // parsing which label is which.
-    use crate::config::ReleaseLifecycle;
-    let lifecycles = [
-        ReleaseLifecycle::Workspace,
-        ReleaseLifecycle::GitOnly,
-        ReleaseLifecycle::Hex,
-    ]
-    .map(|lifecycle| {
-        let count = report
-            .package_lifecycles
-            .iter()
-            .filter(|(_, l)| *l == lifecycle)
-            .count();
-        format!("{count} {}", lifecycle.key())
-    })
-    .join(", ");
+    // Compact lifecycle counts, always in `ReleaseLifecycle::ALL` order, so a
+    // reader can scan the same position across workspaces rather than parsing
+    // which label is which.
+    let lifecycles = crate::config::ReleaseLifecycle::ALL
+        .map(|lifecycle| {
+            let count = report
+                .package_lifecycles
+                .iter()
+                .filter(|record| record.lifecycle == lifecycle)
+                .count();
+            format!("{count} {}", lifecycle.key())
+        })
+        .join(", ");
     if ok {
         // The JSON field behind this count is still `members` — renaming a
         // stable key would bump `trellis.doctor/1`, so it waits for 1.0.
         crate::status!(
             "ok: {} package(s) ({lifecycles}), {warnings} warning(s)",
-            report.packages
+            report.packages()
         );
     } else {
         crate::status!(
@@ -519,7 +511,7 @@ fn check_tool_versions(workspace: &Workspace, report: &mut Report) {
 
 /// Check 6: every exclusion glob matches at least one member (catches typos),
 /// and no member's runtime distribution would depend on a package unavailable
-/// in it — see [`ReleaseLifecycle`]'s ordering.
+/// in it — see [`crate::config::ReleaseLifecycle::available_to`].
 fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     for (task, patterns) in &workspace.config.exclude {
         for pattern in patterns {
@@ -557,18 +549,17 @@ fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     for (idx, member) in workspace.members.iter().enumerate() {
         for &dep in workspace.runtime_deps_of(idx) {
             let dep = &workspace.members[dep];
-            if dep.lifecycle < member.lifecycle {
+            if !dep.lifecycle.available_to(member.lifecycle) {
                 report.push(
                     Finding::error(
                         Check::ReleaseBoundary,
                         format!(
-                            "package `{}` (lifecycle `{}`) path-depends on `{}` (lifecycle \
-                             `{}`), which is unavailable in `{}`'s distribution",
+                            "package `{0}` (lifecycle `{1}`) path-depends on `{2}` (lifecycle \
+                             `{3}`), which is unavailable in `{0}`'s distribution",
                             member.name,
                             member.lifecycle.key(),
                             dep.name,
                             dep.lifecycle.key(),
-                            member.name
                         ),
                     )
                     .at(format!("{}/gleam.toml", member.rel_path))

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,7 +3,7 @@
 
 use crate::config::Strictness;
 use crate::gleam::Requirement;
-use crate::json::{Check, DoctorDocument, Finding, FixRecord, Severity};
+use crate::json::{Check, DoctorDocument, Finding, FixRecord, PackageLifecycleRecord, Severity};
 use crate::lockfile;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result};
@@ -149,6 +149,10 @@ struct Report {
     configless: bool,
     /// `members` is not configured; the member list came from git.
     auto_members: bool,
+    /// Every member's resolved lifecycle, in workspace (topological) order —
+    /// the source for both the text summary's counts and the JSON payload's
+    /// `package_lifecycles`.
+    package_lifecycles: Vec<(String, crate::config::ReleaseLifecycle)>,
 }
 
 impl Report {
@@ -167,6 +171,25 @@ impl Report {
     fn count(&self, severity: Severity) -> usize {
         self.of_severity(severity).count()
     }
+    /// How many members resolved to each lifecycle, in the fixed order
+    /// `workspace, git_only, hex` — the order the text summary prints them.
+    fn lifecycle_counts(&self) -> [(crate::config::ReleaseLifecycle, usize); 3] {
+        use crate::config::ReleaseLifecycle;
+        let count = |lifecycle: ReleaseLifecycle| {
+            self.package_lifecycles
+                .iter()
+                .filter(|(_, l)| *l == lifecycle)
+                .count()
+        };
+        [
+            (
+                ReleaseLifecycle::Workspace,
+                count(ReleaseLifecycle::Workspace),
+            ),
+            (ReleaseLifecycle::GitOnly, count(ReleaseLifecycle::GitOnly)),
+            (ReleaseLifecycle::Hex, count(ReleaseLifecycle::Hex)),
+        ]
+    }
 }
 
 /// Load the workspace and run every check, collecting findings and the fixes
@@ -182,6 +205,11 @@ fn inspect(root: &Path) -> Result<Report> {
         report.packages = workspace.members.len();
         report.configless = workspace.configless;
         report.auto_members = workspace.config.members.is_none();
+        report.package_lifecycles = workspace
+            .members
+            .iter()
+            .map(|member| (member.name.clone(), member.lifecycle))
+            .collect();
         check_exclusions(workspace, &mut report);
         check_tag_collisions(workspace, &mut report);
         check_lockfiles(workspace, &mut report);
@@ -200,7 +228,7 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
         let checked = [
             "member globs resolve and every package has a parseable gleam.toml",
             "path dependencies stay inside the workspace; graph is acyclic",
-            "task exclusion globs match members; no releasable package depends on an unreleasable one",
+            "task exclusion globs match members; no package depends on one unavailable at its release lifecycle",
             "tag format produces a unique tag per releasable package",
             "manifest.toml locked versions match workspace-internal gleam.toml versions",
             "each releasable package's version is not behind its CHANGELOG",
@@ -299,6 +327,14 @@ fn finish(report: &Report, applied: &[Fix], format: DoctorFormat) -> Result<bool
                 findings: &report.findings,
                 fixes: report.fixes.iter().map(Fix::record).collect(),
                 applied: applied.iter().map(Fix::record).collect(),
+                package_lifecycles: report
+                    .package_lifecycles
+                    .iter()
+                    .map(|(name, lifecycle)| PackageLifecycleRecord {
+                        name,
+                        lifecycle: *lifecycle,
+                    })
+                    .collect(),
             };
             println!("{}", serde_json::to_string_pretty(&document)?);
         }
@@ -309,10 +345,22 @@ fn finish(report: &Report, applied: &[Fix], format: DoctorFormat) -> Result<bool
 
 fn print_summary(report: &Report, ok: bool) {
     let warnings = report.count(Severity::Warning);
+    // Compact lifecycle counts, e.g. "3 hex, 1 git_only, 0 workspace" — always
+    // in `workspace, git_only, hex` order, so a reader can scan the same
+    // position across workspaces rather than parsing which label is which.
+    let lifecycles = report
+        .lifecycle_counts()
+        .into_iter()
+        .map(|(lifecycle, count)| format!("{count} {}", lifecycle.key()))
+        .collect::<Vec<_>>()
+        .join(", ");
     if ok {
         // The JSON field behind this count is still `members` — renaming a
         // stable key would bump `trellis.doctor/1`, so it waits for 1.0.
-        crate::status!("ok: {} package(s), {warnings} warning(s)", report.packages);
+        crate::status!(
+            "ok: {} package(s) ({lifecycles}), {warnings} warning(s)",
+            report.packages
+        );
     } else {
         crate::status!(
             "FAILED: {} error(s), {warnings} warning(s)",
@@ -480,7 +528,8 @@ fn check_tool_versions(workspace: &Workspace, report: &mut Report) {
 }
 
 /// Check 6: every exclusion glob matches at least one member (catches typos),
-/// and no releasable member path-depends on a release-excluded member.
+/// and no member's runtime distribution would depend on a package unavailable
+/// in it — see [`ReleaseLifecycle`]'s ordering.
 fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     for (task, patterns) in &workspace.config.exclude {
         for pattern in patterns {
@@ -504,21 +553,32 @@ fn check_exclusions(workspace: &Workspace, report: &mut Report) {
             );
         }
     }
+    // And again for `publish.lifecycle.packages`: a glob matching nothing
+    // silently leaves its packages on the legacy mapping or the default.
+    for pattern in workspace.config.publish.lifecycle.packages.keys() {
+        check_member_glob(
+            workspace,
+            "`publish.lifecycle.packages` glob",
+            pattern,
+            report,
+        );
+    }
 
     for (idx, member) in workspace.members.iter().enumerate() {
-        if !member.releasable {
-            continue;
-        }
-        for &dep in workspace.deps_of(idx) {
+        for &dep in workspace.runtime_deps_of(idx) {
             let dep = &workspace.members[dep];
-            if !dep.releasable {
+            if dep.lifecycle < member.lifecycle {
                 report.push(
                     Finding::error(
                         Check::ReleaseBoundary,
                         format!(
-                            "releasable package `{}` path-depends on `{}`, which is excluded \
-                             from release and will never exist on Hex",
-                            member.name, dep.name
+                            "package `{}` (lifecycle `{}`) path-depends on `{}` (lifecycle \
+                             `{}`), which is unavailable in `{}`'s distribution",
+                            member.name,
+                            member.lifecycle.key(),
+                            dep.name,
+                            dep.lifecycle.key(),
+                            member.name
                         ),
                     )
                     .at(format!("{}/gleam.toml", member.rel_path))

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -20,7 +20,7 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
     crate::status!("version:    {}", member.version());
     crate::status!("path:       {}", member.rel_path);
     crate::status!("lifecycle:  {}", member.lifecycle.key());
-    crate::status!("releasable: {}", member.releasable);
+    crate::status!("releasable: {}", member.releasable());
     // Only the tags this member's mode actually produces — a series-only
     // package has no per-version tag to report.
     if member.tag_mode.includes_exact() {

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -19,6 +19,7 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
     crate::status!("name:       {}", member.name);
     crate::status!("version:    {}", member.version());
     crate::status!("path:       {}", member.rel_path);
+    crate::status!("lifecycle:  {}", member.lifecycle.key());
     crate::status!("releasable: {}", member.releasable);
     // Only the tags this member's mode actually produces — a series-only
     // package has no per-version tag to report.

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -24,8 +24,18 @@ pub fn run(workspace: &Workspace, options: &ListOptions) -> Result<()> {
         let document = ListDocument::new(workspace, &selected);
         println!("{}", serde_json::to_string_pretty(&document)?);
     } else {
+        // Human-readable output is not a stable contract (see
+        // json-output.mdx), but the two columns are always present and in
+        // this order: a reader (or a quick `awk '{print $1}'`) can rely on
+        // `name` coming first whatever else changes.
+        let width = selected
+            .iter()
+            .map(|&idx| workspace.members[idx].name.len())
+            .max()
+            .unwrap_or(0);
         for idx in selected {
-            crate::status!("{}", workspace.members[idx].name);
+            let member = &workspace.members[idx];
+            crate::status!("{:width$}  {}", member.name, member.lifecycle.key());
         }
     }
     Ok(())

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -181,9 +181,9 @@ fn pick_sibling<'a>(
     workspace
         .members
         .iter()
-        .filter(|m| m.releasable)
+        .filter(|m| m.releasable())
         .find(in_parent)
-        .or_else(|| workspace.members.iter().find(|m| m.releasable))
+        .or_else(|| workspace.members.iter().find(|m| m.releasable()))
         .or_else(|| workspace.members.first())
 }
 

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -38,8 +38,13 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
             let idx = workspace
                 .member_index(name)
                 .with_context(|| format!("unknown package `{name}`"))?;
-            if !workspace.members[idx].releasable {
-                bail!("package `{name}` is excluded from release by `@release`");
+            let member = &workspace.members[idx];
+            if !member.publishes_to_hex() {
+                bail!(
+                    "package `{name}` has release lifecycle `{}`, not `hex`, so it is never \
+                     published",
+                    member.lifecycle.key()
+                );
             }
             vec![idx]
         }
@@ -49,6 +54,14 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
                 version: tag_version,
             } => {
                 let member = &workspace.members[idx];
+                if !member.publishes_to_hex() {
+                    bail!(
+                        "tag `{tag}` names `{}`, which has release lifecycle `{}`, not `hex`, \
+                         so it is never published",
+                        member.name,
+                        member.lifecycle.key()
+                    );
+                }
                 if tag_version != member.version() {
                     bail!(
                         "tag `{tag}` says version {tag_version} but {}/gleam.toml says {} — \
@@ -76,16 +89,21 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
         },
         // Member indices are already topological; publish order follows.
         Selector::AllUntagged => (0..workspace.members.len())
-            .filter(|&idx| workspace.members[idx].releasable)
+            .filter(|&idx| workspace.members[idx].publishes_to_hex())
             .collect(),
     };
 
     let hex = HexClient::from_env();
     let retry = &workspace.config.publish.retry;
-    let releasable_versions: BTreeMap<String, String> = workspace
+    // Path deps are rewritten to Hex requirements derived from the
+    // dependency's *current* version — only meaningful for a dependency that
+    // will actually exist on Hex, so this map is `hex`-lifecycle members only.
+    // A `git_only` or `workspace` runtime path dep has no entry here, and
+    // `rewrite_path_deps` refuses to publish a package that needs one.
+    let hex_versions: BTreeMap<String, String> = workspace
         .members
         .iter()
-        .filter(|member| member.releasable)
+        .filter(|member| member.publishes_to_hex())
         .map(|member| (member.name.clone(), member.version().to_string()))
         .collect();
 
@@ -104,14 +122,14 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
         }
 
         // Compute the rewrite up front — for --dry-run reporting, and so a
-        // package that could never publish (path dep on an unreleasable
-        // member) fails before validation wastes time.
+        // package that could never publish (path dep on a non-hex member)
+        // fails before validation wastes time.
         let manifest_path = member.path.join("gleam.toml");
         let original = std::fs::read_to_string(&manifest_path)
             .with_context(|| format!("failed to read {}", manifest_path.display()))?;
         let (rewritten, rewrites) = rewrite::rewrite_path_deps(
             &original,
-            &releasable_versions,
+            &hex_versions,
             workspace.config.publish.path_dep_requirement,
         )
         .with_context(|| format!("cannot prepare `{name}` for publishing"))?;

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -69,7 +69,7 @@ fn plan_tags(workspace: &Workspace) -> Result<Vec<PlannedTag>> {
         .members
         .iter()
         .zip(0..)
-        .filter(|(member, _)| member.releasable)
+        .filter(|(member, _)| member.releasable())
     {
         if member.tag_mode.includes_exact() {
             let tag = workspace.config.format_tag(&member.name, member.version());
@@ -494,7 +494,7 @@ fn candidates(
         .members
         .iter()
         .zip(0..)
-        .filter(|(member, _)| member.releasable && wanted(member.tag_mode))
+        .filter(|(member, _)| member.releasable() && wanted(member.tag_mode))
         .map(|(member, index)| (index, member.name.as_str()))
         .collect()
 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -67,7 +67,7 @@ pub fn compute_plan(workspace: &Workspace, overrides: &Overrides) -> Result<Vec<
     let mut plan = Vec::new();
     let mut bumped: BTreeMap<&str, String> = BTreeMap::new();
     for (idx, member) in workspace.members.iter().enumerate() {
-        if !member.releasable {
+        if !member.releasable() {
             continue;
         }
         // Sorted by dependency name so the rendered order does not depend on
@@ -129,7 +129,7 @@ fn validate_named_packages(workspace: &Workspace, overrides: &Overrides) -> Resu
     for name in overrides.named_packages() {
         match workspace.member_index(name) {
             None => bail!("--bump/--set names unknown package `{name}`"),
-            Some(idx) if !workspace.members[idx].releasable => {
+            Some(idx) if !workspace.members[idx].releasable() => {
                 bail!(
                     "--bump/--set names `{name}`, whose release lifecycle is `{}`, so it is \
                      never versioned",

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -130,7 +130,11 @@ fn validate_named_packages(workspace: &Workspace, overrides: &Overrides) -> Resu
         match workspace.member_index(name) {
             None => bail!("--bump/--set names unknown package `{name}`"),
             Some(idx) if !workspace.members[idx].releasable => {
-                bail!("--bump/--set names `{name}`, which is excluded from releases");
+                bail!(
+                    "--bump/--set names `{name}`, whose release lifecycle is `{}`, so it is \
+                     never versioned",
+                    workspace.members[idx].lifecycle.key()
+                );
             }
             Some(_) => {}
         }

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -28,42 +28,32 @@ fn candidate(value: &str, help: String) -> CompletionCandidate {
     CompletionCandidate::new(value.to_owned()).help(Some(help.into()))
 }
 
-fn member_candidates(releasable_only: bool) -> Vec<CompletionCandidate> {
+fn member_candidates(keep: impl Fn(&crate::workspace::Member) -> bool) -> Vec<CompletionCandidate> {
     let Some(workspace) = workspace() else {
         return Vec::new();
     };
     workspace
         .members
         .iter()
-        .filter(|m| !releasable_only || m.releasable)
+        .filter(|m| keep(m))
         .map(|m| candidate(&m.name, format!("{} v{}", m.rel_path, m.version())))
         .collect()
 }
 
 /// Every workspace member, by name.
 pub fn packages() -> ArgValueCandidates {
-    ArgValueCandidates::new(|| member_candidates(false))
+    ArgValueCandidates::new(|| member_candidates(|_| true))
 }
 
 /// Only members that participate in releases — the ones `changelog new`
 /// accepts (release lifecycle `git_only` or `hex`).
 pub fn releasable_packages() -> ArgValueCandidates {
-    ArgValueCandidates::new(|| member_candidates(true))
+    ArgValueCandidates::new(|| member_candidates(|m| m.releasable()))
 }
 
 /// Only members `publish` will actually accept: release lifecycle `hex`.
 pub fn hex_packages() -> ArgValueCandidates {
-    ArgValueCandidates::new(|| {
-        let Some(workspace) = workspace() else {
-            return Vec::new();
-        };
-        workspace
-            .members
-            .iter()
-            .filter(|m| m.publishes_to_hex())
-            .map(|m| candidate(&m.name, format!("{} v{}", m.rel_path, m.version())))
-            .collect()
-    })
+    ArgValueCandidates::new(|| member_candidates(|m| m.publishes_to_hex()))
 }
 
 /// Built-in verbs plus every `[tools.trellis.tasks]` entry. The built-ins are

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -45,10 +45,25 @@ pub fn packages() -> ArgValueCandidates {
     ArgValueCandidates::new(|| member_candidates(false))
 }
 
-/// Only members that participate in releases — the ones `publish` and
-/// `changelog new` accept.
+/// Only members that participate in releases — the ones `changelog new`
+/// accepts (release lifecycle `git_only` or `hex`).
 pub fn releasable_packages() -> ArgValueCandidates {
     ArgValueCandidates::new(|| member_candidates(true))
+}
+
+/// Only members `publish` will actually accept: release lifecycle `hex`.
+pub fn hex_packages() -> ArgValueCandidates {
+    ArgValueCandidates::new(|| {
+        let Some(workspace) = workspace() else {
+            return Vec::new();
+        };
+        workspace
+            .members
+            .iter()
+            .filter(|m| m.publishes_to_hex())
+            .map(|m| candidate(&m.name, format!("{} v{}", m.rel_path, m.version())))
+            .collect()
+    })
 }
 
 /// Built-in verbs plus every `[tools.trellis.tasks]` entry. The built-ins are

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,9 +115,10 @@ fn deserialize_collecting_unknown(trellis: &toml::Value) -> Result<(ConfigFile, 
 }
 
 /// Tables under `[tools.trellis]` whose *keys* are chosen by the user rather
-/// than by trellis: task names, `exclude` selectors, and tag-mode names. A
-/// hyphen in one of those is the user's own naming, not a stale spelling.
-const FREE_FORM_TABLES: [&str; 3] = ["exclude", "tasks", "tag_mode_overrides"];
+/// than by trellis: task names, `exclude` selectors, tag-mode names, and
+/// `publish.lifecycle.packages` globs. A hyphen in one of those is the user's
+/// own naming (or a directory name inside a glob), not a stale spelling.
+const FREE_FORM_TABLES: [&str; 4] = ["exclude", "tasks", "tag_mode_overrides", "packages"];
 
 /// Find the keys still spelled the pre-0.8 kebab-case way.
 ///
@@ -230,6 +231,11 @@ pub struct PublishConfig {
     /// Retry/backoff policy for Hex-touching steps.
     #[serde(default)]
     pub retry: RetryConfig,
+    /// Per-package release lifecycle: which of changelog/version, git tags,
+    /// and Hex publishing a member participates in. See
+    /// [`ReleaseLifecycle`].
+    #[serde(default)]
+    pub lifecycle: LifecycleConfig,
 }
 
 impl Default for PublishConfig {
@@ -241,8 +247,72 @@ impl Default for PublishConfig {
             tag_mode_overrides: BTreeMap::new(),
             path_dep_requirement: PathDepRequirement::default(),
             retry: RetryConfig::default(),
+            lifecycle: LifecycleConfig::default(),
         }
     }
+}
+
+/// How much of the release pipeline a member participates in.
+///
+/// Replaces the old binary `@release` boundary with three states, so a
+/// monorepo can hold packages at different maturity levels without moving
+/// directories: build-and-test-only packages, packages versioned and tagged
+/// in git but never published, and fully published packages. Ordered from
+/// least to most capable — `dependency >= dependent` in this order is exactly
+/// the rule [`crate::commands::doctor`]'s `release_boundary` check enforces
+/// for runtime path dependencies.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Default,
+    Deserialize,
+    serde::Serialize,
+    clap::ValueEnum,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ReleaseLifecycle {
+    /// No changelog/version, no git tags, no Hex publish — build and test
+    /// only. The legacy `exclude.@release` mapping resolves here.
+    Workspace,
+    /// Changelog, version, and git tags/releases, but never published to Hex.
+    GitOnly,
+    /// The full pipeline: changelog, version, git tags/releases, and Hex
+    /// publish. The default lifecycle.
+    #[default]
+    Hex,
+}
+
+impl ReleaseLifecycle {
+    /// The configuration spelling, for messages that quote it back.
+    pub fn key(self) -> &'static str {
+        match self {
+            ReleaseLifecycle::Workspace => "workspace",
+            ReleaseLifecycle::GitOnly => "git_only",
+            ReleaseLifecycle::Hex => "hex",
+        }
+    }
+}
+
+/// `[tools.trellis.publish.lifecycle]`: the workspace default plus per-package
+/// overrides matched by member-path glob. `packages` is free-form — see
+/// [`FREE_FORM_TABLES`] — since its keys are globs, not schema names.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct LifecycleConfig {
+    /// Lifecycle for a member matched by no `packages` glob and no legacy
+    /// `exclude.@release` glob.
+    #[serde(default)]
+    pub default: ReleaseLifecycle,
+    /// Member-path glob -> lifecycle. A member matched by globs resolving to
+    /// different lifecycles is a deterministic error; matches agreeing on the
+    /// same lifecycle are fine. Takes precedence over `exclude.@release`.
+    #[serde(default)]
+    pub packages: BTreeMap<String, ReleaseLifecycle>,
 }
 
 fn default_tag_format() -> String {
@@ -1015,6 +1085,68 @@ mod tests {
                 .iter()
                 .any(|k| k.label == "Dependencies" && k.bump == Bump::Patch)
         );
+    }
+
+    #[test]
+    fn lifecycle_defaults_to_hex_with_no_package_overrides() {
+        let config =
+            ConfigFile::from_gleam_toml("[tools.trellis]\nmembers = [\"packages/*\"]").unwrap();
+        assert_eq!(config.publish.lifecycle.default, ReleaseLifecycle::Hex);
+        assert!(config.publish.lifecycle.packages.is_empty());
+    }
+
+    #[test]
+    fn lifecycle_parses_nested_table_and_inline_map() {
+        let config = ConfigFile::from_gleam_toml(
+            r###"
+            [tools.trellis.publish.lifecycle]
+            default = "hex"
+            packages = { "member/path/**" = "git_only", "examples/**" = "workspace" }
+            "###,
+        )
+        .unwrap();
+        assert_eq!(config.publish.lifecycle.default, ReleaseLifecycle::Hex);
+        assert_eq!(
+            config.publish.lifecycle.packages["member/path/**"],
+            ReleaseLifecycle::GitOnly
+        );
+        assert_eq!(
+            config.publish.lifecycle.packages["examples/**"],
+            ReleaseLifecycle::Workspace
+        );
+        // Glob keys carrying `-`/`/`/`*` are user-chosen, not deprecated spellings.
+        assert!(config.deprecated_keys.is_empty());
+        assert!(config.unknown_keys.is_empty());
+    }
+
+    #[test]
+    fn lifecycle_default_can_be_overridden() {
+        let config = ConfigFile::from_gleam_toml(
+            "[tools.trellis.publish.lifecycle]\ndefault = \"workspace\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            config.publish.lifecycle.default,
+            ReleaseLifecycle::Workspace
+        );
+    }
+
+    #[test]
+    fn lifecycle_rejects_an_unknown_value() {
+        let err = ConfigFile::from_gleam_toml(
+            "[tools.trellis.publish.lifecycle]\ndefault = \"published\"\n",
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("published"));
+    }
+
+    #[test]
+    fn lifecycle_package_glob_rejects_an_unknown_value() {
+        let err = ConfigFile::from_gleam_toml(
+            "[tools.trellis.publish.lifecycle]\npackages = { \"pkg/*\" = \"nope\" }\n",
+        )
+        .unwrap_err();
+        assert!(format!("{err:#}").contains("nope"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,7 +118,14 @@ fn deserialize_collecting_unknown(trellis: &toml::Value) -> Result<(ConfigFile, 
 /// than by trellis: task names, `exclude` selectors, tag-mode names, and
 /// `publish.lifecycle.packages` globs. A hyphen in one of those is the user's
 /// own naming (or a directory name inside a glob), not a stale spelling.
-const FREE_FORM_TABLES: [&str; 4] = ["exclude", "tasks", "tag_mode_overrides", "packages"];
+/// Entries are full snake-cased dotted paths, so a schema table that happens
+/// to share a segment name (`packages`, say) is not silently exempted.
+const FREE_FORM_TABLES: [&str; 4] = [
+    "exclude",
+    "tasks",
+    "publish.tag_mode_overrides",
+    "publish.lifecycle.packages",
+];
 
 /// Find the keys still spelled the pre-0.8 kebab-case way.
 ///
@@ -156,7 +163,7 @@ fn walk_schema_keys(value: &toml::Value, path: &mut String, visit: &mut impl FnM
         }
         path.push_str(key);
         visit(path, key);
-        if FREE_FORM_TABLES.contains(&snake_case(key).as_str()) {
+        if FREE_FORM_TABLES.contains(&snake_case(path).as_str()) {
             // The next level down is user-named; the one after that is ours.
             if let Some(entries) = value.as_table() {
                 for (name, value) in entries {
@@ -257,23 +264,11 @@ impl Default for PublishConfig {
 /// Replaces the old binary `@release` boundary with three states, so a
 /// monorepo can hold packages at different maturity levels without moving
 /// directories: build-and-test-only packages, packages versioned and tagged
-/// in git but never published, and fully published packages. Ordered from
-/// least to most capable — `dependency >= dependent` in this order is exactly
-/// the rule [`crate::commands::doctor`]'s `release_boundary` check enforces
-/// for runtime path dependencies.
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Default,
-    Deserialize,
-    serde::Serialize,
-    clap::ValueEnum,
-)]
+/// in git but never published, and fully published packages. The states form
+/// a capability ladder — [`ReleaseLifecycle::available_to`] is the rule
+/// [`crate::commands::doctor`]'s `release_boundary` check enforces for
+/// runtime path dependencies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReleaseLifecycle {
     /// No changelog/version, no git tags, no Hex publish — build and test
@@ -288,6 +283,13 @@ pub enum ReleaseLifecycle {
 }
 
 impl ReleaseLifecycle {
+    /// Every lifecycle, least to most capable — the order summaries display.
+    pub const ALL: [ReleaseLifecycle; 3] = [
+        ReleaseLifecycle::Workspace,
+        ReleaseLifecycle::GitOnly,
+        ReleaseLifecycle::Hex,
+    ];
+
     /// The configuration spelling, for messages that quote it back.
     pub fn key(self) -> &'static str {
         match self {
@@ -295,6 +297,23 @@ impl ReleaseLifecycle {
             ReleaseLifecycle::GitOnly => "git_only",
             ReleaseLifecycle::Hex => "hex",
         }
+    }
+
+    /// Position on the capability ladder; higher reaches further through the
+    /// release pipeline.
+    fn rank(self) -> u8 {
+        match self {
+            ReleaseLifecycle::Workspace => 0,
+            ReleaseLifecycle::GitOnly => 1,
+            ReleaseLifecycle::Hex => 2,
+        }
+    }
+
+    /// True when a package at this lifecycle is present in the distribution of
+    /// a dependent at `dependent`'s lifecycle — a dependency must be at least
+    /// as capable as its dependent.
+    pub fn available_to(self, dependent: ReleaseLifecycle) -> bool {
+        self.rank() >= dependent.rank()
     }
 }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -381,7 +381,7 @@ impl<'a> Package<'a> {
             version: member.version(),
             path: &member.rel_path,
             lifecycle: member.lifecycle,
-            releasable: member.releasable,
+            releasable: member.releasable(),
             dependencies: member_names(workspace, workspace.deps_of(idx)),
             dependents: member_names(workspace, workspace.dependents_of(idx)),
         }
@@ -480,7 +480,7 @@ impl<'a> GraphDocument<'a> {
                 version: member.version(),
                 path: &member.rel_path,
                 lifecycle: member.lifecycle,
-                releasable: member.releasable,
+                releasable: member.releasable(),
             })
             .collect();
         let mut edges = Vec::new();

--- a/src/json.rs
+++ b/src/json.rs
@@ -225,11 +225,11 @@ pub struct FixRecord<'a> {
 
 /// One member's resolved release lifecycle, as `doctor --format json` reports
 /// it — additive alongside the numeric `packages` count, in workspace
-/// (topological) order.
+/// (topological) order. Owned so doctor's report can hold it directly.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
-pub struct PackageLifecycleRecord<'a> {
-    pub name: &'a str,
+pub struct PackageLifecycleRecord {
+    pub name: String,
     pub lifecycle: crate::config::ReleaseLifecycle,
 }
 
@@ -258,7 +258,7 @@ pub struct DoctorDocument<'a> {
     pub applied: Vec<FixRecord<'a>>,
     /// Additive: each member's resolved lifecycle, alongside the (retained)
     /// numeric `packages` count above.
-    pub package_lifecycles: Vec<PackageLifecycleRecord<'a>>,
+    pub package_lifecycles: &'a [PackageLifecycleRecord],
 }
 
 impl DoctorDocument<'_> {

--- a/src/json.rs
+++ b/src/json.rs
@@ -47,9 +47,11 @@ pub enum Check {
     DependencyCycle,
     /// The root `[tools.trellis]` table itself is wrong.
     WorkspaceConfig,
-    /// A task-exclusion or tag-mode-override glob matches no member.
+    /// A task-exclusion, tag-mode-override, or `publish.lifecycle.packages`
+    /// glob matches no member.
     ExclusionGlob,
-    /// A releasable package depends on one excluded from release.
+    /// A package's runtime path dependency is less capable than it is —
+    /// see [`crate::config::ReleaseLifecycle`].
     ReleaseBoundary,
     /// Two releasable packages produce the same tag.
     TagCollision,
@@ -221,6 +223,16 @@ pub struct FixRecord<'a> {
     pub package: Option<&'a str>,
 }
 
+/// One member's resolved release lifecycle, as `doctor --format json` reports
+/// it — additive alongside the numeric `packages` count, in workspace
+/// (topological) order.
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct PackageLifecycleRecord<'a> {
+    pub name: &'a str,
+    pub lifecycle: crate::config::ReleaseLifecycle,
+}
+
 /// `trellis doctor --format json`.
 ///
 /// `configless` and `auto_members` are workspace facts rather than problems —
@@ -244,6 +256,9 @@ pub struct DoctorDocument<'a> {
     pub findings: &'a [Finding],
     pub fixes: Vec<FixRecord<'a>>,
     pub applied: Vec<FixRecord<'a>>,
+    /// Additive: each member's resolved lifecycle, alongside the (retained)
+    /// numeric `packages` count above.
+    pub package_lifecycles: Vec<PackageLifecycleRecord<'a>>,
 }
 
 impl DoctorDocument<'_> {
@@ -348,6 +363,11 @@ pub struct Package<'a> {
     pub name: &'a str,
     pub version: &'a str,
     pub path: &'a str,
+    /// Resolved release lifecycle: `workspace`, `git_only`, or `hex`. See
+    /// [`crate::config::ReleaseLifecycle`].
+    pub lifecycle: crate::config::ReleaseLifecycle,
+    /// Derived: `lifecycle != workspace`. Kept for compatibility —
+    /// `--releasable` filters on this, not on `lifecycle == hex`.
     pub releasable: bool,
     pub dependencies: Vec<&'a str>,
     pub dependents: Vec<&'a str>,
@@ -360,6 +380,7 @@ impl<'a> Package<'a> {
             name: &member.name,
             version: member.version(),
             path: &member.rel_path,
+            lifecycle: member.lifecycle,
             releasable: member.releasable,
             dependencies: member_names(workspace, workspace.deps_of(idx)),
             dependents: member_names(workspace, workspace.dependents_of(idx)),
@@ -426,6 +447,7 @@ pub struct GraphNode<'a> {
     pub name: &'a str,
     pub version: &'a str,
     pub path: &'a str,
+    pub lifecycle: crate::config::ReleaseLifecycle,
     pub releasable: bool,
 }
 
@@ -457,6 +479,7 @@ impl<'a> GraphDocument<'a> {
                 name: &member.name,
                 version: member.version(),
                 path: &member.rel_path,
+                lifecycle: member.lifecycle,
                 releasable: member.releasable,
             })
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ struct Cli {
 enum Command {
     /// List packages in topological order (dependencies first)
     List {
-        /// Emit JSON instead of names
+        /// Emit JSON instead of name/lifecycle columns
         #[arg(long)]
         json: bool,
         /// Only packages owning files changed since this git ref
@@ -101,7 +101,7 @@ enum Command {
         /// Add the reverse-dependency closure of the selection
         #[arg(long)]
         with_dependents: bool,
-        /// Only packages that participate in releases (excludes `@release` matches)
+        /// Only packages whose release lifecycle is `git_only` or `hex`
         #[arg(long)]
         releasable: bool,
     },
@@ -223,12 +223,12 @@ enum Command {
     /// Publish packages to Hex, in dependency order, with path deps rewritten
     Publish {
         /// A single package to publish
-        #[arg(add = completion::releasable_packages())]
+        #[arg(add = completion::hex_packages())]
         package: Option<String>,
         /// Resolve a pushed tag (e.g. lat_core-v1.2.0) to its package
         #[arg(long, conflicts_with = "package")]
         tag: Option<String>,
-        /// Every releasable package whose version isn't on Hex yet
+        /// Every `hex`-lifecycle package whose version isn't on Hex yet
         #[arg(long, conflicts_with_all = ["package", "tag"])]
         all_untagged: bool,
         /// Show what would be published (and rewritten) without doing it

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -36,15 +36,16 @@ pub fn hex_requirement(version: &str, mode: PathDepRequirement) -> Result<String
     })
 }
 
-/// Rewrite every path dep in `[dependencies]` (and releasable ones in
-/// `[dev-dependencies]`) to its Hex requirement. `releasable_versions` maps
-/// workspace member name → current version for members that will exist on
-/// Hex. A `[dependencies]` path dep with no entry there is a hard error —
-/// the published package could never resolve it. Dev-only path deps to
-/// unreleasable members are left alone: Hex packages don't ship dev deps.
+/// Rewrite every path dep in `[dependencies]` (and Hex-published ones in
+/// `[dev-dependencies]`) to its Hex requirement. `hex_versions` maps workspace
+/// member name -> current version, for members whose release lifecycle is
+/// `hex` (see [`crate::config::ReleaseLifecycle`]). A `[dependencies]` path
+/// dep with no entry there is a hard error — the published package could
+/// never resolve it. Dev-only path deps to a non-`hex` member are left alone:
+/// Hex packages don't ship dev deps.
 pub fn rewrite_path_deps(
     text: &str,
-    releasable_versions: &BTreeMap<String, String>,
+    hex_versions: &BTreeMap<String, String>,
     mode: PathDepRequirement,
 ) -> Result<(String, Vec<Rewrite>)> {
     let mut doc: DocumentMut = text.parse().context("failed to parse gleam.toml")?;
@@ -69,7 +70,7 @@ pub fn rewrite_path_deps(
             if !is_path_dep {
                 continue;
             }
-            match releasable_versions.get(&name) {
+            match hex_versions.get(&name) {
                 Some(version) => {
                     let requirement = hex_requirement(version, mode)?;
                     let mut value = Value::from(requirement.clone());
@@ -80,10 +81,10 @@ pub fn rewrite_path_deps(
                     rewrites.push(Rewrite { name, requirement });
                 }
                 None if section == "dependencies" => bail!(
-                    "path dependency `{name}` cannot be rewritten: it is not a releasable \
-                     workspace member, so the published package could never resolve it on Hex"
+                    "path dependency `{name}` cannot be rewritten: its release lifecycle is not \
+                     `hex`, so the published package could never resolve it on Hex"
                 ),
-                None => {} // dev-only path dep to an unreleasable member
+                None => {} // dev-only path dep to a non-`hex` member
             }
         }
     }
@@ -154,7 +155,7 @@ mod tests {
     }
 
     #[test]
-    fn dev_only_path_dep_to_unreleasable_member_is_left_alone() {
+    fn dev_only_path_dep_to_a_non_hex_member_is_left_alone() {
         let text = concat!(
             "name = \"lat_cli\"\n",
             "[dependencies]\n",
@@ -174,7 +175,7 @@ mod tests {
     }
 
     #[test]
-    fn regular_path_dep_to_unreleasable_member_is_an_error() {
+    fn regular_path_dep_to_a_non_hex_member_is_an_error() {
         let text = "name = \"app\"\n[dependencies]\nshared = { path = \"../shared\" }\n";
         let err = rewrite_path_deps(text, &versions(&[]), PathDepRequirement::Minor).unwrap_err();
         assert!(err.to_string().contains("shared"));

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -2,7 +2,7 @@
 //! dependency graph. Every command starts here; the topological order is
 //! computed once and consumed everywhere.
 
-use crate::config::{ConfigFile, TagMode};
+use crate::config::{ConfigFile, ReleaseLifecycle, TagMode};
 use crate::gleam::GleamManifest;
 use crate::json::{Check, Finding};
 use anyhow::{Context, Result, bail};
@@ -19,7 +19,13 @@ pub struct Member {
     /// Path relative to the workspace root, with forward slashes.
     pub rel_path: String,
     pub manifest: GleamManifest,
-    /// False when the member matches an `@release` exclusion glob.
+    /// Resolved release lifecycle: `publish.lifecycle.default`, overridden by
+    /// a legacy `exclude.@release` match, overridden in turn by an explicit
+    /// `publish.lifecycle.packages` match. See [`Workspace::load_with_diagnostics`].
+    pub lifecycle: ReleaseLifecycle,
+    /// Derived compatibility field: `lifecycle != workspace`. `true` for both
+    /// `git_only` and `hex` — changelog, version, and tag/release commands
+    /// select on this; `publish` alone needs `lifecycle == hex` specifically.
     pub releasable: bool,
     /// Which tags a release creates for this member: the workspace
     /// `tag_mode`, unless a `tag_mode_overrides` glob claims it.
@@ -27,6 +33,11 @@ pub struct Member {
 }
 
 impl Member {
+    /// True when this member is published to Hex (`lifecycle == hex`).
+    pub fn publishes_to_hex(&self) -> bool {
+        self.lifecycle == ReleaseLifecycle::Hex
+    }
+
     pub fn version(&self) -> &str {
         &self.manifest.version
     }
@@ -45,6 +56,11 @@ pub struct Workspace {
     deps: Vec<Vec<usize>>,
     /// Direct workspace dependents, indexed like `members`.
     dependents: Vec<Vec<usize>>,
+    /// Direct workspace dependencies from *runtime* (`[dependencies]`) path
+    /// deps only, indexed like `members`. Subset of `deps`, used by the
+    /// `release_boundary` lifecycle-availability check — a dev-only path dep
+    /// never ships in a distribution, so it never constrains it.
+    runtime_deps: Vec<Vec<usize>>,
 }
 
 /// Problems collected while loading. `Workspace::load` turns any error into a
@@ -261,6 +277,27 @@ impl Workspace {
                 }
             }
         }
+        // `publish.lifecycle.packages` globs, compiled individually — unlike
+        // `tag_mode_overrides`, each key names exactly one glob, so a member
+        // can match several with different targets, which is the case
+        // `resolve_lifecycle` must reject.
+        let mut lifecycle_overrides: Vec<(&str, ReleaseLifecycle, globset::GlobSet)> = Vec::new();
+        for (pattern, lifecycle) in &config.publish.lifecycle.packages {
+            match single_glob(pattern) {
+                Ok(set) => lifecycle_overrides.push((pattern.as_str(), *lifecycle, set)),
+                Err(err) => {
+                    diagnostics.push(
+                        Finding::error(
+                            Check::WorkspaceConfig,
+                            format!(
+                                "invalid `publish.lifecycle.packages` glob `{pattern}`: {err:#}"
+                            ),
+                        )
+                        .at(GLEAM_TOML),
+                    );
+                }
+            }
+        }
         let mut members = Vec::new();
         for dir in member_dirs {
             let rel_path = rel_path_string(root, &dir);
@@ -299,10 +336,13 @@ impl Workspace {
                                 .in_package(manifest.name.clone()),
                         );
                     }
-                    let releasable = release_excludes
-                        .as_ref()
-                        .map(|set| !set.is_match(&rel_path))
-                        .unwrap_or(true);
+                    let lifecycle = resolve_lifecycle(
+                        &lifecycle_overrides,
+                        release_excludes.as_ref(),
+                        &rel_path,
+                        config.publish.lifecycle.default,
+                        &mut diagnostics,
+                    );
                     let tag_mode = resolve_tag_mode(
                         &tag_mode_overrides,
                         &rel_path,
@@ -314,7 +354,8 @@ impl Workspace {
                         path: dir,
                         rel_path,
                         manifest,
-                        releasable,
+                        releasable: lifecycle != ReleaseLifecycle::Workspace,
+                        lifecycle,
                         tag_mode,
                     });
                 }
@@ -343,13 +384,17 @@ impl Workspace {
             }
         }
 
-        // Resolve path dependencies between members into graph edges.
+        // Resolve path dependencies between members into graph edges. Runtime
+        // edges (non-dev) are also tracked separately: dev-only path deps
+        // never ship in a distribution, so the lifecycle-availability check
+        // must not see them.
         let path_to_idx: HashMap<PathBuf, usize> = members
             .iter()
             .enumerate()
             .map(|(idx, member)| (member.path.clone(), idx))
             .collect();
         let mut edges: BTreeSet<(usize, usize)> = BTreeSet::new();
+        let mut runtime_edges: BTreeSet<(usize, usize)> = BTreeSet::new();
         for (idx, member) in members.iter().enumerate() {
             // Every problem here is a claim about this member's manifest, so
             // they all annotate the same file.
@@ -358,7 +403,7 @@ impl Workspace {
                     .at(format!("{}/{GLEAM_TOML}", member.rel_path))
                     .in_package(member.name.clone())
             };
-            for (dep_name, dep_path, _dev) in member.manifest.path_deps() {
+            for (dep_name, dep_path, dev) in member.manifest.path_deps() {
                 let resolved = normalize_path(&member.path.join(dep_path));
                 if !resolved.starts_with(root) {
                     diagnostics.push(blame(format!(
@@ -382,6 +427,9 @@ impl Workspace {
                             )));
                         } else {
                             edges.insert((dep_idx, idx)); // dependency -> dependent
+                            if !dev {
+                                runtime_edges.insert((dep_idx, idx));
+                            }
                         }
                     }
                     None => diagnostics.push(blame(format!(
@@ -425,7 +473,15 @@ impl Workspace {
             deps[dependent].push(dep);
             dependents[dep].push(dependent);
         }
-        for list in deps.iter_mut().chain(dependents.iter_mut()) {
+        let mut runtime_deps = vec![Vec::new(); members.len()];
+        for &(dep, dependent) in &runtime_edges {
+            runtime_deps[new_index[dependent]].push(new_index[dep]);
+        }
+        for list in deps
+            .iter_mut()
+            .chain(dependents.iter_mut())
+            .chain(runtime_deps.iter_mut())
+        {
             list.sort_unstable();
         }
 
@@ -436,6 +492,7 @@ impl Workspace {
             members,
             deps,
             dependents,
+            runtime_deps,
         };
         Ok((Some(workspace), diagnostics))
     }
@@ -449,6 +506,13 @@ impl Workspace {
     /// are returned unchanged rather than rewritten into `../` chains.
     pub fn rel_path_of(&self, path: &Path) -> String {
         rel_path_string(&self.root, path)
+    }
+
+    /// Direct *runtime* (`[dependencies]`, not `[dev-dependencies]`) workspace
+    /// dependencies of a member — the subset of [`Workspace::deps_of`] that
+    /// would actually ship in that member's distribution.
+    pub fn runtime_deps_of(&self, idx: usize) -> &[usize] {
+        &self.runtime_deps[idx]
     }
 
     /// Direct workspace dependencies of a member.
@@ -824,11 +888,89 @@ fn resolve_tag_mode(
     }
 }
 
+/// The member's resolved release lifecycle:
+///
+/// 1. Start from `publish.lifecycle.default`.
+/// 2. Apply the legacy `exclude.@release` mapping to `workspace`, when matched.
+/// 3. Apply an explicit `publish.lifecycle.packages` rule, when matched —
+///    this takes precedence over both of the above.
+///
+/// A member matched by explicit rules resolving to more than one distinct
+/// lifecycle is a deterministic error (falls back to the default); matching
+/// several rules that agree on the same lifecycle is fine — that's how a
+/// directory and a narrower glob inside it can both claim a member.
+fn resolve_lifecycle(
+    overrides: &[(&str, ReleaseLifecycle, globset::GlobSet)],
+    release_excludes: Option<&globset::GlobSet>,
+    rel_path: &str,
+    default: ReleaseLifecycle,
+    diagnostics: &mut Diagnostics,
+) -> ReleaseLifecycle {
+    let matched: Vec<(&str, ReleaseLifecycle)> = overrides
+        .iter()
+        .filter(|(_, _, set)| set.is_match(rel_path))
+        .map(|(pattern, lifecycle, _)| (*pattern, *lifecycle))
+        .collect();
+    let distinct: BTreeSet<ReleaseLifecycle> = matched.iter().map(|(_, l)| *l).collect();
+    match distinct.len() {
+        0 => {
+            if release_excludes.is_some_and(|set| set.is_match(rel_path)) {
+                ReleaseLifecycle::Workspace
+            } else {
+                default
+            }
+        }
+        1 => distinct.into_iter().next().expect("checked len == 1"),
+        _ => {
+            let mut by_lifecycle: Vec<(ReleaseLifecycle, Vec<&str>)> = Vec::new();
+            for (pattern, lifecycle) in &matched {
+                match by_lifecycle.iter_mut().find(|(l, _)| l == lifecycle) {
+                    Some((_, patterns)) => patterns.push(pattern),
+                    None => by_lifecycle.push((*lifecycle, vec![pattern])),
+                }
+            }
+            diagnostics.push(
+                Finding::error(
+                    Check::WorkspaceConfig,
+                    format!(
+                        "member `{rel_path}` matches `publish.lifecycle.packages` globs for \
+                         conflicting lifecycles: {}",
+                        by_lifecycle
+                            .iter()
+                            .map(|(lifecycle, patterns)| format!(
+                                "`{}` ({})",
+                                lifecycle.key(),
+                                patterns
+                                    .iter()
+                                    .map(|p| format!("`{p}`"))
+                                    .collect::<Vec<_>>()
+                                    .join(", ")
+                            ))
+                            .collect::<Vec<_>>()
+                            .join(" vs "),
+                    ),
+                )
+                .at(GLEAM_TOML),
+            );
+            default
+        }
+    }
+}
+
 fn build_globset(patterns: &[String]) -> Result<globset::GlobSet> {
     let mut builder = globset::GlobSetBuilder::new();
     for pattern in patterns {
         builder.add(globset::Glob::new(pattern)?);
     }
+    Ok(builder.build()?)
+}
+
+/// A `GlobSet` of exactly one pattern, for tables like
+/// `publish.lifecycle.packages` where each key is its own single glob rather
+/// than a mode-keyed list of them.
+fn single_glob(pattern: &str) -> Result<globset::GlobSet> {
+    let mut builder = globset::GlobSetBuilder::new();
+    builder.add(globset::Glob::new(pattern)?);
     Ok(builder.build()?)
 }
 
@@ -944,6 +1086,126 @@ mod tests {
         assert!(error.contains("packages/lat_core"), "{error}");
         assert!(
             error.contains("`series`") && error.contains("`both`"),
+            "{error}"
+        );
+    }
+
+    fn lifecycle_overrides<'a>(
+        entries: &[(&'a str, ReleaseLifecycle, &str)],
+    ) -> Vec<(&'a str, ReleaseLifecycle, globset::GlobSet)> {
+        entries
+            .iter()
+            .map(|(pattern, lifecycle, glob)| (*pattern, *lifecycle, single_glob(glob).unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn lifecycle_falls_back_to_the_workspace_default_with_no_matches() {
+        let mut diagnostics = Diagnostics::default();
+        let lifecycle = resolve_lifecycle(
+            &[],
+            None,
+            "packages/core",
+            ReleaseLifecycle::Hex,
+            &mut diagnostics,
+        );
+        assert_eq!(lifecycle, ReleaseLifecycle::Hex);
+        assert!(!diagnostics.has_errors());
+    }
+
+    #[test]
+    fn legacy_release_exclude_maps_to_workspace_lifecycle() {
+        let mut diagnostics = Diagnostics::default();
+        let release_excludes = globs(&["examples/*"]);
+        let lifecycle = resolve_lifecycle(
+            &[],
+            Some(&release_excludes),
+            "examples/demo",
+            ReleaseLifecycle::Hex,
+            &mut diagnostics,
+        );
+        assert_eq!(lifecycle, ReleaseLifecycle::Workspace);
+        // A member the legacy glob doesn't match keeps the default.
+        let lifecycle = resolve_lifecycle(
+            &[],
+            Some(&release_excludes),
+            "packages/core",
+            ReleaseLifecycle::Hex,
+            &mut diagnostics,
+        );
+        assert_eq!(lifecycle, ReleaseLifecycle::Hex);
+        assert!(!diagnostics.has_errors());
+    }
+
+    #[test]
+    fn explicit_lifecycle_rule_overrides_the_legacy_mapping() {
+        let mut diagnostics = Diagnostics::default();
+        let release_excludes = globs(&["examples/*"]);
+        let overrides =
+            lifecycle_overrides(&[("examples/**", ReleaseLifecycle::GitOnly, "examples/**")]);
+        let lifecycle = resolve_lifecycle(
+            &overrides,
+            Some(&release_excludes),
+            "examples/demo",
+            ReleaseLifecycle::Hex,
+            &mut diagnostics,
+        );
+        // Legacy alone would say `workspace`; the explicit rule wins.
+        assert_eq!(lifecycle, ReleaseLifecycle::GitOnly);
+        assert!(!diagnostics.has_errors());
+    }
+
+    #[test]
+    fn overlapping_rules_agreeing_on_the_same_lifecycle_are_fine() {
+        let mut diagnostics = Diagnostics::default();
+        let overrides = lifecycle_overrides(&[
+            ("packages/**", ReleaseLifecycle::GitOnly, "packages/**"),
+            (
+                "packages/providers/**",
+                ReleaseLifecycle::GitOnly,
+                "packages/providers/**",
+            ),
+        ]);
+        let lifecycle = resolve_lifecycle(
+            &overrides,
+            None,
+            "packages/providers/aws",
+            ReleaseLifecycle::Hex,
+            &mut diagnostics,
+        );
+        assert_eq!(lifecycle, ReleaseLifecycle::GitOnly);
+        assert!(!diagnostics.has_errors());
+    }
+
+    #[test]
+    fn conflicting_explicit_rules_are_a_deterministic_error() {
+        let mut diagnostics = Diagnostics::default();
+        let overrides = lifecycle_overrides(&[
+            ("packages/**", ReleaseLifecycle::GitOnly, "packages/**"),
+            (
+                "packages/special/**",
+                ReleaseLifecycle::Workspace,
+                "packages/special/**",
+            ),
+        ]);
+        let lifecycle = resolve_lifecycle(
+            &overrides,
+            None,
+            "packages/special/thing",
+            ReleaseLifecycle::Hex,
+            &mut diagnostics,
+        );
+        assert_eq!(
+            lifecycle,
+            ReleaseLifecycle::Hex,
+            "falls back to the default"
+        );
+        let errors: Vec<&str> = diagnostics.errors().collect();
+        assert_eq!(errors.len(), 1);
+        let error = errors[0];
+        assert!(error.contains("packages/special/thing"), "{error}");
+        assert!(
+            error.contains("`git_only`") && error.contains("`workspace`"),
             "{error}"
         );
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -23,10 +23,6 @@ pub struct Member {
     /// a legacy `exclude.@release` match, overridden in turn by an explicit
     /// `publish.lifecycle.packages` match. See [`Workspace::load_with_diagnostics`].
     pub lifecycle: ReleaseLifecycle,
-    /// Derived compatibility field: `lifecycle != workspace`. `true` for both
-    /// `git_only` and `hex` — changelog, version, and tag/release commands
-    /// select on this; `publish` alone needs `lifecycle == hex` specifically.
-    pub releasable: bool,
     /// Which tags a release creates for this member: the workspace
     /// `tag_mode`, unless a `tag_mode_overrides` glob claims it.
     pub tag_mode: TagMode,
@@ -36,6 +32,13 @@ impl Member {
     /// True when this member is published to Hex (`lifecycle == hex`).
     pub fn publishes_to_hex(&self) -> bool {
         self.lifecycle == ReleaseLifecycle::Hex
+    }
+
+    /// `true` for both `git_only` and `hex` — changelog, version, and
+    /// tag/release commands select on this; `publish` alone needs
+    /// `lifecycle == hex` specifically.
+    pub fn releasable(&self) -> bool {
+        self.lifecycle != ReleaseLifecycle::Workspace
     }
 
     pub fn version(&self) -> &str {
@@ -281,10 +284,13 @@ impl Workspace {
         // `tag_mode_overrides`, each key names exactly one glob, so a member
         // can match several with different targets, which is the case
         // `resolve_lifecycle` must reject.
-        let mut lifecycle_overrides: Vec<(&str, ReleaseLifecycle, globset::GlobSet)> = Vec::new();
+        let mut lifecycle_overrides: Vec<(&str, ReleaseLifecycle, globset::GlobMatcher)> =
+            Vec::new();
         for (pattern, lifecycle) in &config.publish.lifecycle.packages {
-            match single_glob(pattern) {
-                Ok(set) => lifecycle_overrides.push((pattern.as_str(), *lifecycle, set)),
+            match globset::Glob::new(pattern) {
+                Ok(glob) => {
+                    lifecycle_overrides.push((pattern.as_str(), *lifecycle, glob.compile_matcher()))
+                }
                 Err(err) => {
                     diagnostics.push(
                         Finding::error(
@@ -354,7 +360,6 @@ impl Workspace {
                         path: dir,
                         rel_path,
                         manifest,
-                        releasable: lifecycle != ReleaseLifecycle::Workspace,
                         lifecycle,
                         tag_mode,
                     });
@@ -579,7 +584,7 @@ impl Workspace {
         }
 
         if filter.releasable_only {
-            selected.retain(|&idx| self.members[idx].releasable);
+            selected.retain(|&idx| self.members[idx].releasable());
         }
 
         let mut ordered: Vec<usize> = selected.into_iter().collect();
@@ -900,7 +905,7 @@ fn resolve_tag_mode(
 /// several rules that agree on the same lifecycle is fine — that's how a
 /// directory and a narrower glob inside it can both claim a member.
 fn resolve_lifecycle(
-    overrides: &[(&str, ReleaseLifecycle, globset::GlobSet)],
+    overrides: &[(&str, ReleaseLifecycle, globset::GlobMatcher)],
     release_excludes: Option<&globset::GlobSet>,
     rel_path: &str,
     default: ReleaseLifecycle,
@@ -922,32 +927,20 @@ fn resolve_lifecycle(
         }
         1 => distinct.into_iter().next().expect("checked len == 1"),
         _ => {
-            let mut by_lifecycle: Vec<(ReleaseLifecycle, Vec<&str>)> = Vec::new();
-            for (pattern, lifecycle) in &matched {
-                match by_lifecycle.iter_mut().find(|(l, _)| l == lifecycle) {
-                    Some((_, patterns)) => patterns.push(pattern),
-                    None => by_lifecycle.push((*lifecycle, vec![pattern])),
-                }
-            }
             diagnostics.push(
                 Finding::error(
                     Check::WorkspaceConfig,
                     format!(
                         "member `{rel_path}` matches `publish.lifecycle.packages` globs for \
                          conflicting lifecycles: {}",
-                        by_lifecycle
+                        matched
                             .iter()
-                            .map(|(lifecycle, patterns)| format!(
-                                "`{}` ({})",
-                                lifecycle.key(),
-                                patterns
-                                    .iter()
-                                    .map(|p| format!("`{p}`"))
-                                    .collect::<Vec<_>>()
-                                    .join(", ")
+                            .map(|(pattern, lifecycle)| format!(
+                                "`{pattern}` => `{}`",
+                                lifecycle.key()
                             ))
                             .collect::<Vec<_>>()
-                            .join(" vs "),
+                            .join(", "),
                     ),
                 )
                 .at(GLEAM_TOML),
@@ -962,15 +955,6 @@ fn build_globset(patterns: &[String]) -> Result<globset::GlobSet> {
     for pattern in patterns {
         builder.add(globset::Glob::new(pattern)?);
     }
-    Ok(builder.build()?)
-}
-
-/// A `GlobSet` of exactly one pattern, for tables like
-/// `publish.lifecycle.packages` where each key is its own single glob rather
-/// than a mode-keyed list of them.
-fn single_glob(pattern: &str) -> Result<globset::GlobSet> {
-    let mut builder = globset::GlobSetBuilder::new();
-    builder.add(globset::Glob::new(pattern)?);
     Ok(builder.build()?)
 }
 
@@ -1091,11 +1075,17 @@ mod tests {
     }
 
     fn lifecycle_overrides<'a>(
-        entries: &[(&'a str, ReleaseLifecycle, &str)],
-    ) -> Vec<(&'a str, ReleaseLifecycle, globset::GlobSet)> {
+        entries: &[(&'a str, ReleaseLifecycle)],
+    ) -> Vec<(&'a str, ReleaseLifecycle, globset::GlobMatcher)> {
         entries
             .iter()
-            .map(|(pattern, lifecycle, glob)| (*pattern, *lifecycle, single_glob(glob).unwrap()))
+            .map(|(pattern, lifecycle)| {
+                (
+                    *pattern,
+                    *lifecycle,
+                    globset::Glob::new(pattern).unwrap().compile_matcher(),
+                )
+            })
             .collect()
     }
 
@@ -1141,8 +1131,7 @@ mod tests {
     fn explicit_lifecycle_rule_overrides_the_legacy_mapping() {
         let mut diagnostics = Diagnostics::default();
         let release_excludes = globs(&["examples/*"]);
-        let overrides =
-            lifecycle_overrides(&[("examples/**", ReleaseLifecycle::GitOnly, "examples/**")]);
+        let overrides = lifecycle_overrides(&[("examples/**", ReleaseLifecycle::GitOnly)]);
         let lifecycle = resolve_lifecycle(
             &overrides,
             Some(&release_excludes),
@@ -1159,12 +1148,8 @@ mod tests {
     fn overlapping_rules_agreeing_on_the_same_lifecycle_are_fine() {
         let mut diagnostics = Diagnostics::default();
         let overrides = lifecycle_overrides(&[
-            ("packages/**", ReleaseLifecycle::GitOnly, "packages/**"),
-            (
-                "packages/providers/**",
-                ReleaseLifecycle::GitOnly,
-                "packages/providers/**",
-            ),
+            ("packages/**", ReleaseLifecycle::GitOnly),
+            ("packages/providers/**", ReleaseLifecycle::GitOnly),
         ]);
         let lifecycle = resolve_lifecycle(
             &overrides,
@@ -1181,12 +1166,8 @@ mod tests {
     fn conflicting_explicit_rules_are_a_deterministic_error() {
         let mut diagnostics = Diagnostics::default();
         let overrides = lifecycle_overrides(&[
-            ("packages/**", ReleaseLifecycle::GitOnly, "packages/**"),
-            (
-                "packages/special/**",
-                ReleaseLifecycle::Workspace,
-                "packages/special/**",
-            ),
+            ("packages/**", ReleaseLifecycle::GitOnly),
+            ("packages/special/**", ReleaseLifecycle::Workspace),
         ]);
         let lifecycle = resolve_lifecycle(
             &overrides,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -284,13 +284,10 @@ impl Workspace {
         // `tag_mode_overrides`, each key names exactly one glob, so a member
         // can match several with different targets, which is the case
         // `resolve_lifecycle` must reject.
-        let mut lifecycle_overrides: Vec<(&str, ReleaseLifecycle, globset::GlobMatcher)> =
-            Vec::new();
+        let mut lifecycle_overrides: Vec<(ReleaseLifecycle, globset::GlobMatcher)> = Vec::new();
         for (pattern, lifecycle) in &config.publish.lifecycle.packages {
             match globset::Glob::new(pattern) {
-                Ok(glob) => {
-                    lifecycle_overrides.push((pattern.as_str(), *lifecycle, glob.compile_matcher()))
-                }
+                Ok(glob) => lifecycle_overrides.push((*lifecycle, glob.compile_matcher())),
                 Err(err) => {
                     diagnostics.push(
                         Finding::error(
@@ -905,28 +902,27 @@ fn resolve_tag_mode(
 /// several rules that agree on the same lifecycle is fine — that's how a
 /// directory and a narrower glob inside it can both claim a member.
 fn resolve_lifecycle(
-    overrides: &[(&str, ReleaseLifecycle, globset::GlobMatcher)],
+    overrides: &[(ReleaseLifecycle, globset::GlobMatcher)],
     release_excludes: Option<&globset::GlobSet>,
     rel_path: &str,
     default: ReleaseLifecycle,
     diagnostics: &mut Diagnostics,
 ) -> ReleaseLifecycle {
-    let matched: Vec<(&str, ReleaseLifecycle)> = overrides
+    let matched: Vec<(ReleaseLifecycle, &str)> = overrides
         .iter()
-        .filter(|(_, _, set)| set.is_match(rel_path))
-        .map(|(pattern, lifecycle, _)| (*pattern, *lifecycle))
+        .filter(|(_, matcher)| matcher.is_match(rel_path))
+        .map(|(lifecycle, matcher)| (*lifecycle, matcher.glob().glob()))
         .collect();
-    let distinct: BTreeSet<ReleaseLifecycle> = matched.iter().map(|(_, l)| *l).collect();
-    match distinct.len() {
-        0 => {
+    match matched.split_first() {
+        None => {
             if release_excludes.is_some_and(|set| set.is_match(rel_path)) {
                 ReleaseLifecycle::Workspace
             } else {
                 default
             }
         }
-        1 => distinct.into_iter().next().expect("checked len == 1"),
-        _ => {
+        Some((&(first, _), rest)) if rest.iter().all(|&(lifecycle, _)| lifecycle == first) => first,
+        Some(_) => {
             diagnostics.push(
                 Finding::error(
                     Check::WorkspaceConfig,
@@ -935,7 +931,7 @@ fn resolve_lifecycle(
                          conflicting lifecycles: {}",
                         matched
                             .iter()
-                            .map(|(pattern, lifecycle)| format!(
+                            .map(|(lifecycle, pattern)| format!(
                                 "`{pattern}` => `{}`",
                                 lifecycle.key()
                             ))
@@ -1074,14 +1070,13 @@ mod tests {
         );
     }
 
-    fn lifecycle_overrides<'a>(
-        entries: &[(&'a str, ReleaseLifecycle)],
-    ) -> Vec<(&'a str, ReleaseLifecycle, globset::GlobMatcher)> {
+    fn lifecycle_overrides(
+        entries: &[(&str, ReleaseLifecycle)],
+    ) -> Vec<(ReleaseLifecycle, globset::GlobMatcher)> {
         entries
             .iter()
             .map(|(pattern, lifecycle)| {
                 (
-                    *pattern,
                     *lifecycle,
                     globset::Glob::new(pattern).unwrap().compile_matcher(),
                 )

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -25,7 +25,7 @@ fn list_prints_members_in_topological_order() {
         .arg("list")
         .assert()
         .success()
-        .stdout("lat_core\nlat_mid\nlat_cli\npackage_a\n");
+        .stdout("lat_core   hex\nlat_mid    hex\nlat_cli    hex\npackage_a  workspace\n");
 }
 
 #[test]
@@ -34,7 +34,7 @@ fn list_works_from_inside_a_package() {
         .arg("list")
         .assert()
         .success()
-        .stdout(predicate::str::starts_with("lat_core\n"));
+        .stdout(predicate::str::starts_with("lat_core"));
 }
 
 #[test]
@@ -43,7 +43,7 @@ fn list_releasable_excludes_release_excluded_members() {
         .args(["list", "--releasable"])
         .assert()
         .success()
-        .stdout("lat_core\nlat_mid\nlat_cli\n");
+        .stdout("lat_core  hex\nlat_mid   hex\nlat_cli   hex\n");
 }
 
 #[test]
@@ -60,10 +60,12 @@ fn list_json_includes_graph_facts() {
     let mid = items.iter().find(|i| i["name"] == "lat_mid").unwrap();
     assert_eq!(mid["version"], "0.5.0");
     assert_eq!(mid["path"], "packages/lat_mid");
+    assert_eq!(mid["lifecycle"], "hex");
     assert_eq!(mid["releasable"], true);
     assert_eq!(mid["dependencies"], serde_json::json!(["lat_core"]));
     assert_eq!(mid["dependents"], serde_json::json!(["lat_cli"]));
     let package_a = items.iter().find(|i| i["name"] == "package_a").unwrap();
+    assert_eq!(package_a["lifecycle"], "workspace");
     assert_eq!(package_a["releasable"], false);
 }
 
@@ -471,7 +473,7 @@ fn global_flags_are_accepted_after_the_subcommand() {
         .args(["list", "--verbose", "--color", "never", "--no-update-check"])
         .assert()
         .success()
-        .stdout("lat_core\nlat_mid\nlat_cli\npackage_a\n");
+        .stdout("lat_core   hex\nlat_mid    hex\nlat_cli    hex\npackage_a  workspace\n");
 }
 
 #[test]
@@ -587,7 +589,9 @@ fn doctor_flags_releasable_dep_on_unreleasable_member() {
         .arg("doctor")
         .assert()
         .failure()
-        .stdout(predicate::str::contains("will never exist on Hex"));
+        .stdout(predicate::str::contains(
+            "which is unavailable in `app`'s distribution",
+        ));
 }
 
 #[test]
@@ -642,7 +646,9 @@ fn doctor_fix_seeds_missing_changelog() {
         .arg("doctor")
         .assert()
         .success()
-        .stdout(predicate::str::contains("ok: 1 package(s), 0 warning(s)"));
+        .stdout(predicate::str::contains(
+            "ok: 1 package(s) (0 workspace, 0 git_only, 1 hex), 0 warning(s)",
+        ));
 }
 
 /// A CHANGELOG.md that trellis never batched would be regenerated away on the
@@ -688,7 +694,9 @@ fn doctor_fix_adopts_unbatched_changelog_history() {
         .arg("doctor")
         .assert()
         .success()
-        .stdout(predicate::str::contains("ok: 1 package(s), 0 warning(s)"));
+        .stdout(predicate::str::contains(
+            "ok: 1 package(s) (0 workspace, 0 git_only, 1 hex), 0 warning(s)",
+        ));
 }
 
 #[test]
@@ -1186,13 +1194,13 @@ fn since_selects_changed_packages_and_dependents() {
         .args(["list", "--since", "main"])
         .assert()
         .success()
-        .stdout("lat_mid\n");
+        .stdout("lat_mid  hex\n");
 
     trellis(root)
         .args(["list", "--since", "main", "--with-dependents"])
         .assert()
         .success()
-        .stdout("lat_mid\nlat_cli\npackage_a\n");
+        .stdout("lat_mid    hex\nlat_cli    hex\npackage_a  workspace\n");
 
     // Uncommitted changes count too.
     write(&root.join("packages/lat_core/src/wip.gleam"), "// wip\n");
@@ -1200,7 +1208,7 @@ fn since_selects_changed_packages_and_dependents() {
         .args(["list", "--since", "main"])
         .assert()
         .success()
-        .stdout("lat_core\nlat_mid\n");
+        .stdout("lat_core  hex\nlat_mid   hex\n");
 }
 
 // ---- version ---------------------------------------------------------
@@ -1323,7 +1331,7 @@ fn an_unrecognized_config_key_warns_but_still_loads() {
         .arg("list")
         .assert()
         .success()
-        .stdout("a\nb\n");
+        .stdout("a  hex\nb  hex\n");
 }
 
 #[test]

--- a/tests/configless.rs
+++ b/tests/configless.rs
@@ -55,7 +55,7 @@ fn configless_list_discovers_members_from_the_git_root() {
         .arg("list")
         .assert()
         .success()
-        .stdout("core\ncli\n");
+        .stdout("core  hex\ncli   hex\n");
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn configless_works_from_inside_a_package() {
         .arg("list")
         .assert()
         .success()
-        .stdout("core\ncli\n");
+        .stdout("core  hex\ncli   hex\n");
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn configless_skips_gitignored_paths_and_build() {
         .arg("list")
         .assert()
         .success()
-        .stdout("core\ncli\n");
+        .stdout("core  hex\ncli   hex\n");
 }
 
 #[test]
@@ -200,12 +200,12 @@ fn table_without_members_auto_discovers_and_keeps_exclusions() {
         .arg("list")
         .assert()
         .success()
-        .stdout("core\ncli\ndemo\n");
+        .stdout("core  hex\ncli   hex\ndemo  workspace\n");
     trellis(root)
         .args(["list", "--releasable"])
         .assert()
         .success()
-        .stdout("core\ncli\n");
+        .stdout("core  hex\ncli   hex\n");
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn at_members_excludes_directories_from_membership() {
         .arg("list")
         .assert()
         .success()
-        .stdout("core\ncli\n");
+        .stdout("core  hex\ncli   hex\n");
 }
 
 #[test]
@@ -247,7 +247,7 @@ fn at_members_also_filters_explicit_member_globs() {
         .arg("list")
         .assert()
         .success()
-        .stdout("core\n");
+        .stdout("core  hex\n");
 }
 
 #[test]
@@ -266,5 +266,5 @@ fn new_package_is_discovered_without_a_members_glob() {
         .arg("list")
         .assert()
         .success()
-        .stdout(predicate::str::contains("extra\n"));
+        .stdout(predicate::str::contains("extra"));
 }

--- a/tests/fixtures/lifecycle/examples/demo/gleam.toml
+++ b/tests/fixtures/lifecycle/examples/demo/gleam.toml
@@ -1,0 +1,5 @@
+name = "demo"
+version = "0.0.0"
+
+[dependencies]
+core = { path = "../../packages/core" }

--- a/tests/fixtures/lifecycle/gleam.toml
+++ b/tests/fixtures/lifecycle/gleam.toml
@@ -1,0 +1,13 @@
+# Workspace root exercising all three release lifecycle states in one
+# workspace: `packages/core` is the implicit default (hex), `packages/adapter`
+# is explicit `git_only`, `packages/tooling` is explicit `workspace`, and
+# `examples/demo` reaches `workspace` through the legacy `exclude.@release`
+# mapping rather than an explicit rule.
+
+[tools.trellis]
+members = ["packages/*", "examples/*"]
+exclude = { "@release" = ["examples/*"] }
+
+[tools.trellis.publish.lifecycle]
+default = "hex"
+packages = { "packages/adapter" = "git_only", "packages/tooling" = "workspace" }

--- a/tests/fixtures/lifecycle/packages/adapter/CHANGELOG.md
+++ b/tests/fixtures/lifecycle/packages/adapter/CHANGELOG.md
@@ -1,0 +1,5 @@
+# adapter changelog
+
+## adapter-v0.4.0 - 2026-01-01
+
+- initial

--- a/tests/fixtures/lifecycle/packages/adapter/gleam.toml
+++ b/tests/fixtures/lifecycle/packages/adapter/gleam.toml
@@ -1,0 +1,5 @@
+name = "adapter"
+version = "0.4.0"
+
+[dependencies]
+core = { path = "../core" }

--- a/tests/fixtures/lifecycle/packages/core/CHANGELOG.md
+++ b/tests/fixtures/lifecycle/packages/core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# core changelog
+
+## core-v1.0.0 - 2026-01-01
+
+- initial

--- a/tests/fixtures/lifecycle/packages/core/gleam.toml
+++ b/tests/fixtures/lifecycle/packages/core/gleam.toml
@@ -1,0 +1,2 @@
+name = "core"
+version = "1.0.0"

--- a/tests/fixtures/lifecycle/packages/tooling/gleam.toml
+++ b/tests/fixtures/lifecycle/packages/tooling/gleam.toml
@@ -1,0 +1,5 @@
+name = "tooling"
+version = "0.1.0"
+
+[dependencies]
+adapter = { path = "../adapter" }

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -114,7 +114,7 @@ fn the_written_table_is_what_root_discovery_finds() {
         .arg("list")
         .assert()
         .success()
-        .stdout("a\nb\n");
+        .stdout("a  hex\nb  hex\n");
     // The configless note is gone: the workspace is now declared.
     trellis(root)
         .arg("doctor")
@@ -243,5 +243,9 @@ fn init_in_an_empty_repository_still_writes_a_usable_root() {
         &root.join("packages/a/gleam.toml"),
         "name = \"a\"\nversion = \"1.0.0\"\n",
     );
-    trellis(root).arg("list").assert().success().stdout("a\n");
+    trellis(root)
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("a  hex\n");
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -1,0 +1,503 @@
+//! End-to-end tests for per-package release lifecycle states (issue #74):
+//! `publish.lifecycle` configuration, resolution against the legacy
+//! `exclude.@release` mapping, the dependency-availability rule, and the
+//! lifecycle matrix across changelog, version, tag, publish, and CI commands.
+//!
+//! `tests/fixtures/lifecycle` fixes one workspace exercising all three
+//! states: `core` is the implicit default (`hex`), `adapter` is explicit
+//! `git_only`, `tooling` is explicit `workspace`, and `demo` reaches
+//! `workspace` through the legacy `@release` mapping instead of an explicit
+//! rule.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name)
+}
+
+fn trellis(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("trellis").unwrap();
+    cmd.current_dir(dir);
+    cmd.env("SOURCE_DATE_EPOCH", "1783728000");
+    cmd
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn copy_fixture_to(root: &Path) {
+    fn walk(dir: &Path, files: &mut Vec<PathBuf>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                walk(&path, files);
+            } else {
+                files.push(path);
+            }
+        }
+    }
+    let from = fixture("lifecycle");
+    let mut files = Vec::new();
+    walk(&from, &mut files);
+    for file in files {
+        let dest = root.join(file.strip_prefix(&from).unwrap());
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::copy(&file, &dest).unwrap();
+    }
+}
+
+// ---- introspection over the mixed-lifecycle fixture -------------------
+
+#[test]
+fn doctor_passes_the_mixed_lifecycle_workspace() {
+    trellis(&fixture("lifecycle"))
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "ok: 4 package(s) (2 workspace, 1 git_only, 1 hex)",
+        ));
+}
+
+#[test]
+fn list_json_reports_all_three_lifecycle_states() {
+    let output = trellis(&fixture("lifecycle"))
+        .args(["list", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let items = document["packages"].as_array().unwrap();
+    let lifecycle_of = |name: &str| {
+        items
+            .iter()
+            .find(|p| p["name"] == name)
+            .unwrap_or_else(|| panic!("no package named {name}"))["lifecycle"]
+            .clone()
+    };
+    assert_eq!(lifecycle_of("core"), "hex");
+    assert_eq!(lifecycle_of("adapter"), "git_only");
+    // Explicit rule and legacy `@release` mapping agree on the same state.
+    assert_eq!(lifecycle_of("tooling"), "workspace");
+    assert_eq!(lifecycle_of("demo"), "workspace");
+    // `releasable` stays the git_only+hex compatibility boolean.
+    let core = items.iter().find(|p| p["name"] == "core").unwrap();
+    let adapter = items.iter().find(|p| p["name"] == "adapter").unwrap();
+    let tooling = items.iter().find(|p| p["name"] == "tooling").unwrap();
+    assert_eq!(core["releasable"], true);
+    assert_eq!(adapter["releasable"], true);
+    assert_eq!(tooling["releasable"], false);
+}
+
+#[test]
+fn list_releasable_filters_to_git_only_and_hex() {
+    trellis(&fixture("lifecycle"))
+        .args(["list", "--releasable"])
+        .assert()
+        .success()
+        .stdout("core     hex\nadapter  git_only\n");
+}
+
+#[test]
+fn list_text_default_shows_a_lifecycle_column_for_every_state() {
+    trellis(&fixture("lifecycle"))
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("core     hex\nadapter  git_only\ndemo     workspace\ntooling  workspace\n");
+}
+
+#[test]
+fn graph_json_reports_lifecycle_per_node() {
+    let output = trellis(&fixture("lifecycle"))
+        .args(["graph", "--format", "json"])
+        .output()
+        .unwrap();
+    let graph: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let nodes = graph["nodes"].as_array().unwrap();
+    let adapter = nodes.iter().find(|n| n["name"] == "adapter").unwrap();
+    assert_eq!(adapter["lifecycle"], "git_only");
+}
+
+#[test]
+fn info_reports_lifecycle_in_text_and_json() {
+    trellis(&fixture("lifecycle"))
+        .args(["info", "adapter"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lifecycle:  git_only"));
+
+    let output = trellis(&fixture("lifecycle"))
+        .args(["info", "adapter", "--json"])
+        .output()
+        .unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(document["lifecycle"], "git_only");
+}
+
+#[test]
+fn doctor_json_reports_package_lifecycles_alongside_the_numeric_count() {
+    let output = trellis(&fixture("lifecycle"))
+        .args(["doctor", "--format", "json"])
+        .output()
+        .unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // The numeric field is retained...
+    assert_eq!(document["packages"], 4);
+    // ...and the additive per-package records sit alongside it.
+    let records = document["package_lifecycles"].as_array().unwrap();
+    assert_eq!(records.len(), 4);
+    let lifecycle_of = |name: &str| {
+        records
+            .iter()
+            .find(|r| r["name"] == name)
+            .unwrap_or_else(|| panic!("no record for {name}"))["lifecycle"]
+            .clone()
+    };
+    assert_eq!(lifecycle_of("core"), "hex");
+    assert_eq!(lifecycle_of("adapter"), "git_only");
+    assert_eq!(lifecycle_of("tooling"), "workspace");
+    assert_eq!(lifecycle_of("demo"), "workspace");
+}
+
+// ---- the lifecycle matrix across commands ------------------------------
+
+#[test]
+fn tag_plan_includes_git_only_and_hex_but_not_workspace() {
+    trellis(&fixture("lifecycle"))
+        .args(["tag", "plan"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "core: 1.0.0 needs tag core-v1.0.0",
+        ))
+        .stdout(predicate::str::contains(
+            "adapter: 0.4.0 needs tag adapter-v0.4.0",
+        ))
+        .stdout(predicate::str::contains("tooling").not())
+        .stdout(predicate::str::contains("demo").not());
+}
+
+#[test]
+fn ci_outputs_releasable_is_git_only_and_hex_only() {
+    let output = trellis(&fixture("lifecycle"))
+        .args(["ci", "outputs"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let releasable = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("releasable="))
+        .unwrap();
+    let releasable: Vec<String> = serde_json::from_str(releasable).unwrap();
+    assert_eq!(releasable, ["core", "adapter"]);
+    let tags = stdout
+        .lines()
+        .find_map(|line| line.strip_prefix("tags="))
+        .unwrap();
+    let tags: Vec<String> = serde_json::from_str(tags).unwrap();
+    assert_eq!(tags, ["core-v1.0.0", "adapter-v0.4.0"]);
+}
+
+#[test]
+fn changelog_new_rejects_a_workspace_lifecycle_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    trellis(root)
+        .args([
+            "changelog",
+            "new",
+            "--package",
+            "tooling",
+            "--kind",
+            "Added",
+            "--body",
+            "x",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "package `tooling` has release lifecycle `workspace`, so it never gets a \
+             changelog entry",
+        ));
+}
+
+#[test]
+fn version_plan_rejects_a_workspace_lifecycle_package_by_name() {
+    trellis(&fixture("lifecycle"))
+        .args(["version", "plan", "--bump", "demo=major"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--bump/--set names `demo`, whose release lifecycle is `workspace`",
+        ));
+}
+
+#[test]
+fn publish_rejects_a_git_only_package_by_name() {
+    trellis(&fixture("lifecycle"))
+        .args(["publish", "adapter"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "package `adapter` has release lifecycle `git_only`, not `hex`",
+        ));
+}
+
+#[test]
+fn publish_all_untagged_selects_hex_packages_only() {
+    trellis(&fixture("lifecycle"))
+        .args(["publish", "--all-untagged", "--dry-run"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[core] would publish 1.0.0"))
+        .stdout(predicate::str::contains("adapter").not())
+        .stdout(predicate::str::contains("tooling").not())
+        .stdout(predicate::str::contains("demo").not());
+}
+
+// ---- configuration: parsing, precedence, and conflicts -----------------
+
+#[test]
+fn explicit_rule_overrides_the_legacy_release_exclude_mapping() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\
+         exclude = { \"@release\" = [\"packages/a\"] }\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/a\" = \"git_only\" }\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+
+    let output = trellis(root).args(["list", "--json"]).output().unwrap();
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let packages = document["packages"].as_array().unwrap();
+    // Legacy alone would resolve `a` to `workspace`; the explicit rule wins.
+    assert_eq!(packages[0]["lifecycle"], "git_only");
+}
+
+#[test]
+fn conflicting_explicit_lifecycle_rules_are_a_doctor_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/a\" = \"git_only\", \"packages/*\" = \"workspace\" }\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "matches `publish.lifecycle.packages` globs for conflicting lifecycles",
+        ))
+        .stdout(predicate::str::contains("`git_only`"))
+        .stdout(predicate::str::contains("`workspace`"));
+}
+
+#[test]
+fn overlapping_rules_agreeing_on_the_same_lifecycle_do_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/a\" = \"git_only\", \"packages/*\" = \"git_only\" }\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "ok: 1 package(s) (0 workspace, 1 git_only, 0 hex)",
+        ));
+}
+
+#[test]
+fn an_unknown_lifecycle_value_is_a_clear_config_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         default = \"published\"\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("published"));
+}
+
+#[test]
+fn an_unmatched_lifecycle_glob_is_flagged_by_doctor() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/nomatch\" = \"git_only\" }\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "`publish.lifecycle.packages` glob `packages/nomatch` matches no member",
+        ));
+}
+
+// ---- the dependency-availability rule -----------------------------------
+
+#[test]
+fn a_hex_package_depending_on_a_git_only_package_is_a_doctor_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/lib\" = \"git_only\" }\n",
+    );
+    write(
+        &root.join("packages/app/gleam.toml"),
+        "name = \"app\"\nversion = \"1.0.0\"\n[dependencies]\nlib = { path = \"../lib\" }\n",
+    );
+    write(
+        &root.join("packages/lib/gleam.toml"),
+        "name = \"lib\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "package `app` (lifecycle `hex`) path-depends on `lib` (lifecycle `git_only`), \
+             which is unavailable in `app`'s distribution",
+        ));
+}
+
+#[test]
+fn a_git_only_package_depending_on_a_workspace_package_is_a_doctor_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/app\" = \"git_only\", \"packages/lib\" = \"workspace\" }\n",
+    );
+    write(
+        &root.join("packages/app/gleam.toml"),
+        "name = \"app\"\nversion = \"1.0.0\"\n[dependencies]\nlib = { path = \"../lib\" }\n",
+    );
+    write(
+        &root.join("packages/lib/gleam.toml"),
+        "name = \"lib\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "package `app` (lifecycle `git_only`) path-depends on `lib` (lifecycle `workspace`)",
+        ));
+}
+
+#[test]
+fn a_workspace_package_may_depend_on_a_hex_package() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/app\" = \"workspace\" }\n",
+    );
+    write(
+        &root.join("packages/app/gleam.toml"),
+        "name = \"app\"\nversion = \"1.0.0\"\n[dependencies]\nlib = { path = \"../lib\" }\n",
+    );
+    write(
+        &root.join("packages/lib/gleam.toml"),
+        "name = \"lib\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "ok: 2 package(s) (1 workspace, 0 git_only, 1 hex)",
+        ));
+}
+
+#[test]
+fn a_dev_only_path_dep_is_exempt_from_the_availability_rule() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n\n\
+         [tools.trellis.publish.lifecycle]\n\
+         packages = { \"packages/lib\" = \"workspace\" }\n",
+    );
+    // `app` is `hex` (the default) and only *dev*-depends on the workspace-only
+    // `lib` — a test helper, say. That never ships in `app`'s distribution.
+    write(
+        &root.join("packages/app/gleam.toml"),
+        "name = \"app\"\nversion = \"1.0.0\"\n[dev-dependencies]\nlib = { path = \"../lib\" }\n",
+    );
+    write(
+        &root.join("packages/lib/gleam.toml"),
+        "name = \"lib\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "ok: 2 package(s) (1 workspace, 0 git_only, 1 hex)",
+        ));
+}

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -32,27 +32,6 @@ fn write(path: &Path, content: &str) {
     fs::write(path, content).unwrap();
 }
 
-fn copy_fixture_to(root: &Path) {
-    fn walk(dir: &Path, files: &mut Vec<PathBuf>) {
-        for entry in fs::read_dir(dir).unwrap() {
-            let path = entry.unwrap().path();
-            if path.is_dir() {
-                walk(&path, files);
-            } else {
-                files.push(path);
-            }
-        }
-    }
-    let from = fixture("lifecycle");
-    let mut files = Vec::new();
-    walk(&from, &mut files);
-    for file in files {
-        let dest = root.join(file.strip_prefix(&from).unwrap());
-        fs::create_dir_all(dest.parent().unwrap()).unwrap();
-        fs::copy(&file, &dest).unwrap();
-    }
-}
-
 // ---- introspection over the mixed-lifecycle fixture -------------------
 
 #[test]
@@ -208,10 +187,9 @@ fn ci_outputs_releasable_is_git_only_and_hex_only() {
 
 #[test]
 fn changelog_new_rejects_a_workspace_lifecycle_package() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    copy_fixture_to(root);
-    trellis(root)
+    // Runs against the shared fixture directly: the command fails validation
+    // before it would write anything.
+    trellis(&fixture("lifecycle"))
         .args([
             "changelog",
             "new",

--- a/tests/member_discovery.rs
+++ b/tests/member_discovery.rs
@@ -63,7 +63,7 @@ fn recursive_member_glob_respects_repository_git_ignores() {
         .arg("list")
         .assert()
         .success()
-        .stdout("chatrooms\ncollab_docs_client\n");
+        .stdout("chatrooms           hex\ncollab_docs_client  hex\n");
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn literal_member_path_includes_an_ignored_package() {
         .arg("list")
         .assert()
         .success()
-        .stdout("generated_package\n");
+        .stdout("generated_package  hex\n");
 }
 
 #[test]

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -230,7 +230,7 @@ fn new_fragment_writes_toml_and_validates_inputs() {
         ])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("excluded from release"));
+        .stderr(predicate::str::contains("release lifecycle `workspace`"));
     trellis(root)
         .args([
             "changelog",
@@ -1376,7 +1376,7 @@ fn overrides_reject_names_that_are_not_releasable_members() {
         .args(["version", "plan", "--bump", "package_a=major"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("excluded from releases"));
+        .stderr(predicate::str::contains("release lifecycle is `workspace`"));
     trellis(root)
         .args([
             "version",

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -575,7 +575,9 @@ fn publish_rejects_unreleasable_package() {
         .args(["publish", "package_a"])
         .assert()
         .failure()
-        .stderr(predicate::str::contains("excluded from release"));
+        .stderr(predicate::str::contains(
+            "release lifecycle `workspace`, not `hex`",
+        ));
 }
 
 // ---- series tags -----------------------------------------------------------

--- a/tests/snapshots/json_contract__doctor_json_contract_when_passing.snap
+++ b/tests/snapshots/json_contract__doctor_json_contract_when_passing.snap
@@ -53,6 +53,24 @@ expression: "json_output(&fixture(\"basic\"), &[\"doctor\", \"--format\", \"json
     }
   ],
   "ok": true,
+  "package_lifecycles": [
+    {
+      "lifecycle": "hex",
+      "name": "lat_core"
+    },
+    {
+      "lifecycle": "hex",
+      "name": "lat_mid"
+    },
+    {
+      "lifecycle": "hex",
+      "name": "lat_cli"
+    },
+    {
+      "lifecycle": "workspace",
+      "name": "package_a"
+    }
+  ],
   "packages": 4,
   "schema": "trellis.doctor/1"
 }

--- a/tests/snapshots/json_contract__doctor_json_contract_with_findings.snap
+++ b/tests/snapshots/json_contract__doctor_json_contract_with_findings.snap
@@ -82,6 +82,24 @@ expression: payload
     }
   ],
   "ok": false,
+  "package_lifecycles": [
+    {
+      "lifecycle": "hex",
+      "name": "lat_core"
+    },
+    {
+      "lifecycle": "hex",
+      "name": "lat_mid"
+    },
+    {
+      "lifecycle": "hex",
+      "name": "lat_cli"
+    },
+    {
+      "lifecycle": "workspace",
+      "name": "package_a"
+    }
+  ],
   "packages": 4,
   "schema": "trellis.doctor/1"
 }

--- a/tests/snapshots/json_contract__graph_json_contract.snap
+++ b/tests/snapshots/json_contract__graph_json_contract.snap
@@ -23,24 +23,28 @@ expression: "json_output(&fixture(\"basic\"), &[\"graph\", \"--format\", \"json\
   ],
   "nodes": [
     {
+      "lifecycle": "hex",
       "name": "lat_core",
       "path": "packages/lat_core",
       "releasable": true,
       "version": "1.2.0"
     },
     {
+      "lifecycle": "hex",
       "name": "lat_mid",
       "path": "packages/lat_mid",
       "releasable": true,
       "version": "0.5.0"
     },
     {
+      "lifecycle": "hex",
       "name": "lat_cli",
       "path": "packages/lat_cli",
       "releasable": true,
       "version": "0.3.1"
     },
     {
+      "lifecycle": "workspace",
       "name": "package_a",
       "path": "examples/package-a",
       "releasable": false,

--- a/tests/snapshots/json_contract__info_json_contract.snap
+++ b/tests/snapshots/json_contract__info_json_contract.snap
@@ -9,6 +9,7 @@ expression: "json_output(&fixture(\"basic\"), &[\"info\", \"lat_mid\", \"--json\
   "dependents": [
     "lat_cli"
   ],
+  "lifecycle": "hex",
   "name": "lat_mid",
   "path": "packages/lat_mid",
   "releasable": true,

--- a/tests/snapshots/json_contract__list_json_contract.snap
+++ b/tests/snapshots/json_contract__list_json_contract.snap
@@ -10,6 +10,7 @@ expression: "json_output(&fixture(\"basic\"), &[\"list\", \"--json\"], true)"
         "lat_mid",
         "lat_cli"
       ],
+      "lifecycle": "hex",
       "name": "lat_core",
       "path": "packages/lat_core",
       "releasable": true,
@@ -22,6 +23,7 @@ expression: "json_output(&fixture(\"basic\"), &[\"list\", \"--json\"], true)"
       "dependents": [
         "lat_cli"
       ],
+      "lifecycle": "hex",
       "name": "lat_mid",
       "path": "packages/lat_mid",
       "releasable": true,
@@ -35,6 +37,7 @@ expression: "json_output(&fixture(\"basic\"), &[\"list\", \"--json\"], true)"
       "dependents": [
         "package_a"
       ],
+      "lifecycle": "hex",
       "name": "lat_cli",
       "path": "packages/lat_cli",
       "releasable": true,
@@ -45,6 +48,7 @@ expression: "json_output(&fixture(\"basic\"), &[\"list\", \"--json\"], true)"
         "lat_cli"
       ],
       "dependents": [],
+      "lifecycle": "workspace",
       "name": "package_a",
       "path": "examples/package-a",
       "releasable": false,

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -123,6 +123,8 @@ their roots.
 | `publish.tag_mode` | no | Which tags a release creates: `exact` (default), `series`, or `both`. |
 | `publish.tag_mode_overrides` | no | Per-package tag modes: a map of mode name to member-path globs. A package matching globs under two modes is an error. |
 | `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial_delay, multiplier }`. |
+| `publish.lifecycle.default` | no | Release lifecycle for a member matched by no `packages` glob and no legacy `exclude.@release` glob: `workspace`, `git_only`, or `hex` (default). |
+| `publish.lifecycle.packages` | no | Per-package lifecycle overrides: a map of member-path glob to lifecycle. Takes precedence over `exclude.@release`. A member matched by globs resolving to different lifecycles is an error; matches agreeing on the same lifecycle are fine. |
 | `changelog.kinds` | no | Change kinds and the version bump each implies. The largest bump among a package's unreleased fragments wins. |
 | `changelog.categories` | no | A second grouping axis, rendered above the kind headings. Carries no version bump. Empty by default, which switches the axis off. |
 | `changelog.uncategorized_label` | no | Heading for entries naming no category, rendered last. Default: `Other`. Read only when `categories` is set. |
@@ -161,27 +163,80 @@ through `--since`.
 | --- | --- |
 | `docs` | Matching packages from `trellis run docs`. Built-in tasks can be filtered without overriding their commands. |
 | Any custom task name | Matching packages from that `trellis run <name>` invocation. |
-| `@release` | Matching packages from changelog, version, tag, publish, and release CI operations. Explicit changelog creation and publishing are rejected. |
+| `@release` | Matching packages from changelog, version, tag, publish, and release CI operations — the legacy way to reach the `workspace` [release lifecycle](#release-lifecycle). Explicit changelog creation and publishing are rejected. |
 | `@members` | Matching directories from workspace membership itself — they are invisible to every command, as if they held no `gleam.toml` at all. |
 
 Release-excluded packages remain in the dependency graph and still participate
 in `list`, `graph`, `exec`, and every task that does not exclude them. `info`
 and JSON output expose `releasable: false`; `list --releasable` returns only
-the release set:
+the `git_only`/`hex` set:
 
 ```console
 $ trellis list --releasable
-lat_core
-lat_mid
-lat_cli
+lat_core  hex
+lat_mid   hex
+lat_cli   hex
 ```
 
 <Callout>
 
-`trellis doctor` catches every exclusion glob that matches no member. For
-release exclusions, it also rejects a releasable package that path-depends on
-an excluded one: a published package cannot depend on a workspace package that
-will never exist on Hex.
+`trellis doctor` catches every exclusion glob that matches no member. It also
+validates dependency availability across the release lifecycle: see
+[Release lifecycle](#release-lifecycle) below.
+
+</Callout>
+
+## Release lifecycle
+
+`exclude.@release` is a single on/off switch: a package either participates in
+the full release pipeline or is invisible to all of it. Real monorepos often
+have packages in between — versioned and tagged in git, but never meant for
+Hex, or not ready to release at all yet. `publish.lifecycle` resolves each
+member to one of three states:
+
+| Lifecycle | Changelog/version | Git tags/releases | Hex publish |
+| --- | --- | --- | --- |
+| `workspace` | no | no | no |
+| `git_only` | yes | yes | no |
+| `hex` (default) | yes | yes | yes |
+
+```toml title="gleam.toml" wrap
+[tools.trellis.publish.lifecycle]
+default = "hex"
+packages = { "packages/experimental/**" = "workspace", "packages/providers/**" = "git_only" }
+```
+
+`default` is the lifecycle for a member matched by no `packages` glob and no
+legacy `exclude.@release` glob. `packages` is a map of member-path glob to
+lifecycle; a member matched by globs resolving to *different* lifecycles is a
+`doctor` error, but matching several globs that agree is fine — that's how a
+directory-wide glob and a narrower one inside it can both claim a member.
+
+Resolution order, so a workspace can adopt `publish.lifecycle` incrementally
+alongside an existing `exclude.@release`:
+
+1. Start from `publish.lifecycle.default`.
+2. Apply the legacy `exclude.@release` mapping to `workspace`, when matched.
+3. Apply an explicit `publish.lifecycle.packages` rule, when matched — this
+   overrides both of the above, which is what lets a package graduate from
+   `workspace` to `git_only` to `hex` over time without moving directories or
+   rewriting `exclude.@release`.
+
+`--releasable` (on `list`, `ci matrix`, and elsewhere) still means `git_only`
+**or** `hex` — the set that changelog, version, and tag commands operate on.
+`publish` alone needs the finer distinction: it selects `hex` members only,
+and the path-dependency rewrite it computes at publish time only ever
+substitutes versions of `hex` members, so a `hex` package referencing a
+`git_only` or `workspace` runtime path dependency fails safely instead of
+publishing something unresolvable.
+
+<Callout>
+
+**A dependency must be at least as capable as its dependent.** `hex` may
+depend only on `hex`; `git_only` may depend on `git_only` or `hex`; `workspace`
+may depend on anything. `doctor`'s `release_boundary` check enforces this for
+runtime (`[dependencies]`) path deps only — a dev-only path dep never ships in
+any distribution, so it is exempt regardless of lifecycle.
 
 </Callout>
 

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -16,6 +16,7 @@ its major version:
       "name": "lat_core",
       "version": "1.2.0",
       "path": "packages/lat_core",
+      "lifecycle": "hex",
       "releasable": true,
       "dependencies": [],
       "dependents": ["lat_mid", "lat_cli"]
@@ -47,7 +48,7 @@ commands pretty-print, some emit one line for shell-variable capture).
 | Command | Schema and top-level keys |
 | --- | --- |
 | `list --json` | `trellis.list/1`<br />`{schema, packages[]}` |
-| `info <pkg> --json` | `trellis.info/1`<br />`{schema, name, version, path, releasable, dependencies[], dependents[]}` |
+| `info <pkg> --json` | `trellis.info/1`<br />`{schema, name, version, path, lifecycle, releasable, dependencies[], dependents[]}` |
 | `graph --format json` | `trellis.graph/1`<br />`{schema, nodes[], edges[]}` |
 | `run <task> --json` | `trellis.run/1`<br />`{schema, ok, task, target?, results[]}` |
 | `exec -- <cmd> --json` | `trellis.exec/1`<br />`{schema, ok, command[], results[]}` |
@@ -56,11 +57,15 @@ commands pretty-print, some emit one line for shell-variable capture).
 | `version apply --json` | `trellis.version_apply/1`<br />`{schema, bumped[], lockfiles[], adopted[], fragments_retained}` |
 | `tag plan --json` | `trellis.tag_plan/1`<br />`{schema, tags[]}` |
 | `ci tag-package --json` | `trellis.ci_tag_package/1`<br />`{schema, name, path, version, tag_kind, tag_version \| tag_series}` |
-| `doctor --format json` | `trellis.doctor/1`<br />`{schema, ok, packages, configless, auto_members, findings[], fixes[], applied[]}` |
+| `doctor --format json` | `trellis.doctor/1`<br />`{schema, ok, packages, configless, auto_members, findings[], fixes[], applied[], package_lifecycles[]}` |
 
 Notes:
 
 - `list`'s `packages[]` entries and `info`'s top level share a shape.
+  `lifecycle` is the resolved release lifecycle (`workspace`, `git_only`, or
+  `hex`); `releasable` is a derived boolean (`lifecycle != workspace`), kept
+  for compatibility with the git_only+hex meaning `--releasable` has always
+  had. `graph` nodes also carry both.
 - `version plan`/`version apply` share the `bumped[]` shape (`name`,
   `current`, `next`, `fragments`, `updated_dependencies[]`).
   `fragments_retained` is true only under
@@ -84,6 +89,11 @@ Notes:
 </Callout>
 
 ## `doctor` findings
+
+`package_lifecycles` is an array of `{name, lifecycle}`, one per member in
+workspace order, additive alongside the existing numeric `packages` count —
+`doctor`'s text summary renders the same data as compact counts, e.g.
+`ok: 4 package(s) (1 workspace, 0 git_only, 3 hex), 0 warning(s)`.
 
 One entry per problem:
 
@@ -109,8 +119,8 @@ is prose, not stable — branch on `check`:
 | `path_dependency` | a path dependency escapes the workspace or names no package in it |
 | `dependency_cycle` | the graph is cyclic |
 | `workspace_config` | the root `[tools.trellis]` table is itself wrong |
-| `exclusion_glob` | a task-exclusion or tag-mode-override glob matches no member |
-| `release_boundary` | a releasable package depends on one excluded from release |
+| `exclusion_glob` | a task-exclusion, tag-mode-override, or `publish.lifecycle.packages` glob matches no member |
+| `release_boundary` | a package's runtime path dependency is less capable than it is (a `hex` package depending on `git_only`/`workspace`, or `git_only` on `workspace`) |
 | `tag_collision` | two releasable packages produce the same tag |
 | `lockfile_drift` | a `manifest.toml` locks a workspace-internal dep at a stale version |
 | `changelog_missing` | a releasable package has no `CHANGELOG.md` |

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -99,7 +99,10 @@ release-PR merge instead. Passing a series tag to `publish --tag` is an error
 
 ## Publishing to Hex
 
-`publish` runs, per package and in dependency order:
+`publish` selects members whose [release lifecycle](/docs/configuration/#release-lifecycle)
+is `hex` — `--package <name>` and `--tag <tag>` refuse a `workspace` or
+`git_only` package by name, and `--all-untagged` only ever considers `hex`
+members. It runs, per package and in dependency order:
 
 1. **Idempotency check** — one Hex API query; versions already published are
    skipped.
@@ -107,7 +110,10 @@ release-PR merge instead. Passing a series tag to `publish --tag` is an error
    `gleam test`, run against the original manifest with path deps intact.
 3. **Path-dep rewrite** — computed from the graph, never hand-listed: each
    workspace path dependency becomes the Hex requirement derived from that
-   dep's current version, per `path_dep_requirement`.
+   dep's current version, per `path_dep_requirement`. The version map only
+   ever holds `hex` members, so a path dependency on a `git_only` or
+   `workspace` member fails the rewrite rather than publishing something Hex
+   could never resolve.
 4. **Publish** — `gleam publish --yes`.
 5. **Restore** — the original `gleam.toml` comes back even when publishing
    fails; the repo never shows rewritten files.
@@ -132,9 +138,11 @@ release instead of one per tag.
 
 <Callout>
 
-Dev-only path deps to unreleasable packages are left alone — Hex doesn't ship
-dev dependencies. A regular `[dependencies]` path dep to an unreleasable
-package refuses to publish, and `doctor` catches that boundary on every PR.
+Dev-only path deps to a non-`hex` package are left alone — Hex doesn't ship
+dev dependencies. A regular `[dependencies]` path dep to a package whose
+lifecycle is less capable than its dependent's refuses to publish, and
+`doctor` catches that boundary on every PR — see
+[Release lifecycle](/docs/configuration/#release-lifecycle).
 
 </Callout>
 

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -86,10 +86,10 @@ List packages in topological order (dependencies first)
 
 ###### **Options:**
 
-* `--json` — Emit JSON instead of names
+* `--json` — Emit JSON instead of name/lifecycle columns
 * `--since <REF>` — Only packages owning files changed since this git ref
 * `--with-dependents` — Add the reverse-dependency closure of the selection
-* `--releasable` — Only packages that participate in releases (excludes `@release` matches)
+* `--releasable` — Only packages whose release lifecycle is `git_only` or `hex`
 
 
 
@@ -386,7 +386,7 @@ Publish packages to Hex, in dependency order, with path deps rewritten
 ###### **Options:**
 
 * `--tag <TAG>` — Resolve a pushed tag (e.g. lat_core-v1.2.0) to its package
-* `--all-untagged` — Every releasable package whose version isn't on Hex yet
+* `--all-untagged` — Every `hex`-lifecycle package whose version isn't on Hex yet
 * `--dry-run` — Show what would be published (and rewritten) without doing it
 
 


### PR DESCRIPTION
## Summary

- Add three release lifecycle states — `workspace`, `git_only`, `hex` — configured under `[tools.trellis.publish.lifecycle]` as a workspace `default` plus per-package glob overrides. Lifecycles are resolved once at workspace load (conflicting globs are a deterministic error) and exposed as `Member::lifecycle` with `releasable()` / `publishes_to_hex()` predicates, so a monorepo can hold build-only, git-tagged-only, and Hex-published packages side by side.
- Preserve compatibility: legacy `exclude.@release` globs still resolve to `workspace` (explicit rules take precedence), and the additive `releasable` JSON field is retained alongside the new `lifecycle` field.
- Select by lifecycle across commands: `changelog` and `version` operate on releasable members and refuse others with a message quoting the lifecycle; `publish` accepts only `hex` members (by name, tag, or `--all-untagged`); `tag` and release CI cover releasable members; `list` shows a lifecycle column; `info` and `graph` report it; shell completion offers `hex`-only candidates where `publish` needs them.
- Extend `doctor`: a `release_boundary` check enforces that a runtime path dependency is at least as capable as its dependent (dev-only path deps exempt, since they never ship), lifecycle globs get the same matches-no-member typo check as other globs, the summary counts packages per lifecycle, and the JSON payload gains `package_lifecycles`.
- Keep the internals single-sourced: `ReleaseLifecycle::ALL` and `key()` own the variant list and spelling, `available_to()` names the dependency-availability rule instead of relying on enum ordering, and the free-form config-table exemptions are keyed by full path so schema tables can't silently skip deprecated-key detection.
- Document the lifecycle matrix (configuration, publishing, JSON output, reference, DESIGN, README) and add lifecycle integration tests plus JSON contract snapshots.

Closes #74
