### PR TITLE
fix(doctor): validate @members exclusion globs before filtering

### DIFF
--- a/.changes/unreleased/doctor-Fixed-20260805-172420.yaml
+++ b/.changes/unreleased/doctor-Fixed-20260805-172420.yaml
@@ -1,0 +1,4 @@
+component: doctor
+kind: Fixed
+body: '**`trellis doctor` no longer flags a working `@members` exclusion glob as a typo.** The check compared the glob against the already-filtered member list, so any glob that successfully excluded a directory could never appear to match — every real `@members` exclusion was reported as `matches no member (typo?)`. The typo check now runs against the pre-filter candidate set, before `@members` removes anything, so a working exclusion is never flagged while a genuine typo still is.'
+time: 2026-08-05T17:24:20.994499-07:00

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -522,6 +522,13 @@ fn check_tool_versions(workspace: &Workspace, report: &mut Report) {
 /// in it — see [`crate::config::ReleaseLifecycle::available_to`].
 fn check_exclusions(workspace: &Workspace, report: &mut Report) {
     for (task, patterns) in &workspace.config.exclude {
+        // `@members` is validated in `Workspace::load_with_diagnostics`,
+        // against the pre-filter candidate set — by the time `workspace`
+        // exists here, a working exclusion has already removed its own
+        // evidence from `workspace.members`.
+        if task == crate::config::MEMBERS_EXCLUDE_KEY {
+            continue;
+        }
         for pattern in patterns {
             check_member_glob(
                 workspace,

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -229,11 +229,14 @@ impl Workspace {
         }
 
         // `@members` removes directories from membership entirely, before
-        // their manifests are even parsed.
-        if let Some(patterns) = config.exclude.get(crate::config::MEMBERS_EXCLUDE_KEY)
-            && let Ok(excludes) = build_globset(patterns)
-        {
-            member_dirs.retain(|dir| !excludes.is_match(rel_path_string(root, dir)));
+        // their manifests are even parsed. A working exclusion glob can never
+        // match anything once it's done its job, so the typo check has to run
+        // here, against the pre-filter candidates, not against the survivors.
+        if let Some(patterns) = config.exclude.get(crate::config::MEMBERS_EXCLUDE_KEY) {
+            check_members_exclude_globs(root, &member_dirs, patterns, &mut diagnostics);
+            if let Ok(excludes) = build_globset(patterns) {
+                member_dirs.retain(|dir| !excludes.is_match(rel_path_string(root, dir)));
+            }
         }
         if member_dirs.is_empty() && !diagnostics.has_errors() {
             diagnostics.push(
@@ -741,6 +744,47 @@ fn report_unknown_config_keys(config: &ConfigFile, diagnostics: &mut Diagnostics
             )
             .at(GLEAM_TOML),
         );
+    }
+}
+
+/// Validates `@members` exclusion globs against the pre-filter candidate set
+/// — the same globs are applied as a `retain` right after this runs, so
+/// checking them afterward against the survivors would mean a working
+/// exclusion could never appear to match anything.
+fn check_members_exclude_globs(
+    root: &Path,
+    member_dirs: &[PathBuf],
+    patterns: &[String],
+    diagnostics: &mut Diagnostics,
+) {
+    let rel_paths: Vec<String> = member_dirs
+        .iter()
+        .map(|dir| rel_path_string(root, dir))
+        .collect();
+    for pattern in patterns {
+        match globset::Glob::new(pattern) {
+            Ok(glob) => {
+                let matcher = glob.compile_matcher();
+                if !rel_paths.iter().any(|rel| matcher.is_match(rel)) {
+                    diagnostics.push(
+                        Finding::error(
+                            Check::ExclusionGlob,
+                            format!(
+                                "`@members` exclusion glob `{pattern}` matches no member (typo?)"
+                            ),
+                        )
+                        .at(GLEAM_TOML),
+                    );
+                }
+            }
+            Err(_) => diagnostics.push(
+                Finding::error(
+                    Check::ExclusionGlob,
+                    format!("`@members` exclusion glob `{pattern}` is invalid"),
+                )
+                .at(GLEAM_TOML),
+            ),
+        }
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -545,6 +545,52 @@ fn doctor_reports_all_problems_at_once() {
 }
 
 #[test]
+fn doctor_accepts_working_at_members_exclusion_glob() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\nexclude = { \"@members\" = [\"packages/excluded\"] }\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+    write(
+        &root.join("packages/excluded/gleam.toml"),
+        "name = \"excluded\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("matches no member").not());
+}
+
+#[test]
+fn doctor_reports_at_members_exclusion_glob_typo() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        &root.join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\nexclude = { \"@members\" = [\"packages/nonexistent\"] }\n",
+    );
+    write(
+        &root.join("packages/a/gleam.toml"),
+        "name = \"a\"\nversion = \"1.0.0\"\n",
+    );
+
+    trellis(root)
+        .arg("doctor")
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains(
+            "`@members` exclusion glob `packages/nonexistent` matches no member",
+        ));
+}
+
+#[test]
 fn doctor_detects_dependency_cycles() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();


### PR DESCRIPTION
## Summary
- `trellis doctor` no longer falsely reports a working `@members` exclusion glob as a typo. The check previously compared the glob against `workspace.members`, which is built *after* `@members` filtering runs — so a glob that successfully excluded a directory had already erased its own evidence and was always flagged as `matches no member (typo?)`.
- The typo check now runs in `Workspace::load_with_diagnostics` (`src/workspace.rs`) against the pre-filter candidate set, at the point where `@members` filtering actually happens — mirroring how explicit `members` globs are already validated at expansion time. `doctor.rs`'s `check_exclusions` skips `@members` since it's now validated upstream; `@release` and task-name exclusion keys are unchanged.
- Added a changelog fragment (`.changes/unreleased/doctor-Fixed-*.yaml`).

Fixes #88

## Test plan
- [x] `doctor_accepts_working_at_members_exclusion_glob` (new) — a working `@members` glob no longer triggers "matches no member"
- [x] `doctor_reports_at_members_exclusion_glob_typo` (new) — a genuinely typo'd `@members` glob still fails as before
- [x] `doctor_reports_all_problems_at_once` — `@release`/task-key typo detection still works
- [x] `at_members_excludes_directories_from_membership`, `at_members_also_filters_explicit_member_globs` — `@members` filtering behavior itself is unchanged
- [x] `cargo test` (full suite, 391 tests) passes
- [x] `cargo build` and `cargo clippy --all-targets` clean