### PR TITLE
feat(github): replace the gh CLI with a direct GitHub API client

### DIFF
--- a/.changes/unreleased/Changed-20260801-release-pr-github-api.yaml
+++ b/.changes/unreleased/Changed-20260801-release-pr-github-api.yaml
@@ -1,0 +1,5 @@
+component: release
+kind: Changed
+body: |-
+  **`release pr` drives the GitHub API directly; the gh CLI is no longer required.** The PR is created or updated through api.github.com with a token from `GITHUB_TOKEN` (ambient in GitHub Actions, so CI needs no setup), `GH_TOKEN`, or a logged-in gh CLI as the fallback (`gh auth token`). The repository is read from the `origin` remote; set `TRELLIS_GITHUB_REPO` (`owner/repo`) when the remote URL is not a github.com one.
+time: 2026-08-01T09:06:06.394356583-07:00

--- a/.changes/unreleased/Changed-20260801-tag-github-release-api.yaml
+++ b/.changes/unreleased/Changed-20260801-tag-github-release-api.yaml
@@ -1,0 +1,5 @@
+component: tag
+kind: Changed
+body: |-
+  **`tag create --github-release` creates GitHub Releases through the API instead of the gh CLI.** It needs a token from `GITHUB_TOKEN`, `GH_TOKEN`, or a logged-in gh CLI (`gh auth token`), resolved once before any tag is created so a missing token fails the run up front. Existence checks and release bodies are unchanged: one release per immutable tag, with the matching CHANGELOG section as the body.
+time: 2026-08-01T09:06:06.394356583-07:00

--- a/assets/man/trellis-release-pr.1
+++ b/assets/man/trellis-release-pr.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH trellis-release-pr 1 "" trellis "Trellis Manual"
 .SH NAME
-trellis\-release\-pr \- Create or update the release PR: version apply on a branch, push, gh pr
+trellis\-release\-pr \- Create or update the release PR: version apply on a branch, push, open or refresh the PR via the GitHub API
 .SH SYNOPSIS
 \fBtrellis release pr\fR [\fB\-\-base\fR] [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-branch\fR] [\fB\-\-color\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
-Create or update the release PR: version apply on a branch, push, gh pr
+Create or update the release PR: version apply on a branch, push, open or refresh the PR via the GitHub API
 .SH OPTIONS
 .TP
 \fB\-\-base\fR \fI<BASE>\fR [default: main]

--- a/assets/man/trellis-release.1
+++ b/assets/man/trellis-release.1
@@ -43,4 +43,4 @@ Print help (see a summary with \*(Aq\-h\*(Aq)
 .SH SUBCOMMANDS
 .TP
 trellis\-release\-pr(1)
-Create or update the release PR: version apply on a branch, push, gh pr
+Create or update the release PR: version apply on a branch, push, open or refresh the PR via the GitHub API

--- a/assets/man/trellis-tag-create.1
+++ b/assets/man/trellis-tag-create.1
@@ -31,7 +31,7 @@ never
 .RE
 .TP
 \fB\-\-github\-release\fR
-Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies \-\-push; requires the gh CLI)
+Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies \-\-push; needs a GitHub token from GITHUB_TOKEN, GH_TOKEN, or a logged\-in gh CLI)
 .TP
 \fB\-q\fR, \fB\-\-quiet\fR
 Suppress normal\-path output; JSON/report payloads and errors still print

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -64,11 +64,12 @@ dependencies). The design principle of this tool is therefore:
   depend on *each other* is a separate question, and an open one — see
   "Deferred" below.
 - **GitHub is the only forge trellis integrates with.** This is a statement of
-  what 1.0 supports, not a closed door. `release pr`, `tag create
-  --github-release`, `ci matrix`, and `ci outputs` shell out to `gh`; the
+  what 1.0 supports, not a closed door. `release pr` and `tag create
+  --github-release` talk to the GitHub REST API (a minimal client in
+  `src/github.rs`; the gh CLI survives only as a fallback token source); the
   workspace, graph, version, and publish layers are forge-agnostic and never
   touch one. The dependency is confined to release orchestration — a single
-  resolver and a handful of call sites — so another forge is a tractable
+  client and a handful of call sites — so another forge is a tractable
   addition rather than a rewrite. No such support is promised at 1.0.
 
 ### Deferred — decided *not yet*, not *no*
@@ -455,7 +456,7 @@ With trellis, each workflow keeps its trigger and becomes a few commands:
 ```yaml
 # release.yml (on push to main)
 - run: trellis version apply            # batch, merge, patch lockfiles — no bash
-- run: trellis release pr               # create-or-update the release PR via gh
+- run: trellis release pr               # create-or-update the release PR via the GitHub API
 
 # auto-tag.yml (on release-PR merge)
 - run: trellis tag create --github-release
@@ -601,9 +602,12 @@ end-to-end suite runs against a fixture workspace with a mocked Hex API.
    guard restores `gleam.toml` even when publishing fails. Dev-only path deps
    to unreleasable members are left alone (Hex doesn't ship dev deps); a
    `[dependencies]` path dep to an unreleasable member refuses to publish.
-   `tag create --github-release` implies pushing the tag first and shells out
-   to `gh` (`TRELLIS_GH_BIN` overridable), with the release body extracted
-   from the member's CHANGELOG section for that version. `ci tag-package`
+   `tag create --github-release` implies pushing the tag first and creates
+   the release through the GitHub REST API (token from GITHUB_TOKEN, GH_TOKEN,
+   or `gh auth token`; TRELLIS_GITHUB_API_URL and TRELLIS_GITHUB_REPO
+   overridable, which the e2e suite uses to aim at a local mock), with the
+   release body extracted from the member's CHANGELOG section for that
+   version. `ci tag-package`
    (used in §6's publish workflow sketch) resolves `$GITHUB_REF_NAME` to a
    package name. The retry policy from `[publish] retry` wraps every
    Hex-touching step (`with_retry`, exponential backoff). The gleam binary is
@@ -654,7 +658,8 @@ root `gleam.toml` (§4).
    management in the action, or absorb into `trellis release pr`?~~
    **Resolved: absorbed.** `trellis release pr` computes the plan, runs
    `version apply` on a release branch, force-pushes it (create-or-update
-   semantics), and drives `gh pr create`/`gh pr edit` with a bump table and
+   semantics), and opens or refreshes the PR through the GitHub REST API,
+   with a bump table and
    per-package CHANGELOG sections in the body. (With the native changelog
    engine of §7, `trellis release pr` is the only release-PR path for gleam
    workspaces — the changie-release action drives changie, which trellis no

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -1,12 +1,12 @@
 //! `trellis release pr` — create or update the release pull request (design
 //! §11 question 2, resolved toward "absorb"): compute the version plan, run
-//! `version apply` on a release branch, push it, and drive `gh` to open or
-//! refresh the PR. The tool already knows exactly what changed; gh does the
-//! PR mechanics.
+//! `version apply` on a release branch, push it, and drive the GitHub API to
+//! open or refresh the PR. The tool already knows exactly what changed; the
+//! API does the PR mechanics.
 
 use crate::commands::version_override::Overrides;
 use crate::commands::{tag, version};
-use crate::tools;
+use crate::github::GitHubClient;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
 use std::path::Path;
@@ -87,51 +87,15 @@ fn build_release_commit_and_pr(
         .with_context(|| format!("failed to push branch {}", options.branch))?;
 
     let body = pr_body(workspace, plan);
-    let existing = gh_stdout(
-        root,
-        &[
-            "pr",
-            "list",
-            "--head",
-            &options.branch,
-            "--state",
-            "open",
-            "--json",
-            "number",
-        ],
-    )?;
-    let existing: serde_json::Value =
-        serde_json::from_str(existing.trim()).unwrap_or(serde_json::Value::Null);
-    match existing
-        .as_array()
-        .and_then(|prs| prs.first())
-        .and_then(|pr| pr["number"].as_u64())
-    {
+    let github = GitHubClient::for_repo(root)?;
+    match github.find_open_pr(&options.branch)? {
         Some(number) => {
-            let number = number.to_string();
-            gh_stdout(
-                root,
-                &["pr", "edit", &number, "--title", &title, "--body", &body],
-            )?;
+            github.update_pr(number, &title, &body)?;
             crate::status!("updated release PR #{number}: {title}");
         }
         None => {
-            let url = gh_stdout(
-                root,
-                &[
-                    "pr",
-                    "create",
-                    "--base",
-                    &options.base,
-                    "--head",
-                    &options.branch,
-                    "--title",
-                    &title,
-                    "--body",
-                    &body,
-                ],
-            )?;
-            crate::status!("created release PR: {}", url.trim());
+            let url = github.create_pr(&options.base, &options.branch, &title, &body)?;
+            crate::status!("created release PR: {url}");
         }
     }
     Ok(true)
@@ -168,24 +132,15 @@ fn pr_body(workspace: &Workspace, plan: &[version::PlanEntry]) -> String {
 }
 
 fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
-    run_tool(cwd, "git", args)
-}
-
-fn gh_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
-    let gh = tools::gh_bin();
-    run_tool(cwd, &gh, args)
-}
-
-fn run_tool(cwd: &Path, program: &str, args: &[&str]) -> Result<String> {
-    crate::term::trace_command(program, args, cwd);
-    let output = Command::new(program)
+    crate::term::trace_command("git", args, cwd);
+    let output = Command::new("git")
         .args(args)
         .current_dir(cwd)
         .output()
-        .with_context(|| format!("failed to run `{program}`"))?;
+        .context("failed to run `git`")?;
     if !output.status.success() {
         bail!(
-            "`{program} {}` failed: {}",
+            "`git {}` failed: {}",
             args.join(" "),
             String::from_utf8_lossy(&output.stderr).trim()
         );

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -7,8 +7,8 @@
 //! series releases. Only the immutable ones can carry a GitHub Release — a
 //! release bound to a moving tag would silently retarget.
 
+use crate::github::GitHubClient;
 use crate::json::TagPlanDocument;
-use crate::tools;
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
@@ -175,9 +175,16 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
         return Ok(());
     }
 
+    // Resolved once, up front: a missing token or non-GitHub origin should
+    // fail before any tag is created or pushed, not between two of them.
+    let github = if options.github_release {
+        Some(GitHubClient::for_repo(&workspace.root)?)
+    } else {
+        None
+    };
     for planned in targets {
         match planned.kind {
-            TagKind::Exact => create_exact_tag(workspace, planned, options, push)?,
+            TagKind::Exact => create_exact_tag(workspace, planned, github.as_ref(), push)?,
             TagKind::Series => move_series_tag(workspace, planned, push)?,
         }
     }
@@ -190,7 +197,7 @@ pub fn create(workspace: &Workspace, options: &CreateOptions) -> Result<()> {
 fn create_exact_tag(
     workspace: &Workspace,
     planned: &PlannedTag,
-    options: &CreateOptions,
+    github: Option<&GitHubClient>,
     push: bool,
 ) -> Result<()> {
     let member = &workspace.members[planned.member];
@@ -229,25 +236,12 @@ fn create_exact_tag(
             .with_context(|| format!("failed to push tag {tag}"))?;
         crate::status!("pushed {tag}");
     }
-    if options.github_release {
-        if github_release_exists(&workspace.root, tag)? {
+    if let Some(github) = github {
+        if github.release_exists(tag)? {
             crate::status!("GitHub release {tag} already exists; skipping");
         } else {
             let notes = release_notes(workspace, planned.member);
-            let gh = tools::gh_bin();
-            let args = ["release", "create", tag, "--title", tag, "--notes", &notes];
-            crate::term::trace_command(&gh, &args, &workspace.root);
-            let output = Command::new(&gh)
-                .args(args)
-                .current_dir(&workspace.root)
-                .output()
-                .with_context(|| format!("failed to run `{gh}` — is the GitHub CLI installed?"))?;
-            if !output.status.success() {
-                bail!(
-                    "`{gh} release create {tag}` failed: {}",
-                    String::from_utf8_lossy(&output.stderr).trim()
-                );
-            }
+            github.create_release(tag, tag, &notes)?;
             crate::status!("created GitHub release {tag}");
         }
     }
@@ -356,25 +350,6 @@ fn remote_tag_oid(root: &Path, tag: &str) -> Result<Option<String>> {
             String::from_utf8_lossy(&output.stderr).trim()
         ),
     }
-}
-
-fn github_release_exists(root: &Path, tag: &str) -> Result<bool> {
-    let gh = tools::gh_bin();
-    let args = ["release", "view", tag, "--json", "tagName"];
-    crate::term::trace_command(&gh, &args, root);
-    let output = Command::new(&gh)
-        .args(args)
-        .current_dir(root)
-        .output()
-        .with_context(|| format!("failed to run `{gh}` — is the GitHub CLI installed?"))?;
-    if output.status.success() {
-        return Ok(true);
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if stderr.contains("release not found") {
-        return Ok(false);
-    }
-    bail!("`{gh} release view {tag}` failed: {}", stderr.trim())
 }
 
 /// The member's CHANGELOG section for its current version, or a minimal

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,355 @@
+//! Minimal GitHub REST API client — the five calls trellis needs for release
+//! PR management and GitHub Releases, previously delegated to the gh CLI.
+//! Speaking to the API directly removes the runtime gh dependency; the CLI
+//! remains only as a last-resort token source (`gh auth token`).
+
+use anyhow::{Context, Result, anyhow, bail};
+use std::path::Path;
+use std::process::Command;
+
+pub struct GitHubClient {
+    agent: ureq::Agent,
+    base: String,
+    token: String,
+    owner: String,
+    repo: String,
+}
+
+impl GitHubClient {
+    /// A client for the repository `root` is a checkout of.
+    ///
+    /// The owner/repo pair comes from TRELLIS_GITHUB_REPO (`owner/repo`, tests
+    /// and unusual remotes) or the `origin` remote URL. The token comes from
+    /// GITHUB_TOKEN, then GH_TOKEN — GITHUB_TOKEN is ambient in GitHub Actions,
+    /// so CI needs no setup — then a logged-in gh CLI. The base URL comes from
+    /// TRELLIS_GITHUB_API_URL (tests point this at a local mock), defaulting
+    /// to the public API.
+    pub fn for_repo(root: &Path) -> Result<Self> {
+        let (owner, repo) = resolve_repo(root)?;
+        let agent = ureq::Agent::new_with_config(
+            ureq::Agent::config_builder()
+                .http_status_as_error(false)
+                .build(),
+        );
+        Ok(Self {
+            agent,
+            base: std::env::var("TRELLIS_GITHUB_API_URL")
+                .unwrap_or_else(|_| "https://api.github.com".to_string()),
+            token: resolve_token()?,
+            owner,
+            repo,
+        })
+    }
+
+    /// The number of the open PR whose head is `branch`, if one exists.
+    pub fn find_open_pr(&self, branch: &str) -> Result<Option<u64>> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls?head={}:{branch}&state=open",
+            self.base, self.owner, self.repo, self.owner
+        );
+        let (status, body) = self.get(&url)?;
+        if status != 200 {
+            bail!("GitHub API GET {url} failed: {}", api_error(status, &body));
+        }
+        Ok(body
+            .as_array()
+            .and_then(|prs| prs.first())
+            .and_then(|pr| pr["number"].as_u64()))
+    }
+
+    /// Open a PR and return its URL.
+    pub fn create_pr(&self, base: &str, head: &str, title: &str, body: &str) -> Result<String> {
+        let url = format!("{}/repos/{}/{}/pulls", self.base, self.owner, self.repo);
+        let payload = serde_json::json!({
+            "base": base,
+            "head": head,
+            "title": title,
+            "body": body,
+        });
+        let (status, response) = self.send("POST", &url, &payload)?;
+        if status != 201 {
+            bail!(
+                "GitHub API POST {url} failed: {}",
+                api_error(status, &response)
+            );
+        }
+        response["html_url"]
+            .as_str()
+            .map(str::to_string)
+            .ok_or_else(|| anyhow!("GitHub API POST {url}: response has no html_url"))
+    }
+
+    /// Retitle and re-body an existing PR.
+    pub fn update_pr(&self, number: u64, title: &str, body: &str) -> Result<()> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{number}",
+            self.base, self.owner, self.repo
+        );
+        let payload = serde_json::json!({ "title": title, "body": body });
+        let (status, response) = self.send("PATCH", &url, &payload)?;
+        if status != 200 {
+            bail!(
+                "GitHub API PATCH {url} failed: {}",
+                api_error(status, &response)
+            );
+        }
+        Ok(())
+    }
+
+    /// Whether a GitHub Release exists for `tag`.
+    pub fn release_exists(&self, tag: &str) -> Result<bool> {
+        let url = format!(
+            "{}/repos/{}/{}/releases/tags/{tag}",
+            self.base, self.owner, self.repo
+        );
+        let (status, body) = self.get(&url)?;
+        match status {
+            200 => Ok(true),
+            404 => Ok(false),
+            _ => bail!("GitHub API GET {url} failed: {}", api_error(status, &body)),
+        }
+    }
+
+    /// Create a GitHub Release on `tag`.
+    pub fn create_release(&self, tag: &str, title: &str, notes: &str) -> Result<()> {
+        let url = format!("{}/repos/{}/{}/releases", self.base, self.owner, self.repo);
+        let payload = serde_json::json!({
+            "tag_name": tag,
+            "name": title,
+            "body": notes,
+        });
+        let (status, response) = self.send("POST", &url, &payload)?;
+        if status != 201 {
+            bail!(
+                "GitHub API POST {url} failed: {}",
+                api_error(status, &response)
+            );
+        }
+        Ok(())
+    }
+
+    fn get(&self, url: &str) -> Result<(u16, serde_json::Value)> {
+        crate::term::trace_http("GET", url);
+        let response = self
+            .headers(self.agent.get(url))
+            .call()
+            .with_context(|| format!("GitHub API request failed: GET {url}"))?;
+        read_response(response)
+    }
+
+    fn send(
+        &self,
+        method: &str,
+        url: &str,
+        payload: &serde_json::Value,
+    ) -> Result<(u16, serde_json::Value)> {
+        crate::term::trace_http(method, url);
+        let request = match method {
+            "POST" => self.agent.post(url),
+            "PATCH" => self.agent.patch(url),
+            other => bail!("unsupported HTTP method {other}"),
+        };
+        let response = self
+            .headers(request)
+            .send_json(payload)
+            .with_context(|| format!("GitHub API request failed: {method} {url}"))?;
+        read_response(response)
+    }
+
+    fn headers<B>(&self, request: ureq::RequestBuilder<B>) -> ureq::RequestBuilder<B> {
+        request
+            .header("authorization", format!("Bearer {}", self.token))
+            .header("accept", "application/vnd.github+json")
+            .header("x-github-api-version", "2022-11-28")
+            .header("user-agent", concat!("trellis/", env!("CARGO_PKG_VERSION")))
+    }
+}
+
+fn read_response(
+    mut response: ureq::http::Response<ureq::Body>,
+) -> Result<(u16, serde_json::Value)> {
+    let status = response.status().as_u16();
+    // Error bodies matter as much as success bodies (they carry the API's
+    // "message"), but not every response is JSON — a 502 from a proxy, say.
+    let body = response
+        .body_mut()
+        .read_json()
+        .unwrap_or(serde_json::Value::Null);
+    Ok((status, body))
+}
+
+/// A one-line description of a failed API call: the status plus whatever
+/// `message` GitHub attached.
+fn api_error(status: u16, body: &serde_json::Value) -> String {
+    match body["message"].as_str() {
+        Some(message) => format!("HTTP {status}: {message}"),
+        None => format!("HTTP {status}"),
+    }
+}
+
+/// The token, from the environment or a logged-in gh CLI.
+fn resolve_token() -> Result<String> {
+    for var in ["GITHUB_TOKEN", "GH_TOKEN"] {
+        if let Ok(token) = std::env::var(var) {
+            let token = token.trim().to_string();
+            if !token.is_empty() {
+                return Ok(token);
+            }
+        }
+    }
+    let gh = crate::tools::gh_bin();
+    if let Ok(output) = Command::new(&gh).args(["auth", "token"]).output()
+        && output.status.success()
+    {
+        let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if !token.is_empty() {
+            return Ok(token);
+        }
+    }
+    bail!("no GitHub token found: set GITHUB_TOKEN (or GH_TOKEN), or log in with `gh auth login`")
+}
+
+/// Owner and repository, from TRELLIS_GITHUB_REPO or the `origin` remote.
+fn resolve_repo(root: &Path) -> Result<(String, String)> {
+    if let Ok(spec) = std::env::var("TRELLIS_GITHUB_REPO") {
+        return match spec.split_once('/') {
+            Some((owner, repo)) if !owner.is_empty() && !repo.is_empty() => {
+                Ok((owner.to_string(), repo.to_string()))
+            }
+            _ => bail!("TRELLIS_GITHUB_REPO must be `owner/repo`, got `{spec}`"),
+        };
+    }
+    let args = ["remote", "get-url", "origin"];
+    crate::term::trace_command("git", &args, root);
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .context("failed to run git")?;
+    if !output.status.success() {
+        bail!(
+            "GitHub operations need an `origin` remote: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    parse_remote_url(&url).ok_or_else(|| {
+        anyhow!(
+            "origin remote `{url}` is not a GitHub repository (set TRELLIS_GITHUB_REPO to override)"
+        )
+    })
+}
+
+/// Parse owner/repo from a git remote URL (HTTPS, scp-like SSH, or ssh://).
+///
+/// Returns `None` if the URL is not a GitHub URL or cannot be parsed. Vendored
+/// from tylerbutler/repoverlay (src/github.rs), with input trimming and
+/// `ssh://` handling added.
+pub fn parse_remote_url(url: &str) -> Option<(String, String)> {
+    let url = url.trim();
+    let path = url
+        .strip_prefix("git@github.com:")
+        .or_else(|| url.strip_prefix("ssh://git@github.com/"))
+        .or_else(|| url.strip_prefix("https://github.com/"))
+        .or_else(|| url.strip_prefix("http://github.com/"))?;
+    let mut segments = path.splitn(3, '/');
+    let owner = segments.next()?;
+    let repo = segments.next()?.trim_end_matches(".git");
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_remote_url;
+
+    fn parsed(url: &str) -> Option<(String, String)> {
+        parse_remote_url(url)
+    }
+
+    fn owner_repo(url: &str) -> (String, String) {
+        parsed(url).unwrap()
+    }
+
+    #[test]
+    fn parses_scp_like_ssh_urls() {
+        assert_eq!(
+            owner_repo("git@github.com:owner/repo.git"),
+            ("owner".to_string(), "repo".to_string())
+        );
+        assert_eq!(
+            owner_repo("git@github.com:owner/repo"),
+            ("owner".to_string(), "repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_ssh_scheme_urls() {
+        assert_eq!(
+            owner_repo("ssh://git@github.com/owner/repo.git"),
+            ("owner".to_string(), "repo".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_https_urls() {
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo.git"),
+            ("owner".to_string(), "repo".to_string())
+        );
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo"),
+            ("owner".to_string(), "repo".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_non_github_urls() {
+        assert_eq!(parsed("git@gitlab.com:owner/repo.git"), None);
+        assert_eq!(parsed("https://gitlab.com/owner/repo"), None);
+        assert_eq!(parsed("/local/bare/repo.git"), None);
+    }
+
+    #[test]
+    fn rejects_missing_owner_or_repo() {
+        assert_eq!(parsed("git@github.com:/repo"), None);
+        assert_eq!(parsed("git@github.com:owner/"), None);
+        assert_eq!(parsed("git@github.com:owner"), None);
+        assert_eq!(parsed("https://github.com//repo"), None);
+        assert_eq!(parsed("https://github.com/owner/"), None);
+    }
+
+    #[test]
+    fn trims_the_trailing_newline_git_emits() {
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo.git\n"),
+            ("owner".to_string(), "repo".to_string())
+        );
+    }
+
+    #[test]
+    fn tolerates_extra_path_segments_and_trailing_slash() {
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo/tree/main/subdir"),
+            ("owner".to_string(), "repo".to_string())
+        );
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo/"),
+            ("owner".to_string(), "repo".to_string())
+        );
+    }
+
+    #[test]
+    fn keeps_dots_in_repo_names() {
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo.js.git"),
+            ("owner".to_string(), "repo.js".to_string())
+        );
+        assert_eq!(
+            owner_repo("https://github.com/owner/repo.js"),
+            ("owner".to_string(), "repo.js".to_string())
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod commands;
 mod completion;
 mod config;
 mod git;
+mod github;
 mod gleam;
 mod hex;
 mod json;
@@ -27,8 +28,8 @@ use term::{ColorChoice, Verbosity};
 use workspace::Workspace;
 
 /// Trellis itself could not run: unparseable config, not a git repository, a
-/// missing `gleam`/`gh`, Hex unreachable after retries. Distinct from 1, which
-/// means the command ran and found problems.
+/// missing `gleam`, no GitHub token, Hex unreachable after retries. Distinct
+/// from 1, which means the command ran and found problems.
 const EXIT_INTERNAL_ERROR: u8 = 3;
 
 /// Crate version, with `git describe` output appended for builds that aren't
@@ -381,7 +382,8 @@ impl VersionOverrideArgs {
 
 #[derive(Subcommand)]
 enum ReleaseCommand {
-    /// Create or update the release PR: version apply on a branch, push, gh pr
+    /// Create or update the release PR: version apply on a branch, push,
+    /// open or refresh the PR via the GitHub API
     Pr {
         /// Base branch the PR targets
         #[arg(long, default_value = "main")]
@@ -406,7 +408,8 @@ enum TagCommand {
         #[arg(long)]
         push: bool,
         /// Also create a GitHub Release per tag, with the matching CHANGELOG
-        /// section as the body (implies --push; requires the gh CLI)
+        /// section as the body (implies --push; needs a GitHub token from
+        /// GITHUB_TOKEN, GH_TOKEN, or a logged-in gh CLI)
         #[arg(long)]
         github_release: bool,
     },

--- a/src/term.rs
+++ b/src/term.rs
@@ -126,9 +126,18 @@ pub fn trace_command(program: &str, args: &[impl AsRef<str>], cwd: &Path) {
     eprintln!("+ {line}  ({})", cwd.display());
 }
 
+/// Echo an HTTP request trellis is about to make, on stderr, when `-v` is
+/// set. The API sibling of [`trace_command`]; bodies are elided.
+pub fn trace_http(method: &str, url: &str) {
+    if !verbose() {
+        return;
+    }
+    eprintln!("+ {method} {url}");
+}
+
 /// Quote an argument well enough that the trace can be pasted back into a
 /// shell. Single quotes, since the arguments that need it are prose — a
-/// changelog body in `gh release create --notes`, say.
+/// changelog body passed to `git tag -m`, say.
 fn shell_quote(arg: &str) -> String {
     if !arg.is_empty() && !arg.contains(['\'', ' ', '\t', '\n', '"', '$', '`', '\\']) {
         return arg.to_string();

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -10,6 +10,9 @@ pub fn gleam_bin() -> String {
     std::env::var("TRELLIS_GLEAM_BIN").unwrap_or_else(|_| "gleam".to_string())
 }
 
+/// The gh CLI is no longer driven for GitHub operations — those go through
+/// the REST API (`crate::github`) — but a logged-in gh is still the fallback
+/// token source (`gh auth token`) when GITHUB_TOKEN/GH_TOKEN are unset.
 pub fn gh_bin() -> String {
     std::env::var("TRELLIS_GH_BIN").unwrap_or_else(|_| "gh".to_string())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,115 @@
+//! Shared e2e helpers: a mock GitHub API served from a background thread.
+//!
+//! Point TRELLIS_GITHUB_API_URL at the returned base URL and set
+//! TRELLIS_GITHUB_REPO plus GITHUB_TOKEN; every request the binary makes is
+//! appended to `.fake/github-log` as `METHOD path?query`, then the JSON body,
+//! then `---`, so tests assert on the log the way they asserted on the old
+//! fake-gh log. State lives in `.fake/`: a created release becomes a
+//! `release-<tag>` marker file (so existence checks respond 200 afterwards),
+//! and the PR listing replies with `.fake/pr-list` or `[]`.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+
+pub fn mock_github(root: &Path) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    std::fs::create_dir_all(root.join(".fake")).unwrap();
+    let root: PathBuf = root.to_path_buf();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            handle(&mut stream, &root);
+        }
+    });
+    base
+}
+
+fn handle(stream: &mut TcpStream, root: &Path) {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 4096];
+    let header_end = loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => return,
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            }
+            Err(_) => return,
+        }
+    };
+    let headers = String::from_utf8_lossy(&buf[..header_end]).to_string();
+    let content_length: usize = headers
+        .lines()
+        .find_map(|line| {
+            line.to_ascii_lowercase()
+                .strip_prefix("content-length:")
+                .and_then(|value| value.trim().parse().ok())
+        })
+        .unwrap_or(0);
+    while buf.len() < header_end + content_length {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(_) => break,
+        }
+    }
+    let body = String::from_utf8_lossy(&buf[header_end..]).to_string();
+
+    let mut request_line = headers.lines().next().unwrap_or("").split_whitespace();
+    let method = request_line.next().unwrap_or("").to_string();
+    let target = request_line.next().unwrap_or("").to_string();
+    let path = target.split('?').next().unwrap_or("").to_string();
+
+    let mut log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(root.join(".fake/github-log"))
+        .unwrap();
+    writeln!(log, "{method} {target}\n{body}\n---").unwrap();
+
+    let (status, response) = route(&method, &path, &body, root);
+    let _ = stream.write_all(
+        format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response}",
+            response.len()
+        )
+        .as_bytes(),
+    );
+}
+
+fn route(method: &str, path: &str, body: &str, root: &Path) -> (&'static str, String) {
+    // Paths are /repos/{owner}/{repo}/<resource...>.
+    let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
+    let resource = (parts.first().copied(), parts.get(3).copied());
+    match (method, resource, parts.get(4).copied()) {
+        ("GET", (Some("repos"), Some("pulls")), None) => {
+            let list = std::fs::read_to_string(root.join(".fake/pr-list"))
+                .unwrap_or_else(|_| "[]".to_string());
+            ("200 OK", list)
+        }
+        ("POST", (Some("repos"), Some("pulls")), None) => (
+            "201 Created",
+            r#"{"number":7,"html_url":"https://github.com/example/repo/pull/7"}"#.to_string(),
+        ),
+        ("PATCH", (Some("repos"), Some("pulls")), Some(_)) => ("200 OK", "{}".to_string()),
+        ("GET", (Some("repos"), Some("releases")), Some("tags")) => {
+            let tag = parts.get(5).copied().unwrap_or("");
+            if root.join(format!(".fake/release-{tag}")).exists() {
+                ("200 OK", format!(r#"{{"tag_name":"{tag}"}}"#))
+            } else {
+                ("404 Not Found", r#"{"message":"Not Found"}"#.to_string())
+            }
+        }
+        ("POST", (Some("repos"), Some("releases")), None) => {
+            let parsed: serde_json::Value = serde_json::from_str(body).unwrap_or_default();
+            let tag = parsed["tag_name"].as_str().unwrap_or("unknown");
+            std::fs::write(root.join(format!(".fake/release-{tag}")), "").unwrap();
+            ("201 Created", "{}".to_string())
+        }
+        _ => ("404 Not Found", r#"{"message":"no route"}"#.to_string()),
+    }
+}

--- a/tests/new_and_release.rs
+++ b/tests/new_and_release.rs
@@ -1,6 +1,8 @@
 //! End-to-end tests for `trellis new` (scaffolding), `trellis release pr`
-//! (release-PR management via a fake gh), and doctor's .tool-versions
+//! (release-PR management via a mock GitHub API), and doctor's .tool-versions
 //! advisory.
+
+mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -207,24 +209,25 @@ fn add_fragment(root: &Path, project: &str, kind: &str, body: &str) {
     }
 }
 
-/// Fake gh: logs invocations; `pr list` replies with `.fake/pr-list` (or an
-/// empty array), `pr create` prints a PR URL.
-fn install_fake_gh(root: &Path) -> PathBuf {
-    let script = root.join("fake-gh.sh");
-    write(
-        &script,
-        concat!(
-            "#!/bin/sh\n",
-            "printf 'gh %s\\n' \"$*\" >> .fake/gh-log\n",
-            "case \"$1 $2\" in\n",
-            "  'pr list') cat .fake/pr-list 2>/dev/null || echo '[]' ;;\n",
-            "  'pr create') echo 'https://github.com/example/repo/pull/7' ;;\n",
-            "esac\n",
-        ),
-    );
-    make_executable(&script);
-    fs::create_dir_all(root.join(".fake")).unwrap();
-    script
+/// A trellis invocation aimed at the mock GitHub API: base URL and repo
+/// overridden, a token in the environment, and proxy variables stripped so
+/// requests reach the localhost mock.
+fn trellis_github(dir: &Path, api: &str) -> Command {
+    let mut cmd = trellis(dir);
+    cmd.env("TRELLIS_GITHUB_API_URL", api)
+        .env("TRELLIS_GITHUB_REPO", "example/repo")
+        .env("GITHUB_TOKEN", "test-token");
+    for var in [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ] {
+        cmd.env_remove(var);
+    }
+    cmd
 }
 
 #[test]
@@ -232,7 +235,7 @@ fn release_pr_creates_then_updates_the_pull_request() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
     copy_fixture_to(root);
-    let gh = install_fake_gh(root);
+    let api = common::mock_github(root);
 
     git(root, &["init", "-q", "-b", "main"]);
     git(root, &["add", "."]);
@@ -252,8 +255,7 @@ fn release_pr_creates_then_updates_the_pull_request() {
     git(root, &["add", "."]);
     git(root, &["commit", "-q", "-m", "feature-only"]);
 
-    trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
+    trellis_github(root, &api)
         .args(["release", "pr", "--base", "main"])
         .assert()
         .success()
@@ -263,9 +265,18 @@ fn release_pr_creates_then_updates_the_pull_request() {
 
     // The PR was created against the right base with the bump in the body,
     // including the changelog section the native engine just rendered.
-    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert!(log.contains("pr create --base main --head release/pending"));
-    assert!(log.contains("--title release: lat_core v1.3.0"));
+    let log = fs::read_to_string(root.join(".fake/github-log")).unwrap();
+    assert!(
+        log.contains("GET /repos/example/repo/pulls?head=example:release/pending&state=open"),
+        "{log}"
+    );
+    assert!(log.contains("POST /repos/example/repo/pulls\n"), "{log}");
+    assert!(log.contains(r#""base": "main""#), "{log}");
+    assert!(log.contains(r#""head": "release/pending""#), "{log}");
+    assert!(
+        log.contains(r#""title": "release: lat_core v1.3.0"#),
+        "{log}"
+    );
     assert!(log.contains("| lat_core | 1.2.0 | 1.3.0 | 1 |"));
     assert!(
         log.contains("- pending change"),
@@ -316,14 +327,14 @@ fn release_pr_creates_then_updates_the_pull_request() {
     git(root, &["add", "."]);
     git(root, &["commit", "-q", "-m", "more fragments"]);
 
-    trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
+    trellis_github(root, &api)
         .args(["release", "pr", "--base", "main"])
         .assert()
         .success()
         .stdout(predicate::str::contains("updated release PR #42"));
-    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert!(log.contains("pr edit 42 --title release: lat_core v"));
+    let log = fs::read_to_string(root.join(".fake/github-log")).unwrap();
+    assert!(log.contains("PATCH /repos/example/repo/pulls/42"), "{log}");
+    assert!(log.contains(r#""title": "release: lat_core v"#), "{log}");
 }
 
 #[test]
@@ -331,14 +342,13 @@ fn release_pr_requires_a_clean_tree_and_pending_fragments() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
     copy_fixture_to(root);
-    let gh = install_fake_gh(root);
     git(root, &["init", "-q", "-b", "main"]);
     git(root, &["add", "."]);
     git(root, &["commit", "-q", "-m", "init"]);
 
-    // No fragments: a clean no-op.
+    // No fragments: a clean no-op. Both paths stop before any GitHub call,
+    // so no API mock (or token) is needed.
     trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
         .args(["release", "pr"])
         .assert()
         .success()
@@ -347,7 +357,6 @@ fn release_pr_requires_a_clean_tree_and_pending_fragments() {
     // Dirty tree: refuse before touching anything.
     write(&root.join("packages/lat_core/src/wip.gleam"), "// wip\n");
     trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
         .args(["release", "pr"])
         .assert()
         .failure()

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -1,6 +1,9 @@
 //! End-to-end tests for the tag/publish layer, using a fake gleam binary
-//! (TRELLIS_GLEAM_BIN), a fake gh (TRELLIS_GH_BIN), a mock Hex API served
-//! from a local thread (TRELLIS_HEX_API_URL), and real git repos.
+//! (TRELLIS_GLEAM_BIN), a mock GitHub API (TRELLIS_GITHUB_API_URL), a mock
+//! Hex API served from a local thread (TRELLIS_HEX_API_URL), and real git
+//! repos.
+
+mod common;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
@@ -105,34 +108,14 @@ fn install_fake_gleam(root: &Path) -> PathBuf {
     script
 }
 
-/// A fake gh that logs `release create` calls, notes included.
-fn install_fake_gh(root: &Path) -> PathBuf {
-    let script = root.join("fake-gh.sh");
-    write(
-        &script,
-        &format!(
-            concat!(
-                "#!/bin/sh\n",
-                "set -eu\n",
-                "printf 'gh %s\\n---\\n' \"$*\" >> \"{root}/.fake/gh-log\"\n",
-                "case \"$1 $2\" in\n",
-                "  'release view')\n",
-                "    if [ -f \"{root}/.fake/release-$3\" ]; then\n",
-                "      printf '{{\"tagName\":\"%s\"}}\\n' \"$3\"\n",
-                "    else\n",
-                "      echo 'release not found' >&2\n",
-                "      exit 1\n",
-                "    fi\n",
-                "    ;;\n",
-                "  'release create') touch \"{root}/.fake/release-$3\" ;;\n",
-                "esac\n",
-            ),
-            root = root.display()
-        ),
-    );
-    fs::set_permissions(&script, fs::Permissions::from_mode(0o755)).unwrap();
-    fs::create_dir_all(root.join(".fake")).unwrap();
-    script
+/// A trellis invocation aimed at the mock GitHub API: base URL and repo
+/// overridden, and a token in the environment.
+fn trellis_github(dir: &Path, api: &str) -> Command {
+    let mut cmd = trellis(dir);
+    cmd.env("TRELLIS_GITHUB_API_URL", api)
+        .env("TRELLIS_GITHUB_REPO", "example/repo")
+        .env("GITHUB_TOKEN", "test-token");
+    cmd
 }
 
 /// Serve a canned Hex API from a background thread: `versions` maps package
@@ -243,10 +226,9 @@ fn tag_create_github_release_uses_changelog_section() {
         root,
         &["remote", "add", "origin", remote.path().to_str().unwrap()],
     );
-    let gh = install_fake_gh(root);
+    let api = common::mock_github(root);
 
-    trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
+    trellis_github(root, &api)
         .args(["tag", "create", "--github-release"])
         .assert()
         .success()
@@ -255,10 +237,66 @@ fn tag_create_github_release_uses_changelog_section() {
             "created GitHub release lat_core-v1.2.0",
         ));
 
-    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert!(log.contains("release create lat_core-v1.2.0 --title lat_core-v1.2.0 --notes"));
+    let log = fs::read_to_string(root.join(".fake/github-log")).unwrap();
+    assert!(log.contains("POST /repos/example/repo/releases\n"), "{log}");
+    assert!(log.contains(r#""tag_name": "lat_core-v1.2.0""#), "{log}");
+    assert!(log.contains(r#""name": "lat_core-v1.2.0""#), "{log}");
     // The notes body is the CHANGELOG section for 1.2.0.
-    assert!(log.contains("- initial"), "gh log:\n{log}");
+    assert!(log.contains("- initial"), "github log:\n{log}");
+}
+
+/// With no token in the environment, the client falls back to `gh auth
+/// token` — the one job the gh CLI still has.
+#[test]
+fn github_release_token_falls_back_to_gh_auth_token() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+    let remote = tempfile::tempdir().unwrap();
+    git(remote.path(), &["init", "-q", "--bare"]);
+    git(
+        root,
+        &["remote", "add", "origin", remote.path().to_str().unwrap()],
+    );
+    let api = common::mock_github(root);
+    let gh = root.join("fake-gh.sh");
+    write(
+        &gh,
+        "#!/bin/sh\nif [ \"$1 $2\" = 'auth token' ]; then echo fake-token; fi\n",
+    );
+    fs::set_permissions(&gh, fs::Permissions::from_mode(0o755)).unwrap();
+
+    trellis(root)
+        .env("TRELLIS_GITHUB_API_URL", &api)
+        .env("TRELLIS_GITHUB_REPO", "example/repo")
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("GH_TOKEN")
+        .env("TRELLIS_GH_BIN", &gh)
+        .args(["tag", "create", "--github-release"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "created GitHub release lat_core-v1.2.0",
+        ));
+}
+
+#[test]
+fn github_release_without_any_token_fails_with_guidance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    init_repo(root);
+
+    trellis(root)
+        .env("TRELLIS_GITHUB_REPO", "example/repo")
+        .env_remove("GITHUB_TOKEN")
+        .env_remove("GH_TOKEN")
+        .env("TRELLIS_GH_BIN", "/nonexistent/gh")
+        .args(["tag", "create", "--github-release"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("GITHUB_TOKEN"));
 }
 
 #[test]
@@ -273,7 +311,7 @@ fn tag_create_reconciles_local_tags_with_remote_and_releases() {
         root,
         &["remote", "add", "origin", remote.path().to_str().unwrap()],
     );
-    let gh = install_fake_gh(root);
+    let api = common::mock_github(root);
 
     for (tag, message) in [
         ("lat_core-v1.2.0", "lat_core 1.2.0"),
@@ -283,8 +321,7 @@ fn tag_create_reconciles_local_tags_with_remote_and_releases() {
         git(root, &["tag", "-a", tag, "-m", message]);
     }
 
-    trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
+    trellis_github(root, &api)
         .args(["tag", "create", "--github-release"])
         .assert()
         .success()
@@ -307,16 +344,26 @@ fn tag_create_reconciles_local_tags_with_remote_and_releases() {
     assert!(tags.contains("lat_mid-v0.5.0"));
     assert!(tags.contains("lat_cli-v0.3.1"));
 
-    let first_log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert_eq!(first_log.matches("gh release create").count(), 3);
+    let first_log = fs::read_to_string(root.join(".fake/github-log")).unwrap();
+    assert_eq!(
+        first_log
+            .matches("POST /repos/example/repo/releases\n")
+            .count(),
+        3
+    );
 
-    trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
+    trellis_github(root, &api)
         .args(["tag", "create", "--github-release"])
         .assert()
         .success();
-    let second_log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert_eq!(second_log.matches("gh release create").count(), 3);
+    let second_log = fs::read_to_string(root.join(".fake/github-log")).unwrap();
+    assert_eq!(
+        second_log
+            .matches("POST /repos/example/repo/releases\n")
+            .count(),
+        3,
+        "the second run creates no new releases:\n{second_log}"
+    );
 }
 
 #[test]
@@ -759,10 +806,9 @@ fn github_releases_skip_series_tags() {
         root,
         "tag_mode_overrides = { both = [\"packages/lat_cli\"] }",
     );
-    let gh = install_fake_gh(root);
+    let api = common::mock_github(root);
 
-    trellis(root)
-        .env("TRELLIS_GH_BIN", &gh)
+    trellis_github(root, &api)
         .args(["tag", "create", "--github-release"])
         .assert()
         .success()
@@ -770,11 +816,11 @@ fn github_releases_skip_series_tags() {
             "created GitHub release lat_cli-v0.3.1",
         ));
 
-    let log = fs::read_to_string(root.join(".fake/gh-log")).unwrap();
-    assert!(log.contains("release create lat_cli-v0.3.1"), "{log}");
+    let log = fs::read_to_string(root.join(".fake/github-log")).unwrap();
+    assert!(log.contains(r#""tag_name": "lat_cli-v0.3.1""#), "{log}");
     // A release bound to a moving tag would silently retarget on the next move.
-    assert!(!log.contains("release create lat_cli-v0.3 "), "{log}");
-    assert!(!log.contains("release view lat_cli-v0.3 "), "{log}");
+    assert!(!log.contains(r#""tag_name": "lat_cli-v0.3""#), "{log}");
+    assert!(!log.contains("/releases/tags/lat_cli-v0.3\n"), "{log}");
     // The series tag itself is still created and pushed.
     assert_eq!(commit_of(root, "lat_cli-v0.3"), commit_of(root, "HEAD"));
 }

--- a/website/src/content/docs/docs/compatibility.mdx
+++ b/website/src/content/docs/docs/compatibility.mdx
@@ -12,14 +12,14 @@ can bind a workflow to, and what may change under you.
 
 Every command uses the same four codes. Branch on **1 versus 3** to tell a
 workspace that has problems from an environment where trellis could not run at
-all — a missing `gh`, an unparseable config, or Hex being unreachable.
+all — a missing GitHub token, an unparseable config, or Hex being unreachable.
 
 | Code | Meaning | Examples |
 | --- | --- | --- |
 | `0` | Success, no findings | `doctor` found nothing; every task passed |
 | `1` | The command ran correctly and found problems | `doctor` findings, missing changelog fragments, a failed task |
 | `2` | Usage error | Unknown flag, missing argument, bad subcommand |
-| `3` | Trellis itself could not run | Unparseable config, not a git repository, missing `gleam`/`gh`, Hex unreachable after retries |
+| `3` | Trellis itself could not run | Unparseable config, not a git repository, missing `gleam`, no GitHub token, Hex unreachable after retries |
 
 A failed task exits `1`; trellis does not propagate the child's own exit code.
 If `gleam test` exits `3`, trellis still exits `1`.

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -48,7 +48,9 @@ retry = { attempts = 5, initial_delay = "30s", multiplier = 2 }
 `trellis release pr` turns pending fragments into a release pull request: it
 runs `version apply` on a release branch (default `release/pending`), commits
 the bumps, force-pushes (so the branch is regenerated on each run), and
-creates or updates the PR via the `gh` CLI. The body carries the bump table
+creates or updates the PR via the GitHub API. It needs a token: `GITHUB_TOKEN`
+(ambient in GitHub Actions), `GH_TOKEN`, or a logged-in `gh` CLI as the
+fallback (`gh auth token`). The body carries the bump table
 and each package's new CHANGELOG section. It requires a clean working tree
 and is a no-op when there are no fragments.
 
@@ -56,7 +58,8 @@ and is a no-op when there are no fragments.
 
 `tag plan` lists the tags the current versions call for and don't have yet.
 `tag create` reconciles them in topological order; `--push` pushes them, and
-`--github-release` (which implies `--push` and requires the `gh` CLI) also
+`--github-release` (which implies `--push` and needs the same GitHub token
+as `release pr`) also
 creates a GitHub Release per tag with the matching CHANGELOG section as the
 body.
 

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -314,13 +314,13 @@ Release orchestration
 
 ###### **Subcommands:**
 
-* `pr` — Create or update the release PR: version apply on a branch, push, gh pr
+* `pr` — Create or update the release PR: version apply on a branch, push, open or refresh the PR via the GitHub API
 
 
 
 ## `trellis release pr`
 
-Create or update the release PR: version apply on a branch, push, gh pr
+Create or update the release PR: version apply on a branch, push, open or refresh the PR via the GitHub API
 
 **Usage:** `trellis release pr [OPTIONS]`
 
@@ -369,7 +369,7 @@ Create missing tags in topological order
 ###### **Options:**
 
 * `--push` — Push each created tag to origin
-* `--github-release` — Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies --push; requires the gh CLI)
+* `--github-release` — Also create a GitHub Release per tag, with the matching CHANGELOG section as the body (implies --push; needs a GitHub token from GITHUB_TOKEN, GH_TOKEN, or a logged-in gh CLI)
 
 
 


### PR DESCRIPTION
## What

`release pr` and `tag create --github-release` now talk to the GitHub REST API through a minimal client on the existing ureq/rustls stack (`src/github.rs`) instead of shelling out to `gh`. No new dependencies, no async runtime.

## Why

Removes the gh CLI as a runtime dependency — CI workflows no longer need a gh install step, and the GitHub interaction is testable against a local mock instead of a fake shell script.

## How

- **Token chain**: `GITHUB_TOKEN` (ambient in GitHub Actions, so CI needs zero setup) → `GH_TOKEN` → `gh auth token` as the fallback, so locally-logged-in gh users notice nothing. No token anywhere is a clear exit-3 error with guidance.
- **Repo resolution**: owner/repo parsed from the `origin` remote (HTTPS, scp-style SSH, and `ssh://` forms), overridable via `TRELLIS_GITHUB_REPO` for non-GitHub remote URLs. The parsing is vendored from tylerbutler/repoverlay with input trimming and `ssh://` handling added, tests included.
- **Failure ordering**: in `tag create` the client resolves once up front, so a missing token fails before any tag is created rather than between two of them. In `release pr` it resolves after the push, preserving the existing failure semantics.
- **Errors**: non-2xx responses surface GitHub's `message` field, not just a status code.

## Tests

The fake-gh shell scripts are replaced by a shared mock GitHub API server (`tests/common/mod.rs`) reached via `TRELLIS_GITHUB_API_URL`; it logs method, path, and JSON body per request, so assertions now check actual wire payloads instead of CLI argument strings. New coverage for the `gh auth token` fallback and the no-token error path. `just ci` green throughout.

Docs, man pages, CLI reference, and changie fragments (`release`, `tag`) updated.