### PR TITLE
fix(version): respect dependency ranges

### DIFF
--- a/.changes/unreleased/Fixed-20260803-ripple-requirement-boundary.yaml
+++ b/.changes/unreleased/Fixed-20260803-ripple-requirement-boundary.yaml
@@ -1,0 +1,5 @@
+component: version
+kind: Fixed
+body: |-
+  **`trellis version` no longer ripples dependency bumps outside the published requirement.** A dependent now bumps only when its existing `path_dep_requirement` can select the dependency's new version, so a default `minor` requirement does not ripple across a major-version boundary.
+time: 2026-08-03T22:25:06.539-07:00

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -37,15 +37,22 @@ pub struct UpdatedDep {
     pub version: String,
 }
 
+struct BumpedDep {
+    current: semver::Version,
+    next: semver::Version,
+}
+
 /// One entry per releasable member that either owns unreleased fragments or
-/// depends on something that bumped, in topological order. Any invalid
-/// fragment is a hard error — silently dropping one is exactly the drift this
-/// tool exists to prevent.
+/// depends on something that bumped within its published requirement, in
+/// topological order. Any invalid fragment is a hard error — silently dropping
+/// one is exactly the drift this tool exists to prevent.
 ///
 /// Dependents ripple because a path dep's Hex requirement is derived from the
 /// dependency's version at publish time (`crate::rewrite`). Leaving a dependent
 /// unbumped would let one published version resolve to two different dependency
-/// sets, depending on whether it was fetched before or after the bump.
+/// sets when the new dependency version is inside that requirement. A version
+/// outside the requirement cannot change what the existing release resolves,
+/// so it does not ripple.
 ///
 /// `workspace.members` is topologically ordered, so one forward sweep is enough:
 /// by the time it reaches a member, every dependency's final version is settled.
@@ -77,19 +84,28 @@ pub fn compute_plan_from(
 
     let config = &workspace.config.changelog;
     let mut plan = Vec::new();
-    let mut bumped: BTreeMap<&str, String> = BTreeMap::new();
+    let mut bumped: BTreeMap<&str, BumpedDep> = BTreeMap::new();
     for (idx, member) in workspace.members.iter().enumerate() {
         if !member.releasable() {
             continue;
         }
         // Sorted by dependency name so the rendered order does not depend on
         // the graph's internal indexing.
-        let mut rippled: Vec<(&str, &String)> = workspace
+        let mut rippled: Vec<(&str, String)> = workspace
             .deps_of(idx)
             .iter()
             .filter_map(|&dep| {
                 let dep_name = workspace.members[dep].name.as_str();
-                bumped.get(dep_name).map(|version| (dep_name, version))
+                bumped
+                    .get(dep_name)
+                    .filter(|bump| {
+                        workspace
+                            .config
+                            .publish
+                            .path_dep_requirement
+                            .allows(&bump.current, &bump.next)
+                    })
+                    .map(|bump| (dep_name, bump.next.to_string()))
             })
             .collect();
         rippled.sort_unstable_by_key(|(name, _)| *name);
@@ -103,7 +119,7 @@ pub fn compute_plan_from(
             .into_iter()
             .map(|(name, version)| UpdatedDep {
                 name: name.to_string(),
-                version: version.clone(),
+                version,
             })
             .collect();
 
@@ -118,7 +134,13 @@ pub fn compute_plan_from(
         let current = semver::Version::parse(member.version())
             .with_context(|| format!("`{}` has an invalid version", member.name))?;
         let next = overrides.resolve(&member.name, &current, derived)?;
-        bumped.insert(&member.name, next.to_string());
+        bumped.insert(
+            &member.name,
+            BumpedDep {
+                current: current.clone(),
+                next: next.clone(),
+            },
+        );
         plan.push(PlanEntry {
             name: member.name.clone(),
             current: member.version().to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -423,6 +423,30 @@ pub enum PathDepRequirement {
     Exact,
 }
 
+impl PathDepRequirement {
+    /// Whether the requirement generated from `current` can select `candidate`.
+    pub fn allows(self, current: &semver::Version, candidate: &semver::Version) -> bool {
+        if candidate < current {
+            return false;
+        }
+        match self {
+            Self::Minor => {
+                let Some(major) = current.major.checked_add(1) else {
+                    return true;
+                };
+                candidate < &semver::Version::new(major, 0, 0)
+            }
+            Self::Patch => {
+                let Some(minor) = current.minor.checked_add(1) else {
+                    return true;
+                };
+                candidate < &semver::Version::new(current.major, minor, 0)
+            }
+            Self::Exact => candidate == current,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RetryConfig {
@@ -809,6 +833,22 @@ impl ConfigFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn path_dep_requirement_allows_only_versions_inside_its_range() {
+        let current = semver::Version::parse("1.2.3").unwrap();
+        let patch = semver::Version::parse("1.2.4").unwrap();
+        let minor = semver::Version::parse("1.3.0").unwrap();
+        let major = semver::Version::parse("2.0.0").unwrap();
+
+        assert!(PathDepRequirement::Minor.allows(&current, &patch));
+        assert!(PathDepRequirement::Minor.allows(&current, &minor));
+        assert!(!PathDepRequirement::Minor.allows(&current, &major));
+        assert!(PathDepRequirement::Patch.allows(&current, &patch));
+        assert!(!PathDepRequirement::Patch.allows(&current, &minor));
+        assert!(!PathDepRequirement::Exact.allows(&current, &patch));
+        assert!(PathDepRequirement::Exact.allows(&current, &current));
+    }
 
     #[test]
     fn parses_full_config_from_tools_trellis() {

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -931,8 +931,8 @@ fn version_plan_bumps_by_the_largest_kind() {
         .unwrap();
     assert!(output.status.success());
     let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    // lat_cli owns no fragment, but both of its workspace deps bumped, so it
-    // ripples by a patch. Entries stay in topological order.
+    // lat_cli owns no fragment. lat_core's minor bump is inside its requirement
+    // and ripples; lat_mid's major bump is outside and does not.
     assert_eq!(
         plan,
         serde_json::json!({
@@ -945,12 +945,38 @@ fn version_plan_bumps_by_the_largest_kind() {
                 {"name": "lat_cli", "current": "0.3.1", "next": "0.3.2", "fragments": 0,
                  "updated_dependencies": [
                      {"name": "lat_core", "version": "1.3.0"},
-                     {"name": "lat_mid", "version": "1.0.0"},
                  ]},
             ],
             // An ordinary release retires its fragments.
             "fragments_retained": false,
         })
+    );
+}
+
+#[test]
+fn major_bump_outside_path_dep_requirement_does_not_ripple() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    add_fragment(root, "lat_core", "Breaking", "major-level change");
+
+    let output = trellis(root)
+        .args(["version", "plan", "--json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let plan: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        plan["bumped"],
+        serde_json::json!([
+            {
+                "name": "lat_core",
+                "current": "1.2.0",
+                "next": "2.0.0",
+                "fragments": 1,
+                "updated_dependencies": [],
+            },
+        ])
     );
 }
 

--- a/tests/snapshots/json_contract__version_plan_json_contract.snap
+++ b/tests/snapshots/json_contract__version_plan_json_contract.snap
@@ -32,10 +32,6 @@ expression: "json_output(root, &[\"version\", \"plan\", \"--json\"], true)"
         {
           "name": "lat_core",
           "version": "1.3.0"
-        },
-        {
-          "name": "lat_mid",
-          "version": "1.0.0"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- ripple dependency bumps only when the new version remains inside the dependent's published requirement
- respect `minor`, `patch`, and `exact` path dependency boundaries
- add regression coverage and update the version-plan JSON snapshot

## Testing

- `cargo test --test phase2`
- `cargo test --test json_contract version_plan_json_contract -- --exact`
- `just lint`
