### PR TITLE
docs(website): correct stale command output and fill config reference gaps

### DIFF
--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -7,11 +7,8 @@ import Callout from "../../../components/Callout.astro";
 
 The changelog engine is native — no second tool to install in CI, no config
 file to keep in sync with the workspace. Changes are recorded as small TOML
-fragments; version bumps and changelog sections are derived from them.
-
-The fragment-per-change workflow is modeled on
-[changie](https://changie.dev/)'s project mode, reimplemented natively so a
-managed workspace needs no second binary in CI.
+fragments, one per change; version bumps and changelog sections are derived
+from them.
 
 ```txt wrap
 trellis changelog new [--package <pkg>] --kind <kind> --body <text>
@@ -33,9 +30,9 @@ body = "Add graph-parallel task scheduling"
 
 <Callout>
 
-`package` was spelled `project` through v0.7.0, inherited from changie. Both
-spellings parse, so fragments already sitting in `.changes/unreleased/` keep
-working — but `changelog new` writes `package`, and the alias goes away at 1.0.
+`package` was spelled `project` through v0.7.0. Both spellings parse, so
+fragments already sitting in `.changes/unreleased/` keep working, but
+`changelog new` writes `package` and the alias goes away at 1.0.
 
 </Callout>
 
@@ -53,8 +50,7 @@ created .changes/unreleased/lat_core-1.toml
 
 Invalid fragments — unknown package, kind, or category, empty body,
 unparseable TOML — are hard errors for `check`, `plan`, and `apply`, and
-`doctor` flags them on every PR. Silently dropping a change is exactly the
-drift trellis exists to prevent.
+`doctor` flags them on every PR.
 
 </Callout>
 
@@ -80,9 +76,9 @@ lat_cli: needs a changelog entry
 ```
 
 A package counts as changed when the diff touches *any* file under its
-directory — a README edit trips the same gate as a behavior change. That is
-deliberate (the alternative is a heuristic that guesses wrong quietly), but it
-means the gate is sometimes stricter than a repository wants.
+directory — a README edit trips the same gate as a behavior change. That makes
+the gate stricter than some repositories want; [`strictness`](#strictness)
+turns it down.
 
 ### Scope
 
@@ -266,13 +262,12 @@ lat_cli: 0.4.2 -> 0.4.3 (1 fragment(s), dependencies: lat_core, lat_mid)
 `lat_mid` owns no fragment, yet it is in that plan. When a package bumps, so
 does everything that path-depends on it, transitively.
 
-This is a correctness requirement, not a convenience. A path dependency has no
-version in the repository — it is rewritten into a Hex requirement at publish
-time, derived from whatever version the dependency is on *then*. If `lat_core`
-went 1.1.0 → 1.2.0 and `lat_mid` stayed at 0.5.0, then `lat_mid` 0.5.0 would
-mean `>= 1.1.0 and < 2.0.0` to anyone who fetched it before the release and
-`>= 1.2.0 and < 2.0.0` to anyone who fetched it after. One published version,
-two dependency sets.
+This is a correctness requirement, not a convenience. A path dependency carries
+no version in the repository; it becomes a Hex requirement at publish time,
+derived from whatever version the dependency is on *then*. Holding `lat_mid` at
+0.5.0 while `lat_core` moved would leave one published `lat_mid` 0.5.0 meaning
+two different things — `>= 1.1.0` to whoever fetched it before the release,
+`>= 1.2.0` to whoever fetched it after.
 
 The rules:
 

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -59,10 +59,9 @@ jobs:
 
 <Callout>
 
-Full fan-out is the default: `--since` is opt-in because implicit coupling
-between packages, the kind the path-dep graph can't see, shouldn't be silently
-untested. A repo that wants affected-only CI writes `--since origin/main` into
-its workflow explicitly.
+Full fan-out is the default. `--since` is opt-in because coupling the path-dep
+graph can't see would otherwise go silently untested, so a workspace that wants
+affected-only CI writes `--since origin/main` into its workflow explicitly.
 
 </Callout>
 

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -60,10 +60,9 @@ members are auto-discovered; found 2:
   packages/b
 ```
 
-What it writes is nearly empty, and that is the point. The table's *presence*
-is what marks the workspace root; everything else trellis derives, so
-`members` is not written. In its place are comments pointing at the keys you
-might want.
+What it writes is nearly empty. The table's *presence* is what marks the
+workspace root, and everything else trellis derives, so `members` is not
+written — in its place are comments pointing at the keys you might want.
 
 `init` reports the members it discovered so you can see whether they need
 narrowing, refuses to run if the repository is already a trellis workspace (or
@@ -124,13 +123,15 @@ their roots.
 | `publish.repository_series.format` | with `package` | Repository tag template; must contain `{series}` and no `{name}`. |
 | `publish.tag_mode` | no | Which tags a release creates: `exact` (default), `series`, or `both`. |
 | `publish.tag_mode_overrides` | no | Per-package tag modes: a map of mode name to member-path globs. A package matching globs under two modes is an error. |
-| `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial_delay, multiplier }`. |
+| `publish.path_dep_requirement` | no | How a workspace path dependency becomes a Hex requirement at publish time, from the dependency's current version `X.Y.Z`: `minor` (default, `>= X.Y.Z and < (X+1).0.0`), `patch` (`>= X.Y.Z and < X.(Y+1).0`), or `exact` (`== X.Y.Z`). |
+| `publish.retry` | no | Backoff for Hex rate limits: `{ attempts, initial_delay, multiplier }`. Defaults: 5 attempts, `30s`, multiplier 2. |
 | `publish.lifecycle.default` | no | Release lifecycle for a member matched by no `packages` glob and no legacy `exclude.@release` glob: `workspace`, `git_only`, or `hex` (default). |
 | `publish.lifecycle.packages` | no | Per-package lifecycle overrides: a map of member-path glob to lifecycle. Takes precedence over `exclude.@release`. A member matched by globs resolving to different lifecycles is an error; matches agreeing on the same lifecycle are fine. |
-| `changelog.kinds` | no | Change kinds and the version bump each implies. The largest bump among a package's unreleased fragments wins. |
+| `changelog.dir` | no | Where fragments and batched version sections live. Default: `.changes`. |
+| `changelog.kinds` | no | Change kinds and the version bump each implies. The largest bump among a package's unreleased fragments wins. Replacing the list replaces it entirely. |
 | `changelog.categories` | no | A second grouping axis, rendered above the kind headings. Carries no version bump. Empty by default, which switches the axis off. |
 | `changelog.uncategorized_label` | no | Heading for entries naming no category, rendered last. Default: `Other`. Read only when `categories` is set. |
-| `changelog.*-format` | no | Minijinja templates for rendered changelog sections: `version_format`, `category_format`, `kind_format`, `change_format`. |
+| `changelog.*_format` | no | Minijinja templates for the rendered changelog: `header_format`, `version_format`, `category_format`, `kind_format`, `change_format`. |
 | `changelog.dependency_kind` | no | Kind used for the entries generated when a workspace dependency bumps. Must name one of `kinds`. |
 | `changelog.dependency_body` | no | Minijinja template for one such entry's body. Context: `dependency`, `dependency_version`, `package` (also as `project`, deprecated). |
 | `changelog.strictness` | no | How `changelog check` treats a changed releasable package with no unreleased fragment: `error` (default, fails the run), `warn`, or `off`. An *invalid* fragment fails at every setting. |
@@ -287,13 +288,10 @@ force-pushed lat_cli-v0.4
 ```
 
 Setting `series_tag_format = "v{series}"` drops `{name}` and gives the whole
-repository one shared series tag, which is exactly right for a single-package
-repo. With more than one package it is still allowed, but it costs something:
-the tag no longer identifies a package, so `trellis ci tag-package` cannot
-resolve it. That holds for every such tag regardless of how the packages are
-versioned, since there is no `{name}` to tell them apart. `doctor` therefore
-warns as soon as a second package moves one, rather than waiting for two
-packages to land in the same series.
+repository one shared series tag — exactly right for a single-package
+repository. With more than one package it is still allowed, but the tag no
+longer identifies a package, so `trellis ci tag-package` cannot resolve it.
+`doctor` warns as soon as a second package moves one.
 
 <Callout>
 
@@ -342,14 +340,23 @@ rendering is controlled by small minijinja templates, each with a context of
 
 ```toml wrap
 [tools.trellis.changelog]
+header_format = "# {{ name }} changelog"              # default
 version_format = "## v{{ version }} - {{ date }}"     # default
 kind_format = "### {{ kind }}"                        # default
 change_format = "- {{ body }}"                        # default
+
+# The default kinds, in full. Setting `kinds` replaces the whole list, so
+# copy this before trimming it — a kind you drop becomes an invalid fragment.
 kinds = [
   { label = "Initial Release", bump = "major" },
   { label = "Breaking", bump = "major" },
+  { label = "Removed", bump = "major" },
   { label = "Added", bump = "minor" },
+  { label = "Changed", bump = "minor" },
+  { label = "Deprecated", bump = "minor" },
   { label = "Fixed", bump = "patch" },
+  { label = "Performance", bump = "patch" },
+  { label = "Security", bump = "patch" },
   { label = "Dependencies", bump = "patch" },
 ]
 
@@ -447,10 +454,9 @@ warning: packages disagree on `gleam_stdlib`: `>= 0.44.0` (lat_core) vs
 counts
 ```
 
-Requirements are compared **as written**, never parsed as ranges: trellis
-stores them verbatim, so `>= 1.0` and `>=1.0` read as divergent. Path
-dependencies are out of scope. They carry no requirement to agree on, and
-lockfile drift already covers them.
+Requirements are compared **as written**, never parsed as ranges, so `>= 1.0`
+and `>=1.0` read as divergent. Path dependencies are out of scope — they carry
+no requirement to agree on, and lockfile drift already covers them.
 
 Divergence is sometimes intended, so this warns rather than failing by
 default:
@@ -460,8 +466,8 @@ default:
 shared_dependencies = "error"   # warn (default), error, or off
 ```
 
-There is no `doctor --fix` for it: unifying to the highest requirement is a
-judgment call, not a mechanical remedy.
+There is no `doctor --fix` for it — which requirement to unify on is a judgment
+call.
 
 ## Deprecated and unrecognized keys
 
@@ -475,13 +481,11 @@ warning: [tools.trellis] key `publish.tag-format` is deprecated; rename it to
 `publish.tag_format` (trellis config keys are snake_case)
 ```
 
-A warning, not an error: the key still configures what it always did, so failing
-would break working repositories over a spelling. Plan on the aliases going away
-at 1.0.
+A warning, not an error — the old spelling still configures what it always did.
+Plan on the aliases going away at 1.0.
 
-A key that is not recognized in *any* spelling is also a warning. It may belong
-to a newer trellis, and erroring would make the workspace unloadable under a
-pinned older one — a bad failure for a tool CI pins:
+A key that is not recognized in *any* spelling is also a warning, since it may
+belong to a newer trellis than the one CI has pinned:
 
 ```console
 $ trellis doctor

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -9,17 +9,16 @@ repository and adds changelogs, versioning, and publishing, deriving its model
 of the workspace from the `gleam.toml` files already in it.
 
 Throughout these docs, a **package** is one Gleam package — a directory with
-its own `gleam.toml`. A **member** is a package that belongs to this
-workspace. The two are the same thing seen from different sides, so "member"
-appears only where membership is the point: the `members` key, the `@members`
-exclusion, and the member paths that exclusion globs match.
+its own `gleam.toml`. A **member** is a package that belongs to the workspace;
+that word appears where membership itself is the point, as in the `members`
+key and the `@members` exclusion.
 
 ## Derived, then verified
 
 The member set, its topological order, change impact, and publish order all
-come from manifests that already exist. Four things can't be derived: locked
-versions, changelogs, tags, and toolchain pins. `trellis doctor` checks those
-and exits non-zero when one breaks.
+come from manifests that already exist. What can't be derived has to be
+duplicated somewhere — locked versions, changelogs, tags, toolchain pins — and
+`trellis doctor` checks those, exiting non-zero when one breaks.
 
 Some findings are mechanically fixable — a releasable package missing its
 `CHANGELOG.md`, a `manifest.toml` locked version that drifted from its
@@ -31,13 +30,11 @@ a file.
 
 Trellis has one way of doing each job: change fragments are TOML files in
 `.changes/unreleased/`, every releasable package gets its own git tag, and
-version bumps are derived from fragment kinds. Those opinions are what make
-derivation and verification possible — there's no plugin system to configure
-around them.
+version bumps are derived from fragment kinds.
 
-The jobs themselves are independent. Every capability is a plain command,
-and nothing requires the piece above it, so you can adopt trellis a layer at
-a time:
+The jobs themselves are independent. Every capability is a plain command, and
+nothing requires the piece above it, so you can adopt trellis a layer at a
+time:
 
 - **Just the task runner.** `run`, `exec`, `list`, and `graph` need no
   configuration at all — members are auto-discovered from git. Keep your

--- a/website/src/content/docs/docs/installation.mdx
+++ b/website/src/content/docs/docs/installation.mdx
@@ -6,12 +6,10 @@ description: Trellis ships as a single prebuilt binary that installs in about a 
 import { Code } from "@astrojs/starlight/components";
 import { TRELLIS_VERSION } from "../../../lib/version";
 
-One prebuilt binary, no runtime dependencies, about a second to install on a
-CI runner — the same distribution model as `just`, `changie`, and `ratchet`.
-Releases are built and published by
-[cargo-dist](https://opensource.axo.dev/cargo-dist/) for five targets (Linux
-gnu, macOS, and Windows, on x86_64 and aarch64), with SLSA build provenance
-attestations attached to every release.
+One prebuilt binary, no runtime dependencies, about a second to install on a CI
+runner. Every release ships five targets — Linux (glibc) and macOS on x86_64
+and aarch64, Windows on x86_64 — with SLSA build provenance attestations
+attached.
 
 ## Shell installer
 
@@ -45,9 +43,8 @@ its other tools, so every contributor and CI runner gets the same version:
 
 ## From source
 
-The crate publishes to crates.io as `trellis-gleam` (the `trellis` name
-belongs to an unrelated project), but the installed binary is named `trellis`
-either way:
+On crates.io the crate is `trellis-gleam` — `trellis` was taken — but the
+installed binary is named `trellis` either way:
 
 ```sh
 cargo install trellis-gleam
@@ -82,13 +79,11 @@ trellis completions powershell | Out-String | Invoke-Expression
 ```
 
 Evaluate the snippet on startup rather than saving it into a completions
-directory. It talks to `trellis` over an interface that can change between
-releases, so an `eval` is always in sync with the binary you have, while a saved
-copy silently goes stale after an upgrade.
+directory: an `eval` always matches the binary you have, while a saved copy
+silently goes stale after an upgrade.
 
 One limitation worth knowing: completing after `-C` uses the directory you're
-standing in, not the one you passed. The completion engine sees only the word
-under the cursor, not the rest of the command line.
+standing in, not the one you passed.
 
 ## Man pages
 
@@ -132,7 +127,7 @@ $ trellis doctor
 checked: member globs resolve and every package has a parseable gleam.toml
 checked: path dependencies stay inside the workspace; graph is acyclic
 ...
-ok: 4 package(s), 0 warning(s)`}
+ok: 4 package(s) (1 workspace, 0 git_only, 3 hex), 0 warning(s)`}
 />
 
 If the workspace isn't set up yet, start with the

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -78,9 +78,7 @@ Notes:
   `tag_kind: series` with `tag_series` — the other key is absent, not null.
 - `tag plan` entries use `kind: repository_series` for an anchored repository
   tag. The entry retains the anchor package's `name` and `version`; this kind
-  is never returned by package-oriented `ci tag-package`. Adding this
-  documented enum value advanced the payload from `trellis.tag_plan/1` to
-  `trellis.tag_plan/2`.
+  is never returned by package-oriented `ci tag-package`.
 - `changelog check`'s `preview` field is always present and a string, but its
   Markdown prose can change without a version bump. `needs_entry` reports
   whether an entry is missing; `ok` reports what
@@ -96,11 +94,11 @@ Notes:
 ## `doctor` findings
 
 `package_lifecycles` is an array of `{name, lifecycle}`, one per member in
-workspace order, additive alongside the existing numeric `packages` count —
-`doctor`'s text summary renders the same data as compact counts, e.g.
+workspace order, alongside the numeric `packages` count. `doctor`'s text
+summary renders the same data as compact counts:
 `ok: 4 package(s) (1 workspace, 0 git_only, 3 hex), 0 warning(s)`.
 
-One entry per problem:
+`findings[]` carries one entry per problem:
 
 ```json
 {
@@ -186,5 +184,5 @@ See [CI recipes](/docs/ci/) for how these are consumed.
 
 ## Enforcement
 
-Every payload is defined once, in one file, and snapshotted in trellis's test
-suite. A change to a stable shape fails CI before it can ship.
+Every payload is snapshotted in trellis's test suite, so a change to a stable
+shape fails CI before it can ship.

--- a/website/src/content/docs/docs/task-running.mdx
+++ b/website/src/content/docs/docs/task-running.mdx
@@ -7,8 +7,7 @@ import Callout from "../../../components/Callout.astro";
 
 `trellis run` fans a task out across workspace packages; `trellis exec` does
 the same for an arbitrary command. Both work from anywhere inside the
-workspace and replace the hand-written `for pkg in …` bash loops that
-multi-package Gleam repos otherwise accumulate.
+workspace.
 
 ```txt wrap
 trellis run <task> [pkgs...] [--since <ref>] [--with-dependents]
@@ -32,8 +31,7 @@ Built-in tasks map 1:1 onto gleam verbs — no declaration needed:
 | `clean` | `gleam clean` |
 
 `--target erlang|javascript` selects the compile target; `--target all` runs
-the task once per target, replacing the `test-js`/`build-js` recipe
-duplication.
+the task once per target.
 
 ## Custom tasks
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -86,7 +86,7 @@ tag_format = "{name}-v{version}"`;
           <h3>Just the task runner</h3>
           <p>
             <code>run</code>, <code>exec</code>, <code>list</code>, and{" "}
-            <code>graph</code> need no configuration at all — packages are
+            <code>graph</code> need no configuration at all — members are
             auto-discovered from git. Your changelog tool and CI stay untouched.
           </p>
         </li>
@@ -262,9 +262,9 @@ tag_format = "{name}-v{version}"`;
 
         <figure class="term">
           <figcaption class="term-bar"><span class="prompt">$</span>trellis list --releasable</figcaption>
-          <pre class="term-out"><code><span class="name">lat_core</span>
-<span class="name">lat_mid</span>
-<span class="name">lat_cli</span></code></pre>
+          <pre class="term-out"><code><span class="name">lat_core</span>  <span class="dim">hex</span>
+<span class="name">lat_mid</span>   <span class="dim">hex</span>
+<span class="name">lat_cli</span>   <span class="dim">hex</span></code></pre>
           <figcaption class="term-note">
             <code>lat_example</code> — the <code>examples/</code> member — still
             appears in <code>trellis list</code>, <code>graph</code>,{" "}
@@ -336,16 +336,16 @@ tag_format = "{name}-v{version}"`;
         <figcaption class="term-bar"><span class="prompt">$</span>trellis doctor</figcaption>
         <pre class="term-out"><code><span class="dim">checked:</span> member globs resolve and every package has a parseable gleam.toml
 <span class="dim">checked:</span> path dependencies stay inside the workspace; graph is acyclic
-<span class="dim">checked:</span> task exclusion globs match members; no releasable package depends on an unreleasable one
+<span class="dim">checked:</span> task exclusion globs match members; no package depends on one unavailable at its release lifecycle
 <span class="dim">checked:</span> tag format produces a unique tag per releasable package
 <span class="dim">checked:</span> manifest.toml locked versions match workspace-internal gleam.toml versions
 <span class="dim">checked:</span> each releasable package's version is not behind its CHANGELOG
-<span class="dim">checked:</span> unreleased changelog fragments parse and reference valid packages and kinds
+<span class="dim">checked:</span> unreleased changelog fragments parse and reference valid packages, kinds, and categories
 <span class="dim">checked:</span> [tools.trellis] carries no unrecognized or deprecated keys
 <span class="dim">checked:</span> packages agree on the external dependencies they share
 <span class="dim">checked:</span> gleam on PATH matches the .tool-versions pin (advisory)
 
-<span class="ok">ok: 4 package(s), 0 warning(s)</span></code></pre>
+<span class="ok">ok: 4 package(s) (1 workspace, 0 git_only, 3 hex), 0 warning(s)</span></code></pre>
       </figure>
     </div>
   </section>


### PR DESCRIPTION
Website copy review for correctness, clarity, and concision. Every documented command and config sample was run against the binary in a fixture workspace matching the docs' own `lat_core`/`lat_mid`/`lat_cli`/`lat_example` example, rather than read.

**Stale output.** The landing page and installation page showed `trellis doctor` output the binary no longer produces — two of the ten `checked:` lines have been reworded (release-boundary now reads "no package depends on one unavailable at its release lifecycle"; the fragment check validates categories too), and the summary line has since gained a lifecycle breakdown. The landing page's `trellis list --releasable` transcript was missing its lifecycle column; the configuration page had it right, which is how the two pages came to disagree.

**Config reference gaps.** The Keys table omitted `publish.path_dep_requirement` — documented on the publishing page but absent from the table a reader consults — along with `changelog.dir` and `changelog.header_format`.

**A sample that fails silently.** The `changelog.kinds` example sat among lines marked `# default` while listing five of the ten real defaults. Setting `kinds` replaces the list wholesale, so copying that block would drop `Removed`, `Changed`, `Deprecated`, `Performance`, and `Security`, then surface as invalid-fragment errors with no obvious cause. It now shows the full default list and says that replacing it replaces all of it.

**Prose.** Cut ~175 words of design rationale and version archaeology written for contributors rather than users: the changie lineage of the fragment workflow, payload-versioning history in the JSON page, comparisons to other tools, and passages explaining why a warning is a warning. Migration notes that tell a reader to change something stayed. Corrected the install page's target claim, which read as six targets and overstated Windows (x86_64 only).

Two pages grew — the configuration reference from the added keys and the full `kinds` list, the landing page from the corrected transcripts having more columns.

Site builds, all internal routes and heading anchors resolve, and the generated `reference.md` and man pages are current and untouched. No Rust changed.