### PR TITLE
feat(changelog): name fragments after their body text

### DIFF
--- a/.changes/unreleased/Changed-20260811-fragment-names-from-body.yaml
+++ b/.changes/unreleased/Changed-20260811-fragment-names-from-body.yaml
@@ -1,0 +1,7 @@
+component: changelog
+kind: Changed
+body: |-
+  **`changelog new` names a fragment after the change it describes, not a counter.** The file is now `<package>-<first few words of the body>.toml` — `lat_core-reject-path-deps-that.toml` rather than `lat_core-1.toml` — so a directory of unreleased fragments reads as a list of pending changes, and two branches adding a change to the same package no longer both claim `-1`. Bodies with nothing nameable in them fall back to the package alone, and a genuine clash still takes the next free `-2`, `-3` suffix.
+
+    Existing fragments are unaffected: names are never parsed, only written, so anything already in `.changes/unreleased/` keeps working.
+time: 2026-08-11T00:01:00.000000-07:00

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -256,7 +256,32 @@ pub fn dependency_fragment(
     })
 }
 
-/// Write a new fragment file, picking an unused `<package>-<n>.toml` name.
+/// The filename stem a body earns: its leading words, kebab-cased. Naming the
+/// file after the change is what makes a directory of fragments readable, and
+/// what keeps two branches from both claiming `<package>-1.toml`.
+fn body_slug(body: &str) -> String {
+    let mut out = String::new();
+    for word in body
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .take(4)
+    {
+        let word = word.to_lowercase();
+        if !out.is_empty() {
+            if out.len() + 1 + word.len() > 40 {
+                break;
+            }
+            out.push('-');
+        }
+        out.push_str(&word);
+    }
+    out.truncate(40);
+    out
+}
+
+/// Write a new fragment file, named for the package and the change it
+/// describes. A body with nothing nameable in it (punctuation only) falls back
+/// to the package alone, and any clash takes the next free `-<n>` suffix.
 pub fn write_fragment(
     workspace: &Workspace,
     package: &str,
@@ -273,8 +298,15 @@ pub fn write_fragment(
         doc["category"] = toml_edit::value(category);
     }
     doc["body"] = toml_edit::value(body);
+    let stem = match body_slug(body) {
+        slug if slug.is_empty() => package.to_string(),
+        slug => format!("{package}-{slug}"),
+    };
     for n in 1u32.. {
-        let path = dir.join(format!("{package}-{n}.toml"));
+        let path = dir.join(match n {
+            1 => format!("{stem}.toml"),
+            n => format!("{stem}-{n}.toml"),
+        });
         if !path.exists() {
             std::fs::write(&path, doc.to_string())
                 .with_context(|| format!("failed to write {}", path.display()))?;
@@ -703,6 +735,24 @@ mod tests {
             body: body.to_string(),
             path: Some(PathBuf::from("unused")),
         }
+    }
+
+    /// A fragment's filename comes from its body, so the name has to survive
+    /// whatever a body contains: punctuation, case, unicode, or nothing usable.
+    #[test]
+    fn fragment_names_are_slugs_of_their_body() {
+        assert_eq!(
+            body_slug("repair the flux capacitor, again"),
+            "repair-the-flux-capacitor"
+        );
+        assert_eq!(body_slug("Fix `Vine::grow` panic!"), "fix-vine-grow-panic");
+        assert_eq!(body_slug("  x  "), "x");
+        assert_eq!(body_slug("!!! ---"), "");
+        assert_eq!(body_slug(""), "");
+        // Four long words still stop at the length cap, mid-word if need be.
+        let long = body_slug("aaaaaaaaaaaaaaa bbbbbbbbbbbbbbb ccccccccccccccc");
+        assert_eq!(long, "aaaaaaaaaaaaaaa-bbbbbbbbbbbbbbb");
+        assert!(body_slug(&"z".repeat(60)).len() <= 40);
     }
 
     /// `{{ series }}` renders a heading in a committed changelog, so its

--- a/tests/phase2.rs
+++ b/tests/phase2.rs
@@ -179,15 +179,16 @@ fn new_fragment_writes_toml_and_validates_inputs() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            ".changes/unreleased/lat_core-1.toml",
+            ".changes/unreleased/lat_core-grow-more-vines.toml",
         ));
-    let fragment = fs::read_to_string(root.join(".changes/unreleased/lat_core-1.toml")).unwrap();
+    let fragment =
+        fs::read_to_string(root.join(".changes/unreleased/lat_core-grow-more-vines.toml")).unwrap();
     assert_eq!(
         fragment,
         "package = \"lat_core\"\nkind = \"Added\"\nbody = \"grow more vines\"\n"
     );
 
-    // A second fragment gets the next free name.
+    // A different body earns a different name, no counter involved.
     trellis(root)
         .args([
             "changelog",
@@ -201,7 +202,23 @@ fn new_fragment_writes_toml_and_validates_inputs() {
         ])
         .assert()
         .success()
-        .stdout(predicate::str::contains("lat_core-2.toml"));
+        .stdout(predicate::str::contains("lat_core-x.toml"));
+
+    // The same body twice falls back to a counter.
+    trellis(root)
+        .args([
+            "changelog",
+            "new",
+            "--package",
+            "lat_core",
+            "--kind",
+            "Fixed",
+            "--body",
+            "x",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lat_core-x-2.toml"));
 
     trellis(root)
         .args([
@@ -305,7 +322,8 @@ fn new_fragment_records_a_category_and_validates_it() {
         ])
         .assert()
         .success();
-    let fragment = fs::read_to_string(root.join(".changes/unreleased/lat_core-1.toml")).unwrap();
+    let fragment =
+        fs::read_to_string(root.join(".changes/unreleased/lat_core-grow-more-vines.toml")).unwrap();
     assert_eq!(
         fragment,
         "package = \"lat_core\"\nkind = \"Added\"\ncategory = \"build\"\nbody = \"grow more vines\"\n"
@@ -325,7 +343,7 @@ fn new_fragment_records_a_category_and_validates_it() {
         ])
         .assert()
         .success();
-    let fragment = fs::read_to_string(root.join(".changes/unreleased/lat_core-2.toml")).unwrap();
+    let fragment = fs::read_to_string(root.join(".changes/unreleased/lat_core-x.toml")).unwrap();
     assert_eq!(
         fragment,
         "package = \"lat_core\"\nkind = \"Fixed\"\nbody = \"x\"\n"

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -22,7 +22,7 @@ trellis version apply [--json]
 A fragment is one file in `.changes/unreleased/` with three keys — the package
 it belongs to, a configured change kind, and the entry text:
 
-```toml title=".changes/unreleased/lat_core-1.toml"
+```toml title=".changes/unreleased/lat_core-add-graph-parallel-task.toml"
 package = "lat_core"
 kind = "Added"
 body = "Add graph-parallel task scheduling"
@@ -43,8 +43,12 @@ be omitted when the workspace has exactly one releasable package):
 ```console
 $ trellis changelog new --package lat_core --kind Fixed \
     --body "Reject path deps that escape the workspace"
-created .changes/unreleased/lat_core-1.toml
+created .changes/unreleased/lat_core-reject-path-deps-that.toml
 ```
+
+The filename is the package plus the first few words of the body, so a
+directory of fragments reads as a list of pending changes and two branches
+rarely pick the same name. A clash takes the next free `-2`, `-3` suffix.
 
 <Callout>
 

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -458,7 +458,7 @@ uncategorized_label = "Other"            # default
 
 A fragment opts in by naming one:
 
-```toml title=".changes/unreleased/lat_cli-1.toml"
+```toml title=".changes/unreleased/lat_cli-a-watch-flag.toml"
 package = "lat_cli"
 kind = "Added"
 category = "build"


### PR DESCRIPTION
`changelog new` named fragments `<package>-<n>.toml`, so two branches touching the same package both got `-1` and the filename said nothing about the change.

Names are now `<package>-<slug>.toml`, where slug is the first few words of the body, kebab-cased. Pure function of package + body — no new deps, no randomness. Falls back to the package name if the body has nothing nameable. Collisions still fall back to `-2`, `-3`.

Only affects newly written fragments; existing ones are untouched. Docs updated to match.