### PR TITLE
fix(publish): clear the resolved dep tree after rewriting path deps

### DIFF
--- a/.changes/unreleased/Fixed-20260811-publish-clears-stale-dep-tree.yaml
+++ b/.changes/unreleased/Fixed-20260811-publish-clears-stale-dep-tree.yaml
@@ -1,0 +1,7 @@
+component: publish
+kind: Fixed
+body: |-
+  **`publish` clears a package's resolved dependency tree after rewriting its path deps.** Validation resolves `build/packages` while those deps are still paths, and gleam cannot swap a local dependency for the Hex release of the same name in place: it drops the local entry, then fails reading the `gleam.toml` it just removed. Publishing any package with a path dep died that way, retries and all.
+
+    Only `build/packages` is cleared, so compiled output under `build/dev` survives and the publish compile stays incremental. A package whose manifest needed no rewrite keeps its tree untouched.
+time: 2026-08-11T19:52:00.000000-07:00

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -3,7 +3,8 @@
 //!      failed release),
 //!   2. validation (`gleam format --check`, `build --warnings-as-errors`,
 //!      `test`), Hex-touching steps wrapped in the retry policy,
-//!   3. path-dep rewrite computed from the graph,
+//!   3. path-dep rewrite computed from the graph, clearing the resolved
+//!      dependency tree the rewrite invalidates,
 //!   4. `gleam publish --yes` with retry,
 //!   5. restore the original gleam.toml (the repo never shows rewritten
 //!      files, even on failure).
@@ -176,6 +177,21 @@ pub fn run(workspace: &Workspace, options: &PublishOptions) -> Result<bool> {
         };
         std::fs::write(&manifest_path, &rewritten)
             .with_context(|| format!("failed to write {}", manifest_path.display()))?;
+        // Validation resolved `build/packages` while the rewritten deps were
+        // still paths, and gleam cannot swap a local dependency for the Hex
+        // release of the same name in place: it drops the local entry, then
+        // reads the gleam.toml it just removed and fails with a file-IO error.
+        // Clearing the resolved tree makes the next resolve start from the
+        // rewritten manifest; `build/dev` — the compiled half, and the
+        // expensive one — is untouched.
+        if !rewrites.is_empty() {
+            let resolved = member.path.join("build").join("packages");
+            if resolved.exists() {
+                std::fs::remove_dir_all(&resolved).with_context(|| {
+                    format!("failed to clear resolved deps at {}", resolved.display())
+                })?;
+            }
+        }
         for rewrite in &rewrites {
             crate::status!(
                 "[{}] rewrote {} -> \"{}\"",

--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -86,6 +86,10 @@ fn init_repo(root: &Path) {
 
 /// A fake gleam that logs every invocation (cwd + args) to `.fake/gleam-log`
 /// and snapshots gleam.toml at publish time so tests can observe the rewrite.
+///
+/// It also records whether `build/packages` existed at each invocation, in
+/// `.fake/build-state` — a separate file so tests asserting on the exact
+/// contents of `gleam-log` are unaffected.
 fn install_fake_gleam(root: &Path) -> PathBuf {
     let script = root.join("fake-gleam.sh");
     write(
@@ -96,6 +100,8 @@ fn install_fake_gleam(root: &Path) -> PathBuf {
                 "set -eu\n",
                 "root=\"{root}\"\n",
                 "echo \"$(basename \"$PWD\") gleam $*\" >> \"$root/.fake/gleam-log\"\n",
+                "if [ -d build/packages ]; then state=present; else state=absent; fi\n",
+                "echo \"$(basename \"$PWD\") $1 $state\" >> \"$root/.fake/build-state\"\n",
                 "if [ \"$1\" = publish ]; then\n",
                 "  cp gleam.toml \"$root/.fake/published-$(basename \"$PWD\").toml\"\n",
                 "fi\n",
@@ -456,6 +462,78 @@ fn publish_rewrites_path_deps_and_restores_the_manifest() {
         fs::read_to_string(root.join("packages/lat_mid/gleam.toml")).unwrap(),
         original
     );
+}
+
+#[test]
+fn publish_clears_the_stale_dependency_tree_before_publishing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    let gleam = install_fake_gleam(root);
+    let hex = mock_hex(vec![("lat_core", vec!["1.2.0"])]); // lat_mid: 404
+
+    // Stand in for what validation leaves behind: a dependency tree gleam
+    // resolved while lat_core was still a path dep, alongside compiled output.
+    let packages = root.join("packages/lat_mid/build/packages");
+    fs::create_dir_all(&packages).unwrap();
+    write(&packages.join("lat_core.config_fingerprint"), "stale");
+    let compiled = root.join("packages/lat_mid/build/dev/erlang/lat_mid");
+    fs::create_dir_all(&compiled).unwrap();
+    write(&compiled.join("lat_mid.app"), "compiled");
+
+    trellis(root)
+        .env("TRELLIS_GLEAM_BIN", &gleam)
+        .env("TRELLIS_HEX_API_URL", &hex)
+        .args(["publish", "lat_mid"])
+        .assert()
+        .success();
+
+    // Validation runs against the tree as resolved; publish must not, or gleam
+    // fails reading the local dependency it just dropped from the manifest.
+    let state = fs::read_to_string(root.join(".fake/build-state")).unwrap();
+    assert_eq!(
+        state,
+        concat!(
+            "lat_mid format present\n",
+            "lat_mid build present\n",
+            "lat_mid test present\n",
+            "lat_mid publish absent\n",
+        )
+    );
+    // Only the resolved-dependency half is stale; compiled output survives.
+    assert!(
+        compiled.join("lat_mid.app").exists(),
+        "clearing the dependency tree must not throw away compiled artifacts"
+    );
+}
+
+#[test]
+fn publish_keeps_the_dependency_tree_when_nothing_is_rewritten() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    copy_fixture_to(root);
+    let gleam = install_fake_gleam(root);
+    let hex = mock_hex(vec![]); // nothing published yet
+
+    // lat_core has no path deps, so its manifest is published as-is and its
+    // dependency tree stays valid throughout — no reason to pay for a refetch.
+    let packages = root.join("packages/lat_core/build/packages");
+    fs::create_dir_all(&packages).unwrap();
+    write(&packages.join("gleam.lock"), "");
+
+    trellis(root)
+        .env("TRELLIS_GLEAM_BIN", &gleam)
+        .env("TRELLIS_HEX_API_URL", &hex)
+        .args(["publish", "lat_core"])
+        .assert()
+        .success();
+
+    let state = fs::read_to_string(root.join(".fake/build-state")).unwrap();
+    assert!(
+        state.contains("lat_core publish present"),
+        "unrewritten package should keep its dependency tree:\n{state}"
+    );
+    assert!(packages.join("gleam.lock").exists());
 }
 
 #[test]


### PR DESCRIPTION
## The failure

`trellis publish` fails for every package that has a path dep. Seen in [tylerbutler/lattice run 31556845946](https://github.com/tylerbutler/lattice/actions/runs/31556845946):

```
[lattice_registers] validating 1.2.0
[lattice_registers] $ gleam build --warnings-as-errors   ← resolves with the PATH dep
[lattice_registers] $ gleam test
[lattice_registers] rewrote lattice_core -> ">= 1.0.0 and < 2.0.0"
[lattice_registers] $ gleam publish --yes
error: File IO failure ... build/packages/lattice_core/gleam.toml
    No such file or directory (os error 2)
```

Validation resolves `build/packages` while the deps are still paths. The rewrite then points those same names at Hex, and gleam cannot make that swap in place — it prints `Removed lattice_core`, dropping the local entry, then reads the `gleam.toml` it just removed. The retry policy can't help: it fails identically all five times.

In that release `lattice_presence` (no path deps) published fine and every other package in the set was blocked.

## The fix

Clear `build/packages` after the rewrite, before `gleam publish`, so the resolve starts from the rewritten manifest.

Scope was chosen by bisection on a real workspace:

| cleared after rewrite | result |
|---|---|
| nothing | fails |
| `build/packages/<dep>` + `.config_fingerprint` | fails |
| `build/packages/gleam.lock` (+ fingerprint) | fails |
| **`build/packages`** | **succeeds** |
| `build/dev` | fails |

So `build/packages` is both necessary and sufficient. `build/dev` — the compiled half, and the expensive one — is deliberately untouched, and a package with no rewrites keeps its tree entirely.

The reverse transition (restoring the path dep over a Hex-shaped tree, which `RestoreGuard` does) resolves cleanly, so no cleanup is needed there.

## Verification

- Two new tests in `tests/phase3.rs`. The first fails on `main` (`lat_mid publish present` vs expected `absent`) and passes here; the second pins the no-rewrite case so this doesn't become an unconditional refetch. The fake gleam now records build state to `.fake/build-state`, a separate file, leaving existing `gleam-log` assertions untouched.
- End-to-end against the real lattice workspace with a wrapper that swaps `gleam publish` for `gleam build` (so nothing ships): released 0.10.1 reproduces the file-IO error, this build resolves `lattice_core v1.0.0` from Hex and compiles.
- `just format`, `just lint`, `just test` (404 tests) all clean.

Not a gleam regression — reproduces identically on gleam 1.18.0 and 1.18.1.