### PR TITLE
chore: declare rust-analyzer LSP in apm.yml

### DIFF
--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -1,0 +1,13 @@
+{
+  "lspServers": {
+    "rust-analyzer": {
+      "command": "rust-analyzer",
+      "restartOnCrash": true,
+      "maxRestarts": 3,
+      "fileExtensions": {
+        ".rs": "rust"
+      },
+      "args": []
+    }
+  }
+}

--- a/.lsp.json
+++ b/.lsp.json
@@ -1,0 +1,10 @@
+{
+  "rust-analyzer": {
+    "command": "rust-analyzer",
+    "restartOnCrash": true,
+    "maxRestarts": 3,
+    "extensionToLanguage": {
+      ".rs": "rust"
+    }
+  }
+}

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -539,3 +539,13 @@ deployments:
   - dietrichgebert/ponytail
   active_owner: dietrichgebert/ponytail
   content_hash: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
+lsp_servers:
+- rust-analyzer
+lsp_configs:
+  rust-analyzer:
+    name: rust-analyzer
+    command: rust-analyzer
+    extensionToLanguage:
+      .rs: rust
+    restartOnCrash: true
+    maxRestarts: 3

--- a/apm.yml
+++ b/apm.yml
@@ -14,5 +14,12 @@ dependencies:
     # - git: https://github.com/obra/superpowers
     - DietrichGebert/ponytail
   mcp: []
+  lsp:
+    - name: rust-analyzer
+      command: rust-analyzer
+      extensionToLanguage:
+        ".rs": rust
+      restartOnCrash: true
+      maxRestarts: 3
 includes: auto
 scripts: {}


### PR DESCRIPTION
Adds a `dependencies.lsp` entry for rust-analyzer to the APM manifest, so
Rust code intelligence comes from the manifest instead of per-machine setup.

## Changes

- **`apm.yml`** — declares `rust-analyzer` (`command: rust-analyzer`, `.rs` → `rust`, `restartOnCrash` with `maxRestarts: 3`).
- **`.lsp.json`** — Claude Code config, generated by `apm install`.
- **`.github/lsp.json`** — Copilot CLI config (`lspServers` / `fileExtensions` shape), generated by `apm install`.
- **`apm.lock.yaml`** — now tracks `lsp_servers` and `lsp_configs` so APM only prunes servers it manages.

Both generated files are committed, matching how the vendored skills are handled, so `apm install --frozen` reproduces them.

Requires `rust-analyzer` on `$PATH` (rustup component or mise shim); the server starts in new agent sessions.