### PR TITLE
feat(term): add semantic color to command output

### DIFF
--- a/.changes/unreleased/Added-20260802-command-output-color.yaml
+++ b/.changes/unreleased/Added-20260802-command-output-color.yaml
@@ -1,0 +1,5 @@
+component: trellis
+kind: Added
+body: |-
+  **Command output now uses color.** Errors, warnings, notes, and completed actions (`ok:`, `tagged`, `published`, `bumped`, and similar verbs) are colored consistently across every command, and package names carry the same per-package color already used by `run`'s live output through `list`, `graph`, `version`, `tag`, `publish`, `changelog check`, `info`, and the run summary table. Structural and metadata text — tree glyphs, `$ command` echoes, versions, field labels, `-v` traces, and dry-run `would …` lines — is dimmed so it reads as background rather than action. Color follows the existing `--color`/`NO_COLOR`/TTY resolution, so piped output and `--color never` are unchanged.
+time: 2026-08-02T00:00:00.000-07:00

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-07-11T00:00:00Z",
+  "generatedAt": "2026-08-02T15:52:02-07:00",
   "title": "Design System: Trellis",
   "extensions": {
     "colorMeta": {
@@ -28,6 +28,12 @@
         "canonical": "oklch(0.45 0.086 230)",
         "tonalRamp": ["oklch(0.15 0.06 230)", "oklch(0.25 0.07 230)", "oklch(0.33 0.06 230)", "oklch(0.45 0.086 230)", "oklch(0.55 0.086 230)", "oklch(0.68 0.07 230)", "oklch(0.82 0.05 230)", "oklch(0.95 0.02 230)"]
       },
+      "cobalt-deep": {
+        "role": "primary",
+        "displayName": "Cobalt Deep",
+        "canonical": "oklch(0.33 0.06 230)",
+        "tonalRamp": ["oklch(0.15 0.06 230)", "oklch(0.24 0.06 230)", "oklch(0.33 0.06 230)", "oklch(0.44 0.06 230)", "oklch(0.55 0.06 230)", "oklch(0.68 0.05 230)", "oklch(0.82 0.04 230)", "oklch(0.95 0.02 230)"]
+      },
       "cobalt-band": {
         "role": "primary",
         "displayName": "Cobalt Band",
@@ -40,11 +46,23 @@
         "canonical": "oklch(0.8 0.128 80)",
         "tonalRamp": ["oklch(0.2 0.06 80)", "oklch(0.32 0.08 80)", "oklch(0.45 0.1 80)", "oklch(0.58 0.12 80)", "oklch(0.7 0.128 80)", "oklch(0.8 0.128 80)", "oklch(0.86 0.11 85)", "oklch(0.94 0.06 85)"]
       },
+      "brass-bright": {
+        "role": "secondary",
+        "displayName": "Brass Bright",
+        "canonical": "oklch(0.86 0.11 85)",
+        "tonalRamp": ["oklch(0.2 0.06 85)", "oklch(0.32 0.08 85)", "oklch(0.45 0.1 85)", "oklch(0.58 0.11 85)", "oklch(0.7 0.11 85)", "oklch(0.78 0.11 85)", "oklch(0.86 0.11 85)", "oklch(0.94 0.06 85)"]
+      },
       "ink": {
         "role": "neutral",
         "displayName": "Chart Ink",
         "canonical": "oklch(0.94 0.012 230)",
         "tonalRamp": ["oklch(0.16 0.012 230)", "oklch(0.3 0.012 230)", "oklch(0.45 0.012 230)", "oklch(0.6 0.012 230)", "oklch(0.72 0.012 230)", "oklch(0.82 0.012 230)", "oklch(0.88 0.012 230)", "oklch(0.94 0.012 230)"]
+      },
+      "ink-soft": {
+        "role": "neutral",
+        "displayName": "Ink Soft",
+        "canonical": "oklch(0.88 0.02 230)",
+        "tonalRamp": ["oklch(0.15 0.02 230)", "oklch(0.28 0.02 230)", "oklch(0.4 0.02 230)", "oklch(0.52 0.02 230)", "oklch(0.64 0.02 230)", "oklch(0.76 0.02 230)", "oklch(0.88 0.02 230)", "oklch(0.95 0.015 230)"]
       },
       "muted": {
         "role": "neutral",
@@ -57,12 +75,28 @@
         "displayName": "Ink Dark",
         "canonical": "oklch(0.18 0.03 240)",
         "tonalRamp": ["oklch(0.12 0.03 240)", "oklch(0.18 0.03 240)", "oklch(0.28 0.03 240)", "oklch(0.4 0.03 240)", "oklch(0.52 0.03 240)", "oklch(0.66 0.025 240)", "oklch(0.8 0.02 240)", "oklch(0.93 0.012 240)"]
+      },
+      "line": {
+        "role": "neutral",
+        "displayName": "Line",
+        "canonical": "oklch(0.34 0.03 230)",
+        "tonalRamp": ["oklch(0.15 0.03 230)", "oklch(0.24 0.03 230)", "oklch(0.34 0.03 230)", "oklch(0.45 0.03 230)", "oklch(0.56 0.03 230)", "oklch(0.68 0.03 230)", "oklch(0.82 0.025 230)", "oklch(0.95 0.015 230)"]
+      },
+      "line-soft": {
+        "role": "neutral",
+        "displayName": "Line Soft",
+        "canonical": "oklch(0.27 0.028 230)",
+        "tonalRamp": ["oklch(0.15 0.028 230)", "oklch(0.21 0.028 230)", "oklch(0.27 0.028 230)", "oklch(0.38 0.028 230)", "oklch(0.5 0.028 230)", "oklch(0.64 0.028 230)", "oklch(0.8 0.024 230)", "oklch(0.94 0.015 230)"]
       }
     },
     "typographyMeta": {
       "display": { "displayName": "Display", "purpose": "Hero headline only; Archivo stretched to 'wdth' 118. The brass em inside it is the page's one color-emphasis moment." },
       "headline": { "displayName": "Headline", "purpose": "Section headings, 'wdth' 114." },
       "title": { "displayName": "Title", "purpose": "Phase and panel headings." },
+      "docs-h1": { "displayName": "Docs H1", "purpose": "Docs page titles, 'wdth' 114; docs get the same display care as the landing page." },
+      "docs-h2": { "displayName": "Docs H2", "purpose": "Docs section headings." },
+      "docs-h3": { "displayName": "Docs H3", "purpose": "Docs sub-headings." },
+      "wordmark": { "displayName": "Wordmark", "purpose": "Lowercase 'trellis' beside the lattice glyph in the header, 'wdth' 118." },
       "body": { "displayName": "Body", "purpose": "Prose at 68ch max measure." },
       "label": { "displayName": "Label", "purpose": "Mono: table headers, terminal title bars, fine print." },
       "code": { "displayName": "Code", "purpose": "Mono: code samples and real terminal output; ligatures disabled." }
@@ -103,9 +137,16 @@
     {
       "name": "Terminal Figure",
       "kind": "custom",
-      "description": "Signature: real CLI output with mono title bar; semantic minimal coloring (names 560, structure gray, success brass).",
+      "description": "Signature: real CLI output with mono title bar; semantic minimal coloring (names 560, structure gray, success brass). No traffic-light dots; the brass $ prompt is the frame's only ornament.",
       "html": "<figure class=\"ds-term\"><figcaption class=\"ds-term-bar\"><span class=\"ds-prompt\">$</span>trellis graph</figcaption><pre class=\"ds-term-out\"><code><span class=\"ds-name\">lat_core</span> <span class=\"ds-dim\">(1.2.0)</span>\n<span class=\"ds-name\">lat_mid</span> <span class=\"ds-dim\">(0.5.0)</span>\n<span class=\"ds-dim\">  └─</span> lat_core\n<span class=\"ds-ok\">ok: 2 member(s), 0 warning(s)</span></code></pre></figure>",
       "css": ".ds-term { margin: 0; background: var(--surface, oklch(0.205 0.026 230)); border: 1px solid var(--line, oklch(0.34 0.03 230)); border-radius: 8px; overflow: hidden; max-width: 30rem; } .ds-term-bar { display: flex; align-items: baseline; gap: 0.5ch; padding: 0.5rem 1rem; border-bottom: 1px solid var(--line-soft, oklch(0.27 0.028 230)); font-family: 'Martian Mono Variable', ui-monospace, monospace; font-size: 0.8125rem; color: var(--ink-soft, oklch(0.88 0.02 230)); background: var(--surface-2, oklch(0.25 0.03 230)); } .ds-term .ds-prompt { color: var(--brass, oklch(0.8 0.128 80)); font-weight: 600; } .ds-term-out { margin: 0; padding: 1rem 1rem 1.5rem; overflow-x: auto; font-family: 'Martian Mono Variable', ui-monospace, monospace; font-size: 0.875rem; line-height: 1.7; color: var(--ink, oklch(0.94 0.012 230)); } .ds-name { font-weight: 560; } .ds-dim { color: var(--muted, oklch(0.76 0.022 230)); } .ds-ok { color: var(--brass, oklch(0.8 0.128 80)); font-weight: 600; }"
+    },
+    {
+      "name": "Ledger Table",
+      "kind": "custom",
+      "description": "The proof surface: mono Fog Gray headers on Steel Raised, brass first column for file/key names, Line Soft row dividers, no zebra striping.",
+      "html": "<div class=\"ds-ledger\"><table><thead><tr><th>file</th><th>what it hand-maintained</th></tr></thead><tbody><tr><td class=\"ds-key\">justfile</td><td>bash loop over a hand-kept package list</td></tr><tr><td class=\"ds-key\">.changie.yaml</td><td>one project block per package</td></tr><tr><td class=\"ds-key\">release.yml</td><td>inline sed over workflow files</td></tr></tbody></table></div>",
+      "css": ".ds-ledger { border: 1px solid var(--line, oklch(0.34 0.03 230)); border-radius: 8px; overflow-x: auto; max-width: 40rem; background: var(--surface, oklch(0.205 0.026 230)); } .ds-ledger table { width: 100%; border-collapse: collapse; font-family: 'Archivo Variable', sans-serif; font-size: 0.9375rem; color: var(--ink, oklch(0.94 0.012 230)); } .ds-ledger th { font-family: 'Martian Mono Variable', ui-monospace, monospace; font-size: 0.8125rem; font-weight: 560; text-align: left; color: var(--muted, oklch(0.76 0.022 230)); background: var(--surface-2, oklch(0.25 0.03 230)); padding: 0.6rem 1rem; } .ds-ledger td { padding: 0.6rem 1rem; border-top: 1px solid var(--line-soft, oklch(0.27 0.028 230)); } .ds-ledger .ds-key { font-family: 'Martian Mono Variable', ui-monospace, monospace; font-size: 0.8125rem; color: var(--brass, oklch(0.8 0.128 80)); white-space: nowrap; }"
     },
     {
       "name": "Nav Link",
@@ -124,7 +165,7 @@
   ],
   "narrative": {
     "northStar": "The Calibrated Instrument",
-    "overview": "Trellis is a tool you trust the way you trust a well-made instrument: it derives its answers instead of asking you to declare them, and it verifies everything it cannot derive. The site carries the same character — brass dials on oxidized steel. The page surface is a deep harbor-steel blue, structural panels step up through tonal cobalt layers, and a single warm brass voice marks what matters. Typography pairs Archivo (stretched wide for display) with Martian Mono, which has a register reason: the product IS a CLI, and its real, unretouched output is the site's primary imagery.",
+    "overview": "Trellis is a tool you trust the way you trust a well-made instrument: it derives its answers instead of asking you to declare them, and it verifies everything it cannot derive. The site carries the same character — brass dials on oxidized steel. The page surface is a deep harbor-steel blue, structural panels step up through tonal cobalt layers, and a single warm brass voice marks what matters: the primary action, the active nav item, the $ prompt, the ok: line in real terminal output. Typography pairs Archivo (stretched wide for display, plain for prose) with Martian Mono, which has a register reason: the product IS a CLI, and its real, unretouched output is the site's primary imagery.\n\nDensity is calm but committed. Sections hold one idea each; ledger tables and terminal figures do the persuading; motion is limited to state changes with one exponential ease. The system explicitly rejects the generic SaaS landing page (gradient heroes, floating product screenshots, pricing-page energy), the sterile default docs theme (out-of-the-box Starlight with no identity), and the Linear/Vercel dark-glow lane (near-black surfaces, glowing gradients, luminous blur). Its living references are gleam.run's hand-made friendliness and axo.dev's proof that a small CLI tool can have a real designed identity.",
     "keyCharacteristics": [
       "Committed color: steel cobalt carries the surface; brass is the single accent voice",
       "Real terminal output as imagery — never fabricated, never prettified",
@@ -147,8 +188,8 @@
       "Do give docs pages landing-page-level craft; the docs are the pitch."
     ],
     "donts": [
-      "Don't build a generic SaaS landing page: no gradient heroes, no floating product screenshots, no pricing-page energy.",
-      "Don't ship a sterile default docs theme — an out-of-the-box Starlight/Docusaurus look with no identity.",
+      "Don't build a generic SaaS landing page: no gradient heroes, no floating product screenshots, no pricing-page energy (PRODUCT.md anti-reference).",
+      "Don't ship a sterile default docs theme — an out-of-the-box Starlight/Docusaurus look with no identity (PRODUCT.md anti-reference).",
       "Don't drift into Linear/Vercel dark-glow: glowing gradients, luminous blur, floating UI (The No-Glow Rule).",
       "Don't put Fog Gray text on cobalt fills — it fails contrast at 3.4:1 (The Ink-on-Cobalt Rule).",
       "Don't claim 'simple' or 'powerful' in the abstract; show the lattice before/after ledger and real config instead.",

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,9 +1,5 @@
 # Product
 
-## Register
-
-brand
-
 ## Platform
 
 web

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -79,7 +79,8 @@ pub fn new_fragment(
 
     let path = changelog::write_fragment(workspace, project, kind, category, body.trim())?;
     crate::status!(
-        "created {}",
+        "{} {}",
+        crate::term::ok("created"),
         path.strip_prefix(&workspace.root)
             .unwrap_or(&path)
             .display()
@@ -216,18 +217,18 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
                     format!("{} fragment(s)", status.fragments)
                 } else if !needs_entry.contains(&status.name.as_str()) {
                     // `off`: report the fact, ask for nothing.
-                    "no entries".to_string()
+                    crate::term::dim("no entries")
                 } else if strictness == Strictness::Warn {
                     // Named as advisory, so a green exit code doesn't read as
                     // the line having been ignored.
-                    "needs a changelog entry (warning)".to_string()
+                    crate::term::warn("needs a changelog entry (warning)")
                 } else {
-                    "needs a changelog entry".to_string()
+                    crate::term::err("needs a changelog entry")
                 };
-                crate::status!("{}: {state}", status.name);
+                crate::status!("{}: {state}", crate::term::package(&status.name));
             }
             for problem in &invalid {
-                crate::status!("invalid: {problem}");
+                crate::status!("{} {problem}", crate::term::err("invalid:"));
             }
         }
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -223,7 +223,7 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
             "gleam on PATH matches the .tool-versions pin (advisory)",
         ];
         for check in checked {
-            crate::status!("checked: {check}");
+            crate::status!("{}", crate::term::dim(&format!("checked: {check}")));
         }
         crate::status!();
     }
@@ -236,7 +236,10 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
         if text {
             print_findings(&report);
             for fix in &report.fixes {
-                crate::status!("would fix: {}", fix.describe());
+                crate::status!(
+                    "{}",
+                    crate::term::dim(&format!("would fix: {}", fix.describe()))
+                );
             }
         }
         return finish(&report, &[], options.format);
@@ -249,7 +252,7 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
         for fix in &report.fixes {
             fix.apply()?;
             if text {
-                crate::status!("fixed: {}", fix.describe());
+                crate::status!("{} {}", crate::term::ok("fixed:"), fix.describe());
             }
         }
         if text {
@@ -265,7 +268,8 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
         print_findings(&report);
         if !options.fix && !report.fixes.is_empty() {
             crate::status!(
-                "note: {} finding(s) are auto-fixable; rerun with --fix",
+                "{} {} finding(s) are auto-fixable; rerun with --fix",
+                crate::term::note("note:"),
                 report.fixes.len()
             );
         }
@@ -278,21 +282,23 @@ fn print_findings(report: &Report) {
     // states the inference instead of leaving it invisible.
     if report.configless {
         crate::status!(
-            "note: no [tools.trellis] configuration found; workspace root inferred from git, \
+            "{} no [tools.trellis] configuration found; workspace root inferred from git, \
              {} member(s) auto-discovered",
+            crate::term::note("note:"),
             report.packages()
         );
     } else if report.auto_members {
         crate::status!(
-            "note: `members` is not configured; {} member(s) auto-discovered from git",
+            "{} `members` is not configured; {} member(s) auto-discovered from git",
+            crate::term::note("note:"),
             report.packages()
         );
     }
     for warning in report.of_severity(Severity::Warning) {
-        crate::status!("warning: {}", warning.message);
+        crate::status!("{} {}", crate::term::warn("warning:"), warning.message);
     }
     for error in report.of_severity(Severity::Error) {
-        crate::status!("error: {}", error.message);
+        crate::status!("{} {}", crate::term::err("error:"), error.message);
     }
 }
 
@@ -340,12 +346,14 @@ fn print_summary(report: &Report, ok: bool) {
         // The JSON field behind this count is still `members` — renaming a
         // stable key would bump `trellis.doctor/1`, so it waits for 1.0.
         crate::status!(
-            "ok: {} package(s) ({lifecycles}), {warnings} warning(s)",
+            "{} {} package(s) ({lifecycles}), {warnings} warning(s)",
+            crate::term::ok("ok:"),
             report.packages()
         );
     } else {
         crate::status!(
-            "FAILED: {} error(s), {warnings} warning(s)",
+            "{} {} error(s), {warnings} warning(s)",
+            crate::term::err("FAILED:"),
             report.count(Severity::Error)
         );
     }

--- a/src/commands/graph.rs
+++ b/src/commands/graph.rs
@@ -17,7 +17,11 @@ pub fn run(workspace: &Workspace, format: GraphFormat) -> Result<()> {
     match format {
         GraphFormat::Text => {
             for (idx, member) in workspace.members.iter().enumerate() {
-                crate::status!("{} ({})", member.name, member.version());
+                crate::status!(
+                    "{} {}",
+                    crate::term::package(&member.name),
+                    crate::term::dim(&format!("({})", member.version()))
+                );
                 let deps = workspace.deps_of(idx);
                 for (pos, &dep) in deps.iter().enumerate() {
                     let branch = if pos + 1 == deps.len() {
@@ -25,7 +29,11 @@ pub fn run(workspace: &Workspace, format: GraphFormat) -> Result<()> {
                     } else {
                         "├─"
                     };
-                    crate::status!("  {branch} {}", workspace.members[dep].name);
+                    crate::status!(
+                        "  {} {}",
+                        crate::term::dim(branch),
+                        crate::term::package(&workspace.members[dep].name)
+                    );
                 }
             }
         }

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -16,16 +16,24 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
     }
 
     let member = &workspace.members[idx];
-    crate::status!("name:       {}", member.name);
-    crate::status!("version:    {}", member.version());
-    crate::status!("path:       {}", member.rel_path);
-    crate::status!("lifecycle:  {}", member.lifecycle.key());
-    crate::status!("releasable: {}", member.releasable());
+    // Labels are dimmed with their padding outside the paint, so alignment
+    // survives `--color never` transcripts byte-for-byte.
+    let label = |text: &str| crate::term::dim(text);
+    crate::status!(
+        "{}       {}",
+        label("name:"),
+        crate::term::package(&member.name)
+    );
+    crate::status!("{}    {}", label("version:"), member.version());
+    crate::status!("{}       {}", label("path:"), member.rel_path);
+    crate::status!("{}  {}", label("lifecycle:"), member.lifecycle.key());
+    crate::status!("{} {}", label("releasable:"), member.releasable());
     // Only the tags this member's mode actually produces — a series-only
     // package has no per-version tag to report.
     if member.tag_mode.includes_exact() {
         crate::status!(
-            "tag:        {}",
+            "{}        {}",
+            label("tag:"),
             workspace.config.format_tag(&member.name, member.version())
         );
     }
@@ -34,7 +42,7 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
             .config
             .format_series_tag(&member.name, member.version())
     {
-        crate::status!("series tag: {tag}");
+        crate::status!("{} {tag}", label("series tag:"));
     }
     let format_names = |indices: &[usize]| -> String {
         if indices.is_empty() {
@@ -48,11 +56,13 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
         }
     };
     crate::status!(
-        "workspace deps:       {}",
+        "{}       {}",
+        label("workspace deps:"),
         format_names(workspace.deps_of(idx))
     );
     crate::status!(
-        "workspace dependents: {}",
+        "{} {}",
+        label("workspace dependents:"),
         format_names(workspace.dependents_of(idx))
     );
     let hex_deps: Vec<String> = member
@@ -63,7 +73,8 @@ pub fn run(workspace: &Workspace, name: &str, json: bool) -> Result<()> {
         .map(|dep| dep.name.clone())
         .collect();
     crate::status!(
-        "hex deps:             {}",
+        "{}             {}",
+        label("hex deps:"),
         if hex_deps.is_empty() {
             "(none)".to_string()
         } else {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -42,17 +42,17 @@ pub fn run(start: &Path) -> Result<bool> {
     let document = render_config(existing.as_deref())?;
     std::fs::write(&manifest_path, document)
         .with_context(|| format!("failed to write {}", manifest_path.display()))?;
-    crate::status!(
-        "{} {}",
-        if existing.is_some() {
-            "added [tools.trellis] to"
-        } else {
-            // A root that is not itself a package still needs a manifest to
-            // carry the table; a config-only gleam.toml is a supported shape.
-            "created"
-        },
-        manifest_path.display()
-    );
+    if existing.is_some() {
+        crate::status!(
+            "{} [tools.trellis] to {}",
+            crate::term::ok("added"),
+            manifest_path.display()
+        );
+    } else {
+        // A root that is not itself a package still needs a manifest to
+        // carry the table; a config-only gleam.toml is a supported shape.
+        crate::status!("{} {}", crate::term::ok("created"), manifest_path.display());
+    }
 
     // Reported rather than written: seeing the derived list is what tells the
     // user whether it needs narrowing, and printing it costs nothing.

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -35,7 +35,12 @@ pub fn run(workspace: &Workspace, options: &ListOptions) -> Result<()> {
             .unwrap_or(0);
         for idx in selected {
             let member = &workspace.members[idx];
-            crate::status!("{:width$}  {}", member.name, member.lifecycle.key());
+            let padded = format!("{:width$}", member.name);
+            crate::status!(
+                "{}  {}",
+                crate::term::package_padded(&member.name, &padded),
+                member.lifecycle.key()
+            );
         }
     }
     Ok(())

--- a/src/commands/lockfile.rs
+++ b/src/commands/lockfile.rs
@@ -24,7 +24,11 @@ pub fn refresh(workspace: &Workspace, package: Option<&str>) -> Result<bool> {
         let member = &workspace.members[idx];
         tools::with_retry(retry, &format!("deps download for {}", member.name), || {
             let gleam = tools::gleam_bin();
-            crate::status!("[{}] $ gleam deps download", member.name);
+            crate::status!(
+                "[{}] {}",
+                crate::term::package(&member.name),
+                crate::term::dim("$ gleam deps download")
+            );
             let status = Command::new(&gleam)
                 .args(["deps", "download"])
                 .current_dir(&member.path)

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -138,7 +138,11 @@ pub fn run(workspace: &Workspace, options: &NewOptions) -> Result<()> {
     )?;
     write(&dir.join("README.md"), &format!("# {name}\n"))?;
 
-    crate::status!("created {rel_path}/ (gleam.toml, src, test, CHANGELOG.md, README.md)");
+    crate::status!(
+        "{} {rel_path}/ {}",
+        crate::term::ok("created"),
+        crate::term::dim("(gleam.toml, src, test, CHANGELOG.md, README.md)")
+    );
     if let Some(sibling) = sibling {
         crate::status!("metadata copied from {}", sibling.rel_path);
     }

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -117,7 +117,11 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
             hex.published_versions(&name)
         })?;
         if published.iter().any(|v| v == &version) {
-            crate::status!("[{name}] {version} is already on Hex; skipping");
+            crate::status!(
+                "[{}] {}",
+                crate::term::package(&name),
+                crate::term::dim(&format!("{version} is already on Hex; skipping"))
+            );
             continue;
         }
 
@@ -135,15 +139,26 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
         .with_context(|| format!("cannot prepare `{name}` for publishing"))?;
 
         if options.dry_run {
-            crate::status!("[{name}] would publish {version}");
+            crate::status!(
+                "[{}] {}",
+                crate::term::package(&name),
+                crate::term::dim(&format!("would publish {version}"))
+            );
             for rewrite in &rewrites {
-                crate::status!("[{name}]   {} -> \"{}\"", rewrite.name, rewrite.requirement);
+                crate::status!(
+                    "[{}] {}",
+                    crate::term::package(&name),
+                    crate::term::dim(&format!(
+                        "  {} -> \"{}\"",
+                        rewrite.name, rewrite.requirement
+                    ))
+                );
             }
             continue;
         }
 
         // 2. Validate against the *original* manifest (path deps intact).
-        crate::status!("[{name}] validating {version}");
+        crate::status!("[{}] validating {version}", crate::term::package(&name));
         gleam_step(workspace, idx, &["format", "--check"])?;
         // Build and test resolve deps, which touches Hex — retry those.
         tools::with_retry(retry, &format!("gleam build for {name}"), || {
@@ -163,7 +178,8 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
             .with_context(|| format!("failed to write {}", manifest_path.display()))?;
         for rewrite in &rewrites {
             crate::status!(
-                "[{name}] rewrote {} -> \"{}\"",
+                "[{}] rewrote {} -> \"{}\"",
+                crate::term::package(&name),
                 rewrite.name,
                 rewrite.requirement
             );
@@ -173,7 +189,11 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
         });
         drop(guard); // restore gleam.toml before deciding success
         result?;
-        crate::status!("[{name}] published {version}");
+        crate::status!(
+            "[{}] {} {version}",
+            crate::term::package(&name),
+            crate::term::ok("published")
+        );
     }
     Ok(true)
 }
@@ -201,7 +221,11 @@ impl Drop for RestoreGuard {
 fn gleam_step(workspace: &Workspace, idx: usize, args: &[&str]) -> Result<()> {
     let member = &workspace.members[idx];
     let gleam = tools::gleam_bin();
-    crate::status!("[{}] $ gleam {}", member.name, args.join(" "));
+    crate::status!(
+        "[{}] {}",
+        crate::term::package(&member.name),
+        crate::term::dim(&format!("$ gleam {}", args.join(" ")))
+    );
     let status = Command::new(&gleam)
         .args(args)
         .current_dir(&member.path)

--- a/src/commands/release.rs
+++ b/src/commands/release.rs
@@ -106,11 +106,14 @@ fn build_release_commit_and_pr(
     match github.find_open_pr(&options.branch)? {
         Some(number) => {
             github.update_pr(number, &title, &body)?;
-            crate::status!("updated release PR #{number}: {title}");
+            crate::status!(
+                "{} release PR #{number}: {title}",
+                crate::term::ok("updated")
+            );
         }
         None => {
             let url = github.create_pr(&options.base, &options.branch, &title, &body)?;
-            crate::status!("created release PR: {url}");
+            crate::status!("{} release PR: {url}", crate::term::ok("created"));
         }
     }
     Ok(true)

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -255,7 +255,7 @@ pub fn plan(workspace: &Workspace, json: bool) -> Result<()> {
             };
             crate::status!(
                 "{}: {} {verb} {}",
-                member.name,
+                crate::term::package(&member.name),
                 planned.version,
                 planned.tag
             );
@@ -382,7 +382,7 @@ fn reconcile_remote_repository_series_tag(workspace: &Workspace) -> Result<()> {
     }
     if local_tag_oid(&workspace.root, &tag)?.as_deref() != Some(remote_oid.as_str()) {
         git_stdout(&workspace.root, &["update-ref", &reference, &remote_oid])?;
-        crate::status!("fetched {tag}");
+        crate::status!("{} {tag}", crate::term::ok("fetched"));
     }
     Ok(())
 }
@@ -406,13 +406,13 @@ fn create_exact_tag(
     if planned.action == TagAction::Create {
         if remote_oid.is_some() {
             if options.dry_run {
-                crate::status!("would fetch {tag}");
+                crate::status!("{}", crate::term::dim(&format!("would fetch {tag}")));
             } else {
                 git_stdout(&workspace.root, &["fetch", "origin", "tag", tag])?;
-                crate::status!("fetched {tag}");
+                crate::status!("{} {tag}", crate::term::ok("fetched"));
             }
         } else if options.dry_run {
-            crate::status!("would tag {tag}");
+            crate::status!("{}", crate::term::dim(&format!("would tag {tag}")));
         } else {
             let mut args = crate::git::identity_fallback_args(&workspace.root);
             args.extend([
@@ -424,27 +424,33 @@ fn create_exact_tag(
             ]);
             let args: Vec<&str> = args.iter().map(String::as_str).collect();
             git_stdout(&workspace.root, &args)?;
-            crate::status!("tagged {tag}");
+            crate::status!("{} {tag}", crate::term::ok("tagged"));
         }
     }
     if push && remote_oid.is_none() {
         if options.dry_run {
-            crate::status!("would push {tag}");
+            crate::status!("{}", crate::term::dim(&format!("would push {tag}")));
         } else {
             git_stdout(&workspace.root, &["push", "origin", tag])
                 .with_context(|| format!("failed to push tag {tag}"))?;
-            crate::status!("pushed {tag}");
+            crate::status!("{} {tag}", crate::term::ok("pushed"));
         }
     }
     if let Some(github) = github {
         if github.release_exists(tag)? {
-            crate::status!("GitHub release {tag} already exists; skipping");
+            crate::status!(
+                "{}",
+                crate::term::dim(&format!("GitHub release {tag} already exists; skipping"))
+            );
         } else if options.dry_run {
-            crate::status!("would create GitHub release {tag}");
+            crate::status!(
+                "{}",
+                crate::term::dim(&format!("would create GitHub release {tag}"))
+            );
         } else {
             let notes = release_notes(workspace, planned.member);
             github.create_release(tag, tag, &notes)?;
-            crate::status!("created GitHub release {tag}");
+            crate::status!("{} GitHub release {tag}", crate::term::ok("created"));
         }
     }
     Ok(())
@@ -471,7 +477,7 @@ fn move_series_tag(
             ("move", "moved")
         };
         if options.dry_run {
-            crate::status!("would {verb} {tag}");
+            crate::status!("{}", crate::term::dim(&format!("would {verb} {tag}")));
         } else {
             let mut args = crate::git::identity_fallback_args(&workspace.root);
             args.extend([
@@ -484,7 +490,7 @@ fn move_series_tag(
             ]);
             let args: Vec<&str> = args.iter().map(String::as_str).collect();
             git_stdout(&workspace.root, &args)?;
-            crate::status!("{done} {tag}");
+            crate::status!("{} {tag}", crate::term::ok(done));
         }
     }
     if push {
@@ -500,7 +506,7 @@ fn move_series_tag(
                 "force-push"
             };
             if options.dry_run {
-                crate::status!("would {verb} {tag}");
+                crate::status!("{}", crate::term::dim(&format!("would {verb} {tag}")));
             } else {
                 if planned.kind == TagKind::RepositorySeries {
                     let lease = format!(
@@ -513,7 +519,7 @@ fn move_series_tag(
                     git_stdout(&workspace.root, &["push", "--force", "origin", tag])
                         .with_context(|| format!("failed to push tag {tag}"))?;
                 }
-                crate::status!("{verb}ed {tag}");
+                crate::status!("{} {tag}", crate::term::ok(&format!("{verb}ed")));
             }
         }
     }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -168,17 +168,19 @@ pub fn plan(workspace: &Workspace, overrides: &Overrides, json: bool) -> Result<
     } else {
         for entry in &plan {
             crate::status!(
-                "{}: {} -> {} ({})",
-                entry.name,
+                "{}: {} {} {} {}",
+                crate::term::package(&entry.name),
                 entry.current,
+                crate::term::dim("->"),
                 entry.next,
-                entry.why()
+                crate::term::dim(&format!("({})", entry.why()))
             );
         }
         if overrides.retains_fragments() {
             crate::status!(
-                "note: prerelease — fragments stay unreleased and will be released again \
-                 by the final version"
+                "{} prerelease — fragments stay unreleased and will be released again \
+                 by the final version",
+                crate::term::note("note:")
             );
         }
     }
@@ -400,13 +402,23 @@ pub fn apply(workspace: &Workspace, overrides: &Overrides, json: bool) -> Result
         println!("{}", serde_json::to_string_pretty(&document)?);
     } else {
         for entry in &plan {
-            crate::status!("bumped {}: {} -> {}", entry.name, entry.current, entry.next);
+            crate::status!(
+                "{} {}: {} {} {}",
+                crate::term::ok("bumped"),
+                crate::term::package(&entry.name),
+                entry.current,
+                crate::term::dim("->"),
+                entry.next
+            );
         }
         for file in &patched_files {
-            crate::status!("patched {file}");
+            crate::status!("{} {file}", crate::term::ok("patched"));
         }
         for file in &adopted_files {
-            crate::status!("adopted existing changelog history as {file}");
+            crate::status!(
+                "{} existing changelog history as {file}",
+                crate::term::ok("adopted")
+            );
         }
         if overrides.retains_fragments() {
             crate::status!("kept fragments unreleased for the final version");

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,7 +533,7 @@ fn main() -> ExitCode {
         Ok(true) => ExitCode::SUCCESS,
         Ok(false) => ExitCode::FAILURE,
         Err(err) => {
-            eprintln!("error: {err:#}");
+            eprintln!("{} {err:#}", term::err("error:"));
             ExitCode::from(EXIT_INTERNAL_ERROR)
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,7 +14,6 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, mpsc};
 use std::time::{Duration, Instant};
 
-const NAME_COLOR_CODES: &[u8] = &[31, 32, 33, 34, 35, 36, 91, 92, 93, 94, 95, 96];
 const SPINNER_TICKS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 #[derive(Debug, Clone)]
@@ -83,7 +82,6 @@ pub struct RunOptions {
 #[derive(Clone)]
 struct Output {
     progress: Option<Arc<MultiProgress>>,
-    colors: bool,
     /// `-q`: drop the package stream and the summary table entirely.
     quiet: bool,
     /// `--json`: keep the package stream, but off stdout.
@@ -103,7 +101,6 @@ impl Output {
         Self {
             progress: live
                 .then(|| Arc::new(MultiProgress::with_draw_target(ProgressDrawTarget::stdout()))),
-            colors: crate::term::colors_enabled(),
             quiet,
             to_stderr: json,
         }
@@ -119,15 +116,12 @@ impl Output {
                 .expect("progress template is valid")
                 .tick_strings(SPINNER_TICKS),
             );
-            progress.set_prefix(self.format_name(name, name));
+            progress.set_prefix(crate::term::package(name));
             progress.set_message("starting");
             progress.enable_steady_tick(Duration::from_millis(80));
             progress
         });
-        JobDisplay {
-            progress,
-            colors: self.colors,
-        }
+        JobDisplay { progress }
     }
 
     fn emit(&self, name: &str, width: usize, line: &str) {
@@ -135,8 +129,8 @@ impl Output {
             return;
         }
         let padded = format!("{name:width$}");
-        let name = self.format_name(name, &padded);
-        self.println(format!("{name} ▏ {line}"));
+        let name = crate::term::package_padded(name, &padded);
+        self.println(format!("{name} {} {line}", crate::term::dim("▏")));
     }
 
     fn println(&self, line: String) {
@@ -151,10 +145,6 @@ impl Output {
         }
     }
 
-    fn format_name(&self, name: &str, display: &str) -> String {
-        colorize_name(name, display, self.colors)
-    }
-
     fn clear_live(&self) {
         if let Some(progress) = &self.progress {
             progress.clear().expect("failed to clear progress output");
@@ -165,7 +155,6 @@ impl Output {
 #[derive(Clone)]
 struct JobDisplay {
     progress: Option<ProgressBar>,
-    colors: bool,
 }
 
 impl JobDisplay {
@@ -182,12 +171,11 @@ impl JobDisplay {
         progress.set_style(
             ProgressStyle::with_template("{prefix}  {msg}").expect("progress template is valid"),
         );
-        let (symbol, label, color) = match status {
-            JobStatus::Success => ("✓", "ok", 32),
-            JobStatus::Failed(_) => ("✗", "FAILED", 31),
-            JobStatus::Skipped => ("-", "skipped", 33),
+        let status = match status {
+            JobStatus::Success => crate::term::ok("✓ ok"),
+            JobStatus::Failed(_) => crate::term::err("✗ FAILED"),
+            JobStatus::Skipped => crate::term::warn("- skipped"),
         };
-        let status = colorize_text(&format!("{symbol} {label}"), color, self.colors);
         progress.finish_with_message(format!("{status}  {:.1}s", duration.as_secs_f64()));
     }
 }
@@ -458,29 +446,6 @@ fn run_streaming(
     Ok(child.wait()?)
 }
 
-fn stable_name_hash(name: &str) -> u64 {
-    name.bytes().fold(0xcbf29ce484222325, |hash, byte| {
-        (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
-    })
-}
-
-fn colorize_name(name: &str, display: &str, enabled: bool) -> String {
-    colorize_text(display, name_color_code(name), enabled)
-}
-
-fn name_color_code(name: &str) -> u8 {
-    let index = stable_name_hash(name) as usize % NAME_COLOR_CODES.len();
-    NAME_COLOR_CODES[index]
-}
-
-fn colorize_text(text: &str, color: u8, enabled: bool) -> String {
-    if enabled {
-        format!("\x1b[1;{color}m{text}\x1b[0m")
-    } else {
-        text.to_string()
-    }
-}
-
 fn print_summary(workspace: &Workspace, results: &[JobResult], output: &Output) {
     // `-q` drops it; `--json` replaces it with the payload the caller prints.
     if output.quiet || output.to_stderr {
@@ -493,43 +458,36 @@ fn print_summary(workspace: &Workspace, results: &[JobResult], output: &Output) 
         .unwrap_or(0)
         .max("package".len());
     println!();
-    println!("{:width$}  {:8}  time", "package", "status");
+    println!(
+        "{}",
+        crate::term::dim(&format!("{:width$}  {:8}  time", "package", "status"))
+    );
     for result in results {
         let name = &workspace.members[result.member].name;
         let padded_name = format!("{name:width$}");
-        let display_name = output.format_name(name, &padded_name);
+        let display_name = crate::term::package_padded(name, &padded_name);
         let (status, detail) = match &result.status {
             JobStatus::Success => ("ok", String::new()),
             JobStatus::Failed(reason) => ("FAILED", format!("  {reason}")),
             JobStatus::Skipped => ("skipped", String::new()),
+        };
+        // Padded before painting: ANSI codes inside `{:8}` would defeat it.
+        let status = format!("{status:8}");
+        let status = match &result.status {
+            JobStatus::Success => crate::term::ok(&status),
+            JobStatus::Failed(_) => crate::term::err(&status),
+            JobStatus::Skipped => crate::term::warn(&status),
         };
         let time = if result.status == JobStatus::Skipped {
             String::new()
         } else {
             format!("{:.1}s", result.duration.as_secs_f64())
         };
-        println!("{display_name}  {status:8}  {time}{detail}");
+        println!("{display_name}  {status}  {time}{detail}");
     }
 }
 
 /// True when every job succeeded (skipped counts as failure for exit codes).
 pub fn all_succeeded(results: &[JobResult]) -> bool {
     results.iter().all(|r| r.status == JobStatus::Success)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn package_name_colors_are_stable_and_hash_based() {
-        assert_eq!(name_color_code("lat_core"), 35);
-        assert_eq!(name_color_code("lat_core"), name_color_code("lat_core"));
-        assert_ne!(name_color_code("lat_core"), name_color_code("lat_mid"));
-    }
-
-    #[test]
-    fn package_name_colors_can_be_disabled() {
-        assert_eq!(colorize_name("lat_core", "lat_core", false), "lat_core");
-    }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,4 +1,5 @@
-//! Process-wide presentation settings, resolved once from the global flags.
+//! Process-wide presentation settings, resolved once from the global flags,
+//! and the color vocabulary every command paints with.
 //!
 //! Color and verbosity are decided in `main` and read from anywhere, rather
 //! than threaded through every call. The alternative — passing a settings
@@ -8,6 +9,26 @@
 //!
 //! [`init`] is called once, before anything prints. A reader that runs first
 //! (a unit test, say) gets the same auto-detection a bare invocation would.
+//!
+//! # The color system
+//!
+//! Color is semantic, never decorative, and the words always carry the
+//! meaning on their own — a `--color never` transcript says everything the
+//! colored one does. Six roles, in the cargo/rustc vernacular:
+//!
+//! - [`err`]: `error:`, `FAILED:`, `invalid:` — bold red
+//! - [`warn`]: `warning:` — bold yellow
+//! - [`note`]: `note:` and other advisories — bold cyan
+//! - [`ok`]: `ok:` and completed-action verbs (`tagged`, `published`,
+//!   `bumped`, …) — bold green
+//! - [`package`]: member names, bold in a stable hash-picked color, so one
+//!   package keeps one color across `run`, `list`, `graph`, `version`, …
+//! - [`dim`]: structure and metadata — tree glyphs, `$ command` echoes,
+//!   versions-in-parens, field labels — and entire dry-run `would …` lines,
+//!   so a plan never reads as an action
+//!
+//! Only the 16 named ANSI colors, so output follows the user's terminal
+//! theme; bold for meaning, faint for structure, nothing else.
 
 use std::io::IsTerminal;
 use std::path::Path;
@@ -93,6 +114,75 @@ pub fn verbose() -> bool {
     settings().verbosity == Verbosity::Verbose
 }
 
+/// The hash-picked palette for [`package`]: every named ANSI color except
+/// the ones that read as pure state (plain red/green stay, since bold-on-name
+/// is visually distinct from the status words), across normal and bright.
+const NAME_COLOR_CODES: &[u8] = &[31, 32, 33, 34, 35, 36, 91, 92, 93, 94, 95, 96];
+
+/// Wrap `text` in one SGR sequence, or return it untouched when color is off.
+fn paint(text: &str, sgr: &str, enabled: bool) -> String {
+    if enabled {
+        format!("\x1b[{sgr}m{text}\x1b[0m")
+    } else {
+        text.to_string()
+    }
+}
+
+/// `error:` / `FAILED:` / `invalid:` — bold red.
+pub fn err(text: &str) -> String {
+    paint(text, "1;31", colors_enabled())
+}
+
+/// `warning:` — bold yellow.
+pub fn warn(text: &str) -> String {
+    paint(text, "1;33", colors_enabled())
+}
+
+/// `note:` and other advisories — bold cyan.
+pub fn note(text: &str) -> String {
+    paint(text, "1;36", colors_enabled())
+}
+
+/// `ok:` and completed-action verbs (`tagged`, `published`, `bumped`) — bold
+/// green.
+pub fn ok(text: &str) -> String {
+    paint(text, "1;32", colors_enabled())
+}
+
+/// Structure and metadata: tree glyphs, `$ command` echoes, field labels,
+/// and whole dry-run `would …` lines — faint.
+pub fn dim(text: &str) -> String {
+    paint(text, "2", colors_enabled())
+}
+
+/// A member name, bold in its stable hash-picked color.
+pub fn package(name: &str) -> String {
+    package_padded(name, name)
+}
+
+/// A member name padded to column width: the color is picked from `name`,
+/// but `display` (name plus trailing spaces) is what gets painted — ANSI
+/// codes inside a `{:width$}` would defeat the padding.
+pub fn package_padded(name: &str, display: &str) -> String {
+    paint(
+        display,
+        &format!("1;{}", name_color_code(name)),
+        colors_enabled(),
+    )
+}
+
+fn name_color_code(name: &str) -> u8 {
+    let index = stable_name_hash(name) as usize % NAME_COLOR_CODES.len();
+    NAME_COLOR_CODES[index]
+}
+
+/// FNV-1a, so a package keeps its color across runs, machines, and releases.
+fn stable_name_hash(name: &str) -> u64 {
+    name.bytes().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
 /// Print a line of human-facing narration, unless `-q` suppressed it.
 ///
 /// Every command's normal-path prose goes through this — progress lines,
@@ -123,7 +213,7 @@ pub fn trace_command(program: &str, args: &[impl AsRef<str>], cwd: &Path) {
         line.push(' ');
         line.push_str(&shell_quote(arg.as_ref()));
     }
-    eprintln!("+ {line}  ({})", cwd.display());
+    eprintln!("{}", dim(&format!("+ {line}  ({})", cwd.display())));
 }
 
 /// Echo an HTTP request trellis is about to make, on stderr, when `-v` is
@@ -132,7 +222,7 @@ pub fn trace_http(method: &str, url: &str) {
     if !verbose() {
         return;
     }
-    eprintln!("+ {method} {url}");
+    eprintln!("{}", dim(&format!("+ {method} {url}")));
 }
 
 /// Quote an argument well enough that the trace can be pasted back into a
@@ -161,6 +251,32 @@ mod tests {
     fn auto_is_off_when_not_a_terminal() {
         // The test harness pipes stdout, so auto-detection must say no.
         assert!(!resolve_colors(ColorChoice::Auto));
+    }
+
+    #[test]
+    fn painting_wraps_in_one_sgr_sequence() {
+        assert_eq!(paint("error:", "1;31", true), "\x1b[1;31merror:\x1b[0m");
+    }
+
+    #[test]
+    fn painting_disabled_is_a_passthrough() {
+        assert_eq!(paint("error:", "1;31", false), "error:");
+        assert_eq!(paint("lat_core", "1;35", false), "lat_core");
+    }
+
+    #[test]
+    fn package_name_colors_are_stable_and_hash_based() {
+        assert_eq!(name_color_code("lat_core"), 35);
+        assert_eq!(name_color_code("lat_core"), name_color_code("lat_core"));
+        assert_ne!(name_color_code("lat_core"), name_color_code("lat_mid"));
+    }
+
+    #[test]
+    fn padded_names_paint_the_display_with_the_name_color() {
+        // The test harness pipes stdout, so the public functions are the
+        // colors-off path; the invariant they must keep is returning the
+        // padded display untouched.
+        assert_eq!(package_padded("lat_core", "lat_core   "), "lat_core   ");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a semantic color system to trellis's terminal output. Previously only `trellis run`'s fan-out stream had color; every other command printed plain text.

The vocabulary lives in `src/term.rs` — six roles in the cargo/rustc vernacular, using only the 16 named ANSI colors so output follows the user's terminal theme:

- **Bold red** — `error:`, `FAILED:`, `invalid:`
- **Bold yellow** — `warning:`, runner `skipped`
- **Bold cyan** — `note:` advisories
- **Bold green** — `ok:` and completed-action verbs (`tagged`, `pushed`, `published`, `bumped`, `patched`, `fixed`, `created`, `updated`)
- **Hash-colored bold package names** — the runner's existing per-package color now follows a package through `list`, `graph`, `version`, `tag`, `publish`, `changelog check`, `info`, and the summary table
- **Faint** — structure/metadata (tree glyphs, `$ command` echoes, versions-in-parens, field labels, `checked:` lines, `-v` traces) and whole dry-run `would …` lines

Color never carries meaning alone — a `--color never` transcript says everything the colored one does.

## Implementation

- Hand-rolled ANSI painting and hash-based name palette moved from `runner.rs` into `term.rs`, alongside the existing `--color`/`NO_COLOR`/TTY resolution — one paint path (`err`, `warn`, `note`, `ok`, `dim`, `package`, `package_padded`).
- Run summary table's status column is now colored.
- Padding happens outside the paint, so column alignment matches in both modes.
- No new dependencies.

## Also in this PR

- Refreshed `.impeccable/design.json` from current DESIGN.md.
- Dropped the deprecated `## Register` section from PRODUCT.md.