### PR TITLE
fix(changelog): row packages documented by fragments, not just diffed

### DIFF
--- a/.changes/unreleased/Fixed-20260804-changelog-check-rows-documented-packages.yaml
+++ b/.changes/unreleased/Fixed-20260804-changelog-check-rows-documented-packages.yaml
@@ -1,0 +1,5 @@
+component: changelog
+kind: Fixed
+body: |-
+  **`trellis changelog check` now rows every package the branch documented, not just the ones whose files it changed.** A fragment written for a package the diff never touched — a break propagating to a dependent, documented where it lands — still bumps that package, and the release preview said so while the table above it did not. Such a package now gets its own row, is reported as `changed: false` in the `--json` payload, and is never asked for a changelog entry of its own.
+time: 2026-08-04T00:00:00.000-07:00

--- a/src/commands/changelog.rs
+++ b/src/commands/changelog.rs
@@ -115,6 +115,12 @@ pub struct CheckOptions {
 struct PackageStatus {
     name: String,
     fragments: usize,
+    /// Whether the diff touched this package's own files. False for a package
+    /// the branch documented without editing — a break that propagates to a
+    /// dependent, say. Such a package is only here because it has a fragment,
+    /// so `changed == false` implies `fragments > 0`; nothing is ever asked of
+    /// it, and `needs_entry` says so explicitly rather than leaning on that.
+    changed: bool,
 }
 
 /// Map the base...head diff to releasable packages and decide which still
@@ -133,14 +139,24 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
     let all = changelog::load_fragments(workspace)?;
     let fragments = fragments_changed_by(workspace, &all, options)?;
 
+    // Rowed for either reason: the diff touched the package, or the branch
+    // wrote it a fragment. A fragment without a code change is a real release —
+    // a break propagating to a dependent is documented where it lands, not
+    // where it originated — and reporting only the diff left that package out
+    // of the table while the release preview happily listed the bump.
     let statuses: Vec<PackageStatus> = workspace
         .members
         .iter()
         .enumerate()
-        .filter(|(idx, member)| changed.contains(idx) && member.releasable())
-        .map(|(_, member)| PackageStatus {
-            name: member.name.clone(),
-            fragments: fragments.count_for(&member.name),
+        .filter(|(_, member)| member.releasable())
+        .filter_map(|(idx, member)| {
+            let count = fragments.count_for(&member.name);
+            let touched = changed.contains(&idx);
+            (touched || count > 0).then(|| PackageStatus {
+                name: member.name.clone(),
+                fragments: count,
+                changed: touched,
+            })
         })
         .collect();
 
@@ -151,7 +167,7 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
         Strictness::Off => Vec::new(),
         Strictness::Warn | Strictness::Error => statuses
             .iter()
-            .filter(|status| status.fragments == 0)
+            .filter(|status| status.changed && status.fragments == 0)
             .map(|status| status.name.as_str())
             .collect(),
     };
@@ -187,7 +203,7 @@ pub fn check(workspace: &Workspace, options: &CheckOptions) -> Result<bool> {
                     .iter()
                     .map(|status| ChangelogPackage {
                         name: &status.name,
-                        changed: true,
+                        changed: status.changed,
                         has_entry: status.fragments > 0,
                         fragments: status.fragments,
                     })

--- a/src/json.rs
+++ b/src/json.rs
@@ -500,13 +500,15 @@ impl<'a> GraphDocument<'a> {
     }
 }
 
-/// One changed package in `trellis changelog check --json`.
+/// One package `trellis changelog check --json` has something to say about:
+/// the diff touched it, the branch wrote it a fragment, or both.
 #[derive(Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct ChangelogPackage<'a> {
     pub name: &'a str,
-    /// Always true — the list only contains packages the diff touched. Kept so
-    /// a future `--all` can report unchanged packages without a schema bump.
+    /// Whether the diff touched this package's own files. False for a package
+    /// listed only because the branch documented it — which is the release it
+    /// still gets — and such a package is never asked for an entry.
     pub changed: bool,
     pub has_entry: bool,
     pub fragments: usize,

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -468,6 +468,53 @@ fn changelog_check_maps_diff_to_missing_fragments() {
         .stdout(predicate::str::contains("lat_mid: 1 fragment(s)"));
 }
 
+#[test]
+fn changelog_check_rows_a_package_the_branch_wrote_a_fragment_for() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+
+    git(root, &["init", "-q", "-b", "main"]);
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "init"]);
+    git(root, &["checkout", "-q", "-b", "feature"]);
+    // Only `lat_core` has changed files. `lat_mid` is documented by a fragment
+    // this branch wrote — a break that propagates to it without touching its
+    // source — so it releases, and the check must say so rather than leaving it
+    // to be discovered in the release preview alone.
+    write(&root.join("packages/lat_core/src/new.gleam"), "// x\n");
+    add_fragment(root, "lat_core", "Added", "something");
+    add_fragment(root, "lat_mid", "Fixed", "propagated");
+    git(root, &["add", "."]);
+    git(root, &["commit", "-q", "-m", "change"]);
+
+    let output = trellis(root)
+        .args(["changelog", "check", "--base", "main", "--format", "json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "both packages are documented");
+    let payload: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let packages = payload["packages"].as_array().unwrap();
+    assert_eq!(packages.len(), 2);
+    let core = packages.iter().find(|p| p["name"] == "lat_core").unwrap();
+    assert_eq!(core["changed"], true);
+    assert_eq!(core["fragments"], 1);
+    let mid = packages.iter().find(|p| p["name"] == "lat_mid").unwrap();
+    // Rowed on the strength of its fragment, and honestly marked as untouched.
+    assert_eq!(mid["changed"], false);
+    assert_eq!(mid["has_entry"], true);
+    assert_eq!(mid["fragments"], 1);
+    // The comment's table and its release preview now agree on the package set.
+    let preview = payload["preview"].as_str().unwrap();
+    assert!(preview.contains("| lat_mid | ✅ 1 |"), "preview: {preview}");
+
+    trellis(root)
+        .args(["changelog", "check", "--base", "main"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lat_mid: 1 fragment(s)"));
+}
+
 // ---- changelog check: strictness ------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary
- `trellis changelog check` only rowed packages whose files the diff touched, even when a fragment documented a dependent package the diff never touched (a break propagating downstream). The table and release preview disagreed.
- Rows now include any releasable package that's either touched by the diff or has a fragment. The `--json` payload reports `changed: false` for fragment-only rows, and such packages are never asked for a changelog entry of their own.

## Test plan
- [x] `cargo test` — added `changelog_check_rows_a_package_the_branch_wrote_a_fragment_for` in `tests/phase2.rs`, verifying both JSON payload fields and the text-mode preview