### PR TITLE
feat(changelog)!: preview the release in the check comment, scoped to the branch

### DIFF
--- a/.changes/unreleased/Added-20260801-changelog-check-release-preview.yaml
+++ b/.changes/unreleased/Added-20260801-changelog-check-release-preview.yaml
@@ -1,5 +1,5 @@
 component: changelog
 kind: Added
 body: |-
-  **`changelog check`'s PR comment previews the release itself.** The sticky-comment `preview` now adds a version column (`1.2.0 → 1.3.0`) to the package table and a collapsible "Release preview" section rendering the exact changelog sections `version apply` would write — fragment bodies, generated ripple entries, and rippled-only dependents included. When a fragment does not parse, the versions and preview are omitted and the problem is reported as before.
+  **`changelog check`'s PR comment previews the release itself.** The sticky-comment `preview` now adds a version column (`1.2.0 → 1.3.0`) to the package table and a collapsible "Release preview" section rendering the changelog sections `version apply` would write — fragment bodies, generated ripple entries, and rippled-only dependents included. Like the rest of the check it is scoped to the branch, so the comment shows what merging this branch releases and `version` is the bump this PR causes rather than what the base branch's backlog adds up to. When a fragment does not parse, the versions and preview are omitted and the problem is reported as before.
 time: 2026-08-01T00:00:00.000-07:00

--- a/.changes/unreleased/Added-20260801-changelog-check-release-preview.yaml
+++ b/.changes/unreleased/Added-20260801-changelog-check-release-preview.yaml
@@ -1,0 +1,5 @@
+component: changelog
+kind: Added
+body: |-
+  **`changelog check`'s PR comment previews the release itself.** The sticky-comment `preview` now adds a version column (`1.2.0 → 1.3.0`) to the package table and a collapsible "Release preview" section rendering the exact changelog sections `version apply` would write — fragment bodies, generated ripple entries, and rippled-only dependents included. When a fragment does not parse, the versions and preview are omitted and the problem is reported as before.
+time: 2026-08-01T00:00:00.000-07:00

--- a/.changes/unreleased/Breaking-20260802-changelog-check-scoped-to-the-branch.yaml
+++ b/.changes/unreleased/Breaking-20260802-changelog-check-scoped-to-the-branch.yaml
@@ -1,0 +1,5 @@
+component: changelog
+kind: Breaking
+body: |-
+  **`changelog check` counts only the fragments the branch wrote.** A fragment is the branch's own when its contents differ from the merge base of `base...head` — added outright, or edited from what the base branch already had. Unreleased fragments the branch left untouched document the PRs that added them, and no longer satisfy the check for a later PR touching the same package: one entry can no longer excuse every change until the next release. Comparing contents rather than reading the diff means an uncommitted fragment counts too, so a local run answers the way CI will. Invalid fragments are deliberately not scoped — a fragment that does not parse blocks the next release whoever committed it. `packages[].fragments`, `packages[].has_entry`, and `has_entries` narrow with the count, advancing the payload from `trellis.changelog_check/1` to `trellis.changelog_check/2`. PRs that relied on a base-branch fragment now report a missing entry; set `changelog.strictness = "warn"` to land the reporting without failing builds.
+time: 2026-08-02T00:00:00.000-07:00

--- a/assets/man/trellis-changelog-check.1
+++ b/assets/man/trellis-changelog-check.1
@@ -34,7 +34,7 @@ never
 Head ref of the change range
 .TP
 \fB\-\-format\fR \fI<FORMAT>\fR [default: text]
-How to report: prose, the `trellis.changelog_check/1` JSON payload (including a Markdown `preview` for a PR comment), or `key=value` lines for $GITHUB_OUTPUT
+How to report: prose, the `trellis.changelog_check/2` JSON payload (including a Markdown `preview` for a PR comment), or `key=value` lines for $GITHUB_OUTPUT
 .br
 
 .br
@@ -43,7 +43,7 @@ How to report: prose, the `trellis.changelog_check/1` JSON payload (including a 
 .IP \(bu 2
 text
 .IP \(bu 2
-json: The `trellis.changelog_check/1` payload
+json: The `trellis.changelog_check/2` payload
 .IP \(bu 2
 github: `key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post, update, or delete a PR comment without a `jq` pipeline
 .RE

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -2,6 +2,8 @@
 //! writes a fragment; `check` decides which changed packages still need one.
 
 use crate::changelog;
+use crate::commands::version;
+use crate::commands::version_override::Overrides;
 use crate::config::Strictness;
 use crate::json::{ChangelogCheckDocument, ChangelogPackage};
 use crate::workspace::Workspace;
@@ -153,7 +155,14 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
     // and stays an array of strings; the structured form exists for `doctor`.
     let invalid = fragments.problem_messages();
     let has_entries = !fragments.fragments.is_empty();
-    let preview = preview(&statuses, &needs_entry, &invalid, strictness);
+    // No plan can be computed over a fragment that does not parse, so the
+    // preview falls back to counts alone — the problems are reported anyway.
+    let releases = if fragments.problems.is_empty() {
+        plan_releases(workspace, &fragments)?
+    } else {
+        Vec::new()
+    };
+    let preview = preview(&statuses, &needs_entry, &invalid, strictness, &releases);
 
     match options.format {
         CheckFormat::Json => {
@@ -264,6 +273,51 @@ fn heredoc_delimiter(value: &str) -> String {
     delimiter
 }
 
+/// A planned release, rendered for the preview: what `version apply` would do
+/// with today's fragments, said in the sticky comment before it happens.
+struct ReleasePreview {
+    name: String,
+    current: String,
+    next: String,
+    /// The exact version section `version apply` would write, ripple entries
+    /// included, so the comment can never drift from the eventual changelog.
+    section: String,
+}
+
+/// Compute the version plan and render each entry's section, exactly as
+/// `version apply` would. The plan reaches beyond the PR's diff on purpose:
+/// a dependent that merely ripples still releases, and the preview says so.
+fn plan_releases(
+    workspace: &Workspace,
+    fragments: &changelog::Fragments,
+) -> Result<Vec<ReleasePreview>> {
+    let plan = version::compute_plan(workspace, &Overrides::default())?;
+    let date = changelog::today();
+    plan.iter()
+        .map(|entry| {
+            let rendered: Vec<&changelog::Fragment> = fragments
+                .for_package(&entry.name)
+                .chain(entry.generated.iter())
+                .collect();
+            let tag = workspace.config.format_tag(&entry.name, &entry.next);
+            let section = changelog::render_section(
+                &workspace.config.changelog,
+                &entry.name,
+                &entry.next,
+                &tag,
+                &date,
+                &rendered,
+            )?;
+            Ok(ReleasePreview {
+                name: entry.name.clone(),
+                current: entry.current.clone(),
+                next: entry.next.clone(),
+                section,
+            })
+        })
+        .collect()
+}
+
 /// Markdown summary for the PR sticky comment. `needs_entry` is passed rather
 /// than re-derived so the comment says exactly what the exit code did — under
 /// `off` there is no ❌ and no call to action.
@@ -272,12 +326,13 @@ fn preview(
     needs_entry: &[&str],
     invalid: &[String],
     strictness: Strictness,
+    releases: &[ReleasePreview],
 ) -> String {
     let mut out = String::from("### Changelog check\n\n");
     if statuses.is_empty() {
         out.push_str("No releasable packages changed.\n");
     } else {
-        out.push_str("| package | fragments |\n| --- | --- |\n");
+        out.push_str("| package | fragments | version |\n| --- | --- | --- |\n");
         for status in statuses {
             let cell = if status.fragments > 0 {
                 format!("✅ {}", status.fragments)
@@ -288,12 +343,26 @@ fn preview(
             } else {
                 "❌ needs an entry".to_string()
             };
-            out.push_str(&format!("| {} | {cell} |\n", status.name));
+            let version = releases
+                .iter()
+                .find(|release| release.name == status.name)
+                .map(|release| format!("{} → {}", release.current, release.next))
+                .unwrap_or_else(|| "—".to_string());
+            out.push_str(&format!("| {} | {cell} | {version} |\n", status.name));
         }
         if !needs_entry.is_empty() {
             out.push_str(
                 "\nAdd one with `trellis changelog new --package <name> --kind <kind> --body <text>`.\n",
             );
+        }
+    }
+    if !releases.is_empty() {
+        out.push_str("\n### Release preview\n");
+        for release in releases {
+            out.push_str(&format!(
+                "\n<details>\n<summary><code>{}</code> {} → {}</summary>\n\n{}\n</details>\n",
+                release.name, release.current, release.next, release.section
+            ));
         }
     }
     for problem in invalid {

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -8,6 +8,7 @@ use crate::config::Strictness;
 use crate::json::{ChangelogCheckDocument, ChangelogPackage};
 use crate::workspace::Workspace;
 use anyhow::{Context, Result, bail};
+use std::path::PathBuf;
 
 // ---- new ---------------------------------------------------------------
 
@@ -95,7 +96,7 @@ pub fn new_fragment(
 pub enum CheckFormat {
     #[default]
     Text,
-    /// The `trellis.changelog_check/1` payload.
+    /// The `trellis.changelog_check/2` payload.
     Json,
     /// `key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post, update,
     /// or delete a PR comment without a `jq` pipeline.
@@ -118,12 +119,18 @@ struct PackageStatus {
 /// Map the base...head diff to releasable packages and decide which still
 /// need a changelog fragment. Returns false (non-zero exit) when one does and
 /// strictness is `error`, or when any fragment is invalid.
+///
+/// Everything the check counts is scoped to the branch: a fragment the base
+/// branch was already carrying documents the PR that added it, and letting it
+/// answer for this one is how a change ships undocumented. Invalid fragments
+/// are the deliberate exception — see `all.problems` below.
 pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
     let strictness = options
         .strictness
         .unwrap_or(workspace.config.changelog.strictness);
     let changed = crate::git::changed_members_between(workspace, &options.base, &options.head)?;
-    let fragments = changelog::load_fragments(workspace)?;
+    let all = changelog::load_fragments(workspace)?;
+    let fragments = fragments_changed_by(workspace, &all, options)?;
 
     let statuses: Vec<PackageStatus> = workspace
         .members
@@ -148,16 +155,18 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
             .collect(),
     };
     // A fragment that does not parse is malformed input, not a judgment call,
-    // so it fails at every strictness.
-    let ok = (strictness != Strictness::Error || needs_entry.is_empty())
-        && fragments.problems.is_empty();
-    // `invalid_fragments` is a contract field of `trellis.changelog_check/1`
+    // so it fails at every strictness — and unlike the counts it is *not*
+    // scoped to the branch. A broken fragment on the base branch blocks the
+    // next release for everyone; scoping it would leave every PR green while
+    // the release stayed stuck.
+    let ok = (strictness != Strictness::Error || needs_entry.is_empty()) && all.problems.is_empty();
+    // `invalid_fragments` is a contract field of `trellis.changelog_check/2`
     // and stays an array of strings; the structured form exists for `doctor`.
-    let invalid = fragments.problem_messages();
+    let invalid = all.problem_messages();
     let has_entries = !fragments.fragments.is_empty();
     // No plan can be computed over a fragment that does not parse, so the
     // preview falls back to counts alone — the problems are reported anyway.
-    let releases = if fragments.problems.is_empty() {
+    let releases = if all.problems.is_empty() {
         plan_releases(workspace, &fragments)?
     } else {
         Vec::new()
@@ -273,8 +282,53 @@ fn heredoc_delimiter(value: &str) -> String {
     delimiter
 }
 
-/// A planned release, rendered for the preview: what `version apply` would do
-/// with today's fragments, said in the sticky comment before it happens.
+/// The subset of `fragments` this branch wrote — added outright, or edited from
+/// what the base branch had. Fragments the branch left untouched document the
+/// PRs that added them; counting them here would let one PR's entry excuse the
+/// next PR's undocumented change, which is the whole failure the check exists
+/// to catch.
+///
+/// Editing counts as writing on purpose: a PR that corrects an existing
+/// fragment's body has documented its change, and demanding a second entry for
+/// it would be a false alarm.
+///
+/// Problems are dropped rather than carried over: they are reported unscoped by
+/// the caller, and a scoped set that kept them would invite double-counting.
+fn fragments_changed_by(
+    workspace: &Workspace,
+    fragments: &changelog::Fragments,
+    options: &CheckOptions,
+) -> Result<changelog::Fragments> {
+    // Generated fragments never come from disk; `load_fragments` does not
+    // produce them, but nothing here depends on that.
+    let candidates: Vec<PathBuf> = fragments
+        .fragments
+        .iter()
+        .filter_map(|fragment| fragment.path.clone())
+        .collect();
+    let untouched = crate::git::unchanged_since_merge_base(
+        workspace,
+        &options.base,
+        &options.head,
+        &changelog::unreleased_dir(workspace),
+        &candidates,
+    )?;
+    Ok(changelog::Fragments {
+        fragments: fragments
+            .fragments
+            .iter()
+            .filter(|fragment| match &fragment.path {
+                Some(path) => !untouched.contains(path),
+                None => true,
+            })
+            .cloned()
+            .collect(),
+        problems: Vec::new(),
+    })
+}
+
+/// A planned release, rendered for the preview: what this PR's fragments would
+/// do, said in the sticky comment before it happens.
 struct ReleasePreview {
     name: String,
     current: String,
@@ -284,14 +338,17 @@ struct ReleasePreview {
     section: String,
 }
 
-/// Compute the version plan and render each entry's section, exactly as
-/// `version apply` would. The plan reaches beyond the PR's diff on purpose:
-/// a dependent that merely ripples still releases, and the preview says so.
+/// Compute the version plan and render each entry's section, the way
+/// `version apply` would render it. `fragments` is scoped to what this PR
+/// added, so the comment answers "what does merging this release" rather than
+/// republishing whatever the base branch has been accumulating. The plan still
+/// reaches beyond the PR's diff on purpose: a dependent that merely ripples off
+/// one of these fragments still releases, and the preview says so.
 fn plan_releases(
     workspace: &Workspace,
     fragments: &changelog::Fragments,
 ) -> Result<Vec<ReleasePreview>> {
-    let plan = version::compute_plan(workspace, &Overrides::default())?;
+    let plan = version::compute_plan_from(workspace, &Overrides::default(), fragments)?;
     let date = changelog::today();
     plan.iter()
         .map(|entry| {

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -59,6 +59,18 @@ pub fn compute_plan(workspace: &Workspace, overrides: &Overrides) -> Result<Vec<
             fragments.problem_messages().join("\n  - ")
         );
     }
+    compute_plan_from(workspace, overrides, &fragments)
+}
+
+/// [`compute_plan`] over a caller-supplied fragment set, for the callers that
+/// plan a release from something other than everything on disk — the sticky
+/// comment previews the release *this PR* would add to, not the one the base
+/// branch has been accumulating.
+pub fn compute_plan_from(
+    workspace: &Workspace,
+    overrides: &Overrides,
+    fragments: &changelog::Fragments,
+) -> Result<Vec<PlanEntry>> {
     // Before anything is computed, so a typo'd package name fails immediately
     // rather than being silently ignored.
     validate_named_packages(workspace, overrides)?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -53,6 +53,99 @@ pub fn changed_members_between(
     Ok(members_owning(workspace, &repo_root, files))
 }
 
+/// Which of `candidates` (absolute paths under `dir`) the branch left exactly
+/// as the merge base of `base...head` had them — same path, byte-identical
+/// content. Everything else is the branch's own work: added, or edited.
+///
+/// Comparing content against the merge base rather than reading the
+/// `base...head` diff is what makes the answer hold in every mode a fragment
+/// can reach the check in — committed on the branch, staged, merely written to
+/// the working tree, or an edit to a file the base branch already had. A
+/// contributor running the check locally before committing gets the same
+/// answer CI will give afterwards.
+pub fn unchanged_since_merge_base(
+    workspace: &Workspace,
+    base: &str,
+    head: &str,
+    dir: &Path,
+    candidates: &[PathBuf],
+) -> Result<HashSet<PathBuf>> {
+    if candidates.is_empty() {
+        return Ok(HashSet::new());
+    }
+    let repo_root = git_stdout(&workspace.root, &["rev-parse", "--show-toplevel"])
+        .context("changelog check requires the workspace to be inside a git repository")?;
+    let repo_root = PathBuf::from(repo_root.trim())
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(repo_root.trim()));
+    // A `dir` outside the repository has no tracked history to compare
+    // against, so every file in it reads as the branch's own.
+    let Ok(relative) = dir.strip_prefix(&repo_root) else {
+        return Ok(HashSet::new());
+    };
+    // git pathspecs are `/`-separated on every platform.
+    let pathspec = relative
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+    let merge_base = git_stdout(&workspace.root, &["merge-base", base, head])
+        .with_context(|| format!("no merge base between {base} and {head}"))?;
+
+    // `--full-tree` makes both the pathspec and the output relative to the
+    // repository root rather than to the directory git was invoked in; `-z`
+    // turns off the path quoting that would mangle a non-ASCII filename.
+    let listed = git_stdout(
+        &workspace.root,
+        &[
+            "ls-tree",
+            "-r",
+            "-z",
+            "--full-tree",
+            merge_base.trim(),
+            "--",
+            &pathspec,
+        ],
+    )?;
+    let mut at_base: std::collections::HashMap<PathBuf, String> = std::collections::HashMap::new();
+    for record in listed.split('\0').filter(|record| !record.is_empty()) {
+        // "<mode> SP <type> SP <object> TAB <path>"
+        let Some((meta, path)) = record.split_once('\t') else {
+            continue;
+        };
+        let Some(object) = meta.split_whitespace().nth(2) else {
+            continue;
+        };
+        at_base.insert(repo_root.join(path), object.to_string());
+    }
+    if at_base.is_empty() {
+        return Ok(HashSet::new());
+    }
+
+    // Hash the working-tree files the same way git would, so the comparison
+    // sees content rather than mtimes or index state.
+    let stdin = candidates
+        .iter()
+        .map(|path| path.to_string_lossy().into_owned())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let hashed = git_stdout_with_stdin(&workspace.root, &["hash-object", "--stdin-paths"], &stdin)?;
+    let hashes: Vec<String> = lines(&hashed).collect();
+    if hashes.len() != candidates.len() {
+        bail!(
+            "git hash-object returned {} hash(es) for {} file(s)",
+            hashes.len(),
+            candidates.len()
+        );
+    }
+    Ok(candidates
+        .iter()
+        .zip(hashes)
+        .filter(|(path, hash)| at_base.get(*path).is_some_and(|object| object == hash))
+        .map(|(path, _)| path.clone())
+        .collect())
+}
+
 fn members_owning(
     workspace: &Workspace,
     repo_root: &Path,
@@ -150,6 +243,38 @@ fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
         .current_dir(cwd)
         .output()
         .context("failed to run git")?;
+    if !output.status.success() {
+        bail!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// [`git_stdout`] with `stdin` piped in, for the plumbing that reads its input
+/// that way rather than from argv.
+fn git_stdout_with_stdin(cwd: &Path, args: &[&str], stdin: &str) -> Result<String> {
+    use std::io::Write;
+    use std::process::Stdio;
+
+    crate::term::trace_command("git", args, cwd);
+    let mut child = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("failed to run git")?;
+    child
+        .stdin
+        .take()
+        .context("git stdin was not piped")?
+        .write_all(stdin.as_bytes())
+        .context("failed to write to git")?;
+    let output = child.wait_with_output().context("failed to run git")?;
     if !output.status.success() {
         bail!(
             "git {} failed: {}",

--- a/src/json.rs
+++ b/src/json.rs
@@ -533,7 +533,7 @@ pub struct ChangelogCheckDocument<'a> {
 }
 
 impl ChangelogCheckDocument<'_> {
-    pub const SCHEMA: &'static str = "trellis.changelog_check/1";
+    pub const SCHEMA: &'static str = "trellis.changelog_check/2";
 }
 
 /// A workspace dependency that bumped in the same plan. Its dependents bump

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,7 +317,7 @@ enum ChangelogCommand {
         /// Head ref of the change range
         #[arg(long, default_value = "HEAD")]
         head: String,
-        /// How to report: prose, the `trellis.changelog_check/1` JSON payload
+        /// How to report: prose, the `trellis.changelog_check/2` JSON payload
         /// (including a Markdown `preview` for a PR comment), or `key=value`
         /// lines for $GITHUB_OUTPUT
         #[arg(long, value_enum, default_value = "text")]

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -687,6 +687,164 @@ fn the_preview_reports_next_versions_and_fragment_contents() {
 }
 
 #[test]
+fn the_release_preview_ignores_fragments_already_on_the_base_branch() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    // Unreleased on `main` already: an earlier PR's fragment, which this PR
+    // neither added nor is answerable for.
+    add_fragment(root, "lat_mid", "Fixed", "from an earlier pr");
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+    git(root, &["checkout", "-q", "-b", "feature"]);
+    write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
+    add_fragment(root, "lat_core", "Added", "from this pr");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let preview = payload["preview"].as_str().unwrap();
+    assert!(preview.contains("- from this pr"), "{preview}");
+    assert!(!preview.contains("from an earlier pr"), "{preview}");
+    // lat_mid still appears — this PR ripples it — but only with the entry
+    // this PR is responsible for.
+    assert!(preview.contains("Updated lat_core to 1.3.0"), "{preview}");
+    assert!(
+        preview.contains("| lat_core | ✅ 1 | 1.2.0 → 1.3.0 |"),
+        "{preview}"
+    );
+}
+
+/// The base branch carries an unreleased `lat_core` fragment; this PR changes
+/// `lat_core` and adds nothing. The earlier PR's entry documents the earlier
+/// PR, so it cannot answer for this one.
+fn workspace_with_a_base_branch_fragment(root: &Path) {
+    copy_fixture_to(root);
+    add_fragment(root, "lat_core", "Added", "from an earlier pr");
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+    git(root, &["checkout", "-q", "-b", "feature"]);
+    write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
+}
+
+#[test]
+fn a_base_branch_fragment_does_not_satisfy_a_later_pr() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_a_base_branch_fragment(root);
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["needs_entry"], true);
+    assert_eq!(payload["ok"], false);
+    // `has_entries` follows the counts: this PR wrote nothing, so the CI recipe
+    // deletes the comment rather than posting an empty preview.
+    assert_eq!(payload["has_entries"], false);
+    assert_eq!(payload["packages"][0]["fragments"], 0);
+    assert_eq!(payload["packages"][0]["has_entry"], false);
+    let preview = payload["preview"].as_str().unwrap();
+    assert!(
+        preview.contains("| lat_core | ❌ needs an entry | — |"),
+        "{preview}"
+    );
+    assert!(!preview.contains("### Release preview"), "{preview}");
+}
+
+#[test]
+fn editing_a_base_branch_fragment_counts_as_this_prs_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_a_base_branch_fragment(root);
+    // A PR that rewrites an existing entry has documented its change; asking
+    // it for a second fragment would be a false alarm.
+    write(
+        &root.join(".changes/unreleased/lat_core-1.toml"),
+        "project = \"lat_core\"\nkind = \"Added\"\nbody = \"reworded by this pr\"\n",
+    );
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "reword"]);
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["needs_entry"], false);
+    let preview = payload["preview"].as_str().unwrap();
+    assert!(preview.contains("- reworded by this pr"), "{preview}");
+    assert!(
+        preview.contains("| lat_core | ✅ 1 | 1.2.0 → 1.3.0 |"),
+        "{preview}"
+    );
+}
+
+#[test]
+fn an_uncommitted_fragment_satisfies_the_check_before_it_is_committed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_a_base_branch_fragment(root);
+    // Written but not committed: running the check locally has to give the
+    // answer CI will give once it is.
+    add_fragment(root, "lat_core", "Fixed", "not committed yet");
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["needs_entry"], false);
+    let preview = payload["preview"].as_str().unwrap();
+    assert!(preview.contains("- not committed yet"), "{preview}");
+    assert!(!preview.contains("from an earlier pr"), "{preview}");
+}
+
+#[test]
+fn an_invalid_base_branch_fragment_still_fails_the_check() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    // Unlike the counts, problems are not scoped: this one blocks the next
+    // release whoever committed it, so every check reports it.
+    write(
+        &root.join(".changes/unreleased/broken-1.toml"),
+        "not toml at all {{{\n",
+    );
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+    git(root, &["checkout", "-q", "-b", "feature"]);
+    write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
+    add_fragment(root, "lat_core", "Added", "from this pr");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(payload["needs_entry"], false);
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["invalid_fragments"].as_array().unwrap().len(), 1);
+}
+
+#[test]
 fn invalid_fragments_leave_the_preview_without_versions() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();
@@ -723,7 +881,7 @@ fn json_stays_an_alias_for_format_json() {
         .output()
         .unwrap();
     let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(payload["schema"], "trellis.changelog_check/1");
+    assert_eq!(payload["schema"], "trellis.changelog_check/2");
 }
 
 #[test]

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -650,6 +650,68 @@ fn github_format_reports_a_clean_check() {
 }
 
 #[test]
+fn the_preview_reports_next_versions_and_fragment_contents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    add_fragment(root, "lat_mid", "Fixed", "more");
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let preview = payload["preview"].as_str().unwrap();
+    // The table carries each package's planned bump alongside its counts.
+    assert!(
+        preview.contains("| lat_core | ✅ 1 | 1.2.0 → 1.3.0 |"),
+        "{preview}"
+    );
+    assert!(
+        preview.contains("| lat_mid | ✅ 1 | 0.5.0 → 0.5.1 |"),
+        "{preview}"
+    );
+    // The release preview renders the exact sections `version apply` would
+    // write: fragment bodies, and generated ripple entries for dependents —
+    // including lat_cli, which did not change in the diff but bumps anyway.
+    assert!(preview.contains("### Release preview"), "{preview}");
+    assert!(preview.contains("- something"), "{preview}");
+    assert!(preview.contains("- more"), "{preview}");
+    assert!(preview.contains("Updated lat_core to 1.3.0"), "{preview}");
+    assert!(preview.contains("lat_cli"), "{preview}");
+    // A ripple is never a demand: lat_cli did not change in the diff, so it
+    // gets no table row and cannot be asked for a fragment.
+    assert!(!preview.contains("| lat_cli"), "{preview}");
+    assert_eq!(payload["needs_entry"], false);
+}
+
+#[test]
+fn invalid_fragments_leave_the_preview_without_versions() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    workspace_with_one_missing_fragment(root);
+    add_fragment(root, "lat_mid", "Fixed", "more");
+    write(
+        &root.join(".changes/unreleased/broken-1.toml"),
+        "not toml at all {{{\n",
+    );
+
+    // A plan cannot be computed over a fragment that does not parse, so the
+    // preview falls back to counts alone — the problem itself is reported.
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let preview = payload["preview"].as_str().unwrap();
+    assert!(!preview.contains("### Release preview"), "{preview}");
+    assert!(preview.contains("| lat_core | ✅ 1 | — |"), "{preview}");
+    assert!(preview.contains("broken-1.toml"), "{preview}");
+}
+
+#[test]
 fn json_stays_an_alias_for_format_json() {
     let tmp = tempfile::tempdir().unwrap();
     let root = tmp.path();

--- a/tests/snapshots/json_contract__changelog_check_json_contract.snap
+++ b/tests/snapshots/json_contract__changelog_check_json_contract.snap
@@ -22,6 +22,6 @@ expression: payload
     }
   ],
   "preview": "[markdown]",
-  "schema": "trellis.changelog_check/1",
+  "schema": "trellis.changelog_check/2",
   "strictness": "error"
 }

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -128,7 +128,7 @@ sticky comment:
     { "name": "lat_core", "changed": true, "has_entry": true, "fragments": 2 },
     { "name": "lat_cli", "changed": true, "has_entry": false, "fragments": 0 }
   ],
-  "preview": "### Changelog check\n\n| package | fragments |\n| --- | --- |\n…"
+  "preview": "### Changelog check\n\n| package | fragments | version |\n| --- | --- | --- |\n…"
 }
 ```
 
@@ -160,18 +160,54 @@ invalid_fragments=[]
 preview<<TRELLIS_PREVIEW
 ### Changelog check
 
-| package | fragments |
-| --- | --- |
-| lat_core | ✅ 2 |
-| lat_cli | ❌ needs an entry |
+| package | fragments | version |
+| --- | --- | --- |
+| lat_core | ✅ 2 | 1.2.0 → 1.3.0 |
+| lat_cli | ❌ needs an entry | 0.3.1 → 0.3.2 |
 
 Add one with `trellis changelog new --package <name> --kind <kind> --body <text>`.
+
+### Release preview
+
+<details>
+<summary><code>lat_core</code> 1.2.0 → 1.3.0</summary>
+
+## v1.3.0 - 2026-07-11
+
+### Added
+
+- add a --dry-run flag
+
+### Fixed
+
+- stop truncating long names
+
+</details>
+
+<details>
+<summary><code>lat_cli</code> 0.3.1 → 0.3.2</summary>
+
+## v0.3.2 - 2026-07-11
+
+### Dependencies
+
+- Updated lat_core to 1.3.0
+
+</details>
 TRELLIS_PREVIEW
 ```
 
 `needs_entry_packages` and `invalid_fragments` are JSON arrays, read with
 `fromJSON()`; `preview` uses GitHub's heredoc form because it is multi-line.
 See [CI recipes](/docs/ci/#the-changelog-comment) for the workflow.
+
+The table covers the packages the PR's diff touched; the release preview
+covers every package the release would touch, computed the same way
+`version plan` computes it — so a dependent that merely ripples (like
+`lat_cli` above) appears with its generated `Dependencies` entry. Each
+collapsed section is exactly the version section `version apply` would write.
+When a fragment does not parse, no plan can be computed, so the versions and
+the release preview are omitted and the problem is reported instead.
 
 ## Planning a release
 

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -84,6 +84,42 @@ directory — a README edit trips the same gate as a behavior change. That is
 deliberate (the alternative is a heuristic that guesses wrong quietly), but it
 means the gate is sometimes stricter than a repository wants.
 
+### Scope
+
+`check` counts only the fragments the branch itself wrote: those whose contents
+differ from the merge base of `base...head`, whether the branch added them
+outright or edited what the base branch already had. Fragments the branch left
+untouched document the PRs that added them.
+
+This is what makes the gate per-PR. A package with an unreleased fragment from
+an earlier PR does not satisfy the check for a *later* PR that touches the same
+package — otherwise one entry excuses every change until the next release. It
+also keeps the [PR comment](#driving-a-pr-comment) honest: `version` is the bump
+this PR causes rather than what the accumulated backlog adds up to, and a
+package whose only unreleased fragment came from the base branch shows `—`.
+
+Comparing contents rather than reading the diff means an uncommitted fragment
+counts too, so running `check` locally before committing gives the same answer
+CI gives afterwards.
+
+<Callout>
+
+**Invalid fragments are not scoped.** A fragment that does not parse fails
+`check` wherever it came from, because it blocks the next release for everyone
+— scoping it would leave every PR green while the release stayed stuck.
+
+</Callout>
+
+<Callout>
+
+**Upgrading from v0.9.0 or earlier.** The counts were previously unscoped, so a
+PR touching a package that already had an unreleased fragment passed without
+adding its own. Those PRs now report a missing entry, and the payload advanced
+to `trellis.changelog_check/2`. Set [`strictness`](#strictness) to `warn` to
+land the reporting without failing builds while the open PRs catch up.
+
+</Callout>
+
 ### Strictness
 
 `changelog.strictness` sets what a missing entry costs:
@@ -118,7 +154,7 @@ sticky comment:
 
 ```json
 {
-  "schema": "trellis.changelog_check/1",
+  "schema": "trellis.changelog_check/2",
   "ok": false,
   "strictness": "error",
   "has_entries": true,
@@ -133,7 +169,9 @@ sticky comment:
 ```
 
 `needs_entry` states the fact; `ok` states the verdict after strictness is
-applied, and matches the exit code. The `schema` field is there so a workflow
+applied, and matches the exit code. `fragments`, `has_entry`, and `has_entries`
+count only the fragments this branch wrote (see [Scope](#scope)). The `schema`
+field is there so a workflow
 can assert on the shape it expects; the [JSON output](/docs/json-output/) page
 covers what it promises. Note that `preview` is guaranteed to be present and a
 string, but its Markdown is prose — render it rather than parsing it.
@@ -201,13 +239,13 @@ TRELLIS_PREVIEW
 `fromJSON()`; `preview` uses GitHub's heredoc form because it is multi-line.
 See [CI recipes](/docs/ci/#the-changelog-comment) for the workflow.
 
-The table covers the packages the PR's diff touched; the release preview
-covers every package the release would touch, computed the same way
-`version plan` computes it — so a dependent that merely ripples (like
-`lat_cli` above) appears with its generated `Dependencies` entry. Each
-collapsed section is exactly the version section `version apply` would write.
-When a fragment does not parse, no plan can be computed, so the versions and
-the release preview are omitted and the problem is reported instead.
+The table covers the packages the PR's diff touched; the release preview covers
+every package this PR's fragments would release, computed the same way
+`version plan` computes it — so a dependent that merely ripples (like `lat_cli`
+above) appears with its generated `Dependencies` entry. Each collapsed section
+is the version section `version apply` would write for these fragments. When a
+fragment does not parse, no plan can be computed, so the versions and the
+release preview are omitted and the problem is reported instead.
 
 ## Planning a release
 

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -164,8 +164,11 @@ The comment appears when there is something to say — entries to preview, an
 entry missing, or a fragment that doesn't parse — and is deleted when there
 isn't, so a fixed PR doesn't keep a stale complaint. It shows each changed
 package's fragment count and planned next version, plus a collapsible release
-preview of the exact changelog sections `version apply` would write, ripple
-bumps included. `ok` carries the verdict
+preview of the changelog sections this PR's own fragments would produce, ripple
+bumps included. Everything it counts is
+[scoped to the branch](/docs/changelog/#scope) — fragments already unreleased on
+the base branch answer for the PRs that added them, not this one. `ok` carries
+the verdict
 `continue-on-error` swallowed, and is empty if trellis could not run at all,
 which fails the job either way.
 

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -162,7 +162,10 @@ steps:
 
 The comment appears when there is something to say — entries to preview, an
 entry missing, or a fragment that doesn't parse — and is deleted when there
-isn't, so a fixed PR doesn't keep a stale complaint. `ok` carries the verdict
+isn't, so a fixed PR doesn't keep a stale complaint. It shows each changed
+package's fragment count and planned next version, plus a collapsible release
+preview of the exact changelog sections `version apply` would write, ripple
+bumps included. `ok` carries the verdict
 `continue-on-error` swallowed, and is empty if trellis could not run at all,
 which fails the job either way.
 

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -52,7 +52,7 @@ commands pretty-print, some emit one line for shell-variable capture).
 | `graph --format json` | `trellis.graph/1`<br />`{schema, nodes[], edges[]}` |
 | `run <task> --json` | `trellis.run/1`<br />`{schema, ok, task, target?, results[]}` |
 | `exec -- <cmd> --json` | `trellis.exec/1`<br />`{schema, ok, command[], results[]}` |
-| `changelog check --format json` | `trellis.changelog_check/1`<br />`{schema, ok, strictness, has_entries, needs_entry, invalid_fragments[], packages[], preview}` |
+| `changelog check --format json` | `trellis.changelog_check/2`<br />`{schema, ok, strictness, has_entries, needs_entry, invalid_fragments[], packages[], preview}` |
 | `version plan --json` | `trellis.version_plan/1`<br />`{schema, bumped[], fragments_retained}` |
 | `version apply --json` | `trellis.version_apply/1`<br />`{schema, bumped[], lockfiles[], adopted[], fragments_retained}` |
 | `tag plan --json` | `trellis.tag_plan/2`<br />`{schema, tags[]}` |
@@ -179,7 +179,7 @@ series_tags=[]
 
 `changelog check --format github` emits the same style of lines — scalars
 plain, arrays as JSON, and the multi-line `preview` in GitHub's heredoc form.
-It is the `trellis.changelog_check/1` data in a shape the runner parses, not a
+It is the `trellis.changelog_check/2` data in a shape the runner parses, not a
 payload of its own, so it carries no `schema` either.
 
 See [CI recipes](/docs/ci/) for how these are consumed.

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -216,14 +216,14 @@ Verify changed packages have changelog fragments; non-zero exit if not
 * `--head <HEAD>` — Head ref of the change range
 
   Default value: `HEAD`
-* `--format <FORMAT>` — How to report: prose, the `trellis.changelog_check/1` JSON payload (including a Markdown `preview` for a PR comment), or `key=value` lines for $GITHUB_OUTPUT
+* `--format <FORMAT>` — How to report: prose, the `trellis.changelog_check/2` JSON payload (including a Markdown `preview` for a PR comment), or `key=value` lines for $GITHUB_OUTPUT
 
   Default value: `text`
 
   Possible values:
   - `text`
   - `json`:
-    The `trellis.changelog_check/1` payload
+    The `trellis.changelog_check/2` payload
   - `github`:
     `key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post, update, or delete a PR comment without a `jq` pipeline
 


### PR DESCRIPTION
## What

Two changes to `changelog check`, both about making its PR sticky comment answer for *this* PR.

**The comment previews the release.** The package table gains a **version** column (`1.2.0 → 1.3.0`), and a new **Release preview** section renders one collapsible `<details>` per planned release containing the changelog section `version apply` would write — fragment bodies grouped by kind/category, generated `Updated X to Y` ripple entries, and dependents that bump only via ripple. Rendered through the same `compute_plan` and `render_section` the real release uses, so the comment can't drift from the eventual changelog.

**Everything the check counts is scoped to the branch.** A fragment is the branch's own when its contents differ from the merge base of `base...head` — added outright, or edited from what the base branch already had. Fragments the branch left untouched document the PRs that added them, and no longer answer for this one.

## Why the scoping matters

Previously `check` read every unreleased fragment on disk. A PR touching a package that already had a pending fragment from an earlier PR passed the gate without adding its own, so a change could ship undocumented — one entry excused every change until the next release. The preview had the same problem in reverse: it showed the whole accumulated backlog rather than what merging this branch releases.

Comparing contents (blob hash vs. the merge base tree) rather than reading the diff keeps an uncommitted fragment counted, so a local run answers the way CI will. Editing an existing fragment counts as writing one, so a PR that rewords an entry isn't asked for a second.

## Breaking

- `packages[].fragments`, `packages[].has_entry`, `has_entries`, `needs_entry`, and `ok` now reflect only the branch's own fragments. PRs that relied on a base-branch fragment report a missing entry and fail under `strictness = "error"`; `warn` lands the reporting without failing builds.
- The payload advances to `trellis.changelog_check/2`.

Invalid fragments are deliberately *not* scoped — one that doesn't parse blocks the next release whoever committed it, and scoping it would leave every PR green while the release stayed stuck.

## Also

- `version::compute_plan_from` — `compute_plan` over a caller-supplied fragment set.
- `git::unchanged_since_merge_base` — which of a set of paths the branch left byte-identical to the merge base.
- Docs: a new [Scope](https://github.com/tylerbutler/trellis/blob/feat/changelog-check-release-preview/website/src/content/docs/docs/changelog.mdx) section under "Enforcing entries on PRs", with an upgrade callout; `ci.mdx` and the JSON contract page updated.
