### PR TITLE
fix(workspace): treat git deps with a path subdirectory as external

### DIFF
--- a/.changes/unreleased/trellis-Fixed-20260806-134645.yaml
+++ b/.changes/unreleased/trellis-Fixed-20260806-134645.yaml
@@ -1,0 +1,4 @@
+component: trellis
+kind: Fixed
+body: '**Git dependencies with a `path` subdirectory (Gleam 1.18+) are treated as external.** Gleam 1.18.0 added an optional `path` key on git dependencies that selects a subdirectory of the remote repository. Trellis classified any dependency carrying a `path` key as a workspace path dependency, so a git dependency into an external monorepo made every command fail with `workspace is invalid` — or, when the dependency shared a member''s name, invented a phantom graph edge that could report a false dependency cycle. The `git` key now wins: such dependencies stay out of the workspace graph, and `trellis publish` leaves them untouched instead of rewriting them to Hex requirements.'
+time: 2026-08-06T13:46:45.000000-07:00

--- a/src/gleam.rs
+++ b/src/gleam.rs
@@ -79,6 +79,10 @@ impl GleamManifest {
             for (name, dep) in deps {
                 let requirement = match dep {
                     RawDep::Requirement(req) => Requirement::Hex(req.clone()),
+                    // `git` wins over `path`: since Gleam 1.18 a git dep may
+                    // carry a `path` key selecting a subdirectory of the
+                    // remote repo, which is not a workspace-local path.
+                    RawDep::Detailed { git: Some(git), .. } => Requirement::Git(git.clone()),
                     RawDep::Detailed {
                         path: Some(path), ..
                     } => Requirement::Path(path.clone()),
@@ -86,7 +90,6 @@ impl GleamManifest {
                         version: Some(version),
                         ..
                     } => Requirement::Hex(version.clone()),
-                    RawDep::Detailed { git: Some(git), .. } => Requirement::Git(git.clone()),
                     RawDep::Detailed { .. } => {
                         anyhow::bail!(
                             "dependency `{name}` has neither a version, a path, nor a git source"
@@ -185,6 +188,34 @@ mod tests {
         // Git deps are external: they never join the path-dependency graph.
         let paths: Vec<_> = manifest.path_deps().collect();
         assert_eq!(paths, vec![("beryl", "../beryl", false)]);
+    }
+
+    #[test]
+    fn git_dep_with_subdirectory_path_is_still_external() {
+        // Gleam 1.18+: git deps may carry a `path` key selecting a
+        // subdirectory of the remote repository. The `git` key wins.
+        let manifest = GleamManifest::parse(
+            r#"
+            name = "gp_app"
+            version = "0.2.0"
+
+            [dependencies]
+            gp_core = { path = "../gp_core" }
+            remote_lib = { git = "https://github.com/example/monorepo.git", ref = "main", path = "packages/remote_lib" }
+            "#,
+        )
+        .unwrap();
+        let git_dep = manifest
+            .dependencies
+            .iter()
+            .find(|dep| dep.name == "remote_lib")
+            .unwrap();
+        assert_eq!(
+            git_dep.requirement,
+            Requirement::Git("https://github.com/example/monorepo.git".to_string())
+        );
+        let paths: Vec<_> = manifest.path_deps().collect();
+        assert_eq!(paths, vec![("gp_core", "../gp_core", false)]);
     }
 
     #[test]

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -63,10 +63,12 @@ pub fn rewrite_path_deps(
             let Some(item) = table.get_mut(&name) else {
                 continue;
             };
+            // A `path` key alongside `git` selects a subdirectory of the
+            // remote repo (Gleam 1.18+), not a workspace-local path dep.
             let is_path_dep = item
                 .as_value()
                 .and_then(|value| value.as_inline_table())
-                .is_some_and(|dep| dep.contains_key("path"));
+                .is_some_and(|dep| dep.contains_key("path") && !dep.contains_key("git"));
             if !is_path_dep {
                 continue;
             }
@@ -172,6 +174,34 @@ mod tests {
         assert_eq!(rewrites.len(), 1);
         assert!(rewritten.contains("lat_core = \"== 1.2.0\""));
         assert!(rewritten.contains("test_helpers = { path = \"../test_helpers\" }"));
+    }
+
+    #[test]
+    fn git_dep_with_subdirectory_path_is_never_rewritten() {
+        // Gleam 1.18+ git deps may carry a `path` subdirectory key. They are
+        // external: not rewritten even when the name matches a hex member,
+        // and not an error when it doesn't.
+        let text = concat!(
+            "name = \"gp_app\"\n",
+            "[dependencies]\n",
+            "gp_core = { path = \"../gp_core\" }\n",
+            "remote_lib = { git = \"https://github.com/example/monorepo.git\", ref = \"main\", path = \"packages/remote_lib\" }\n",
+            "gp_core_fork = { git = \"https://github.com/example/fork.git\", ref = \"v2\", path = \"../gp_core_fork\" }\n",
+        );
+        let (rewritten, rewrites) = rewrite_path_deps(
+            text,
+            &versions(&[("gp_core", "1.0.0"), ("gp_core_fork", "2.0.0")]),
+            PathDepRequirement::Minor,
+        )
+        .unwrap();
+        assert_eq!(rewrites.len(), 1);
+        assert!(rewritten.contains("gp_core = \">= 1.0.0 and < 2.0.0\""));
+        assert!(rewritten.contains(
+            "remote_lib = { git = \"https://github.com/example/monorepo.git\", ref = \"main\", path = \"packages/remote_lib\" }"
+        ));
+        assert!(rewritten.contains(
+            "gp_core_fork = { git = \"https://github.com/example/fork.git\", ref = \"v2\", path = \"../gp_core_fork\" }"
+        ));
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -29,6 +29,19 @@ fn list_prints_members_in_topological_order() {
 }
 
 #[test]
+fn list_treats_git_deps_with_subdirectory_paths_as_external() {
+    // Gleam 1.18+ git deps may carry a `path` key selecting a subdirectory
+    // of the remote repo. They must not join the workspace path-dep graph
+    // (regression: they were misread as workspace path deps, making every
+    // command fail with "workspace is invalid").
+    trellis(&fixture("git-path-deps"))
+        .arg("list")
+        .assert()
+        .success()
+        .stdout("gp_core  hex\ngp_app   hex\n");
+}
+
+#[test]
 fn list_works_from_inside_a_package() {
     trellis(&fixture("basic").join("packages/lat_mid"))
         .arg("list")

--- a/tests/fixtures/git-path-deps/gleam.toml
+++ b/tests/fixtures/git-path-deps/gleam.toml
@@ -1,0 +1,5 @@
+# Workspace exercising Gleam 1.18 git dependencies that carry a `path`
+# subdirectory key. Git deps are external regardless of the `path` key.
+
+[tools.trellis]
+members = ["packages/*"]

--- a/tests/fixtures/git-path-deps/packages/gp_app/CHANGELOG.md
+++ b/tests/fixtures/git-path-deps/packages/gp_app/CHANGELOG.md
@@ -1,0 +1,5 @@
+# gp_app changelog
+
+## gp_app-v0.2.0 - 2026-06-01
+
+- initial

--- a/tests/fixtures/git-path-deps/packages/gp_app/gleam.toml
+++ b/tests/fixtures/git-path-deps/packages/gp_app/gleam.toml
@@ -1,0 +1,15 @@
+name = "gp_app"
+version = "0.2.0"
+
+[dependencies]
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gp_core = { path = "../gp_core" }
+# Gleam 1.18+: git dependency pointing at a subdirectory of an external
+# monorepo. External to the workspace — must not join the path-dep graph.
+remote_lib = { git = "https://github.com/example/monorepo.git", ref = "main", path = "packages/remote_lib" }
+
+[dev-dependencies]
+gleeunit = ">= 1.2.0 and < 2.0.0"
+# Subdirectory path that coincidentally resolves to a workspace member —
+# still external; the `git` key wins.
+gp_core_fork = { git = "https://github.com/example/fork.git", ref = "v2", path = "../gp_core" }

--- a/tests/fixtures/git-path-deps/packages/gp_core/CHANGELOG.md
+++ b/tests/fixtures/git-path-deps/packages/gp_core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# gp_core changelog
+
+## gp_core-v1.0.0 - 2026-06-01
+
+- initial

--- a/tests/fixtures/git-path-deps/packages/gp_core/gleam.toml
+++ b/tests/fixtures/git-path-deps/packages/gp_core/gleam.toml
@@ -1,0 +1,5 @@
+name = "gp_core"
+version = "1.0.0"
+
+[dependencies]
+gleam_stdlib = ">= 0.34.0 and < 2.0.0"


### PR DESCRIPTION
## Problem

Gleam 1.18.0 added an optional `path` key on git dependencies that selects a subdirectory of the remote repository:

```toml
[dependencies]
remote_lib = { git = "https://github.com/example/monorepo.git", ref = "main", path = "packages/remote_lib" }
```

Trellis classified any dependency carrying a `path` key as a workspace path dependency, which broke workspaces using the new syntax:

1. **Every command fails** — a git+path dep into an external monorepo makes workspace loading error with `path dependency ... is not a workspace member`, taking down `list`, `graph`, `doctor`, `publish`, everything (exit 3).
2. **False name-mismatch error** when the subdirectory path coincidentally resolves to a member directory.
3. **Phantom graph edges** when the git dep shares a workspace member's name — up to a false `dependency cycle between workspace members` on an acyclic workspace, or silently corrupted topological/publish order.
4. **Publish-time corruption** — `rewrite_path_deps` also keyed on the `path` key, so a git+path dep would be silently replaced with a Hex requirement (name collides with a hex member) or hard-fail the publish.

## Fix

- `src/gleam.rs` — `git` takes precedence over `path` in the `RawDep::Detailed` match: git+path deps parse as `Requirement::Git` (external) and never join the path-dep graph.
- `src/rewrite.rs` — the publish rewrite treats an inline table as a path dep only when it has `path` **without** `git`.

## Tests

Written TDD (all three failed before the fix):

- `gleam.rs`: git+path dep parses as `Git` and stays out of `path_deps()`
- `rewrite.rs`: git+path deps are never rewritten — neither the silent-rewrite case (name matches a hex member) nor the spurious-error case
- `tests/cli.rs` + new `tests/fixtures/git-path-deps/` fixture: end-to-end `list` succeeds on a workspace using the Gleam 1.18 syntax, including a dev git+path dep whose subdirectory resolves to a real member directory

Full suite (385 tests) and clippy pass.