### PR TITLE
ci: allow explicit release versions

### DIFF
--- a/.changes/unreleased/Added-20260819-prerelease-dispatch.yaml
+++ b/.changes/unreleased/Added-20260819-prerelease-dispatch.yaml
@@ -1,0 +1,5 @@
+component: trellis
+kind: Added
+body: |-
+  **Release automation accepts an explicit prerelease version.** Manually dispatching the Changie Release workflow now accepts `auto` or an explicit SemVer such as `1.0.0-rc.1`; merging the generated release PR lets the existing release-plz and cargo-dist pipeline publish the crate and artifacts as a prerelease.
+time: 2026-08-19T17:42:52.502-07:00

--- a/.changes/unreleased/Added-20260819-prerelease-dispatch.yaml
+++ b/.changes/unreleased/Added-20260819-prerelease-dispatch.yaml
@@ -1,5 +1,0 @@
-component: trellis
-kind: Added
-body: |-
-  **Release automation accepts an explicit prerelease version.** Manually dispatching the Changie Release workflow now accepts `auto` or an explicit SemVer such as `1.0.0-rc.1`; merging the generated release PR lets the existing release-plz and cargo-dist pipeline publish the crate and artifacts as a prerelease.
-time: 2026-08-19T17:42:52.502-07:00

--- a/.github/workflows/changie-release.yml
+++ b/.github/workflows/changie-release.yml
@@ -9,6 +9,11 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (`auto` or explicit semver)
+        required: false
+        default: auto
 
 jobs:
   release:
@@ -29,6 +34,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
+          version: ${{ inputs.version || 'auto' }}
           version-files: 'Cargo.toml:package.version'
           pr-title-template: 'chore(release): {version}'
 


### PR DESCRIPTION
## Summary

- add a `version` input to manual Changie Release dispatches
- pass explicit SemVer values such as `1.0.0-rc.1` to the existing release action
- preserve `auto` for pushes and ordinary manual runs

Merging the generated release PR continues through release-plz and cargo-dist; prerelease tags create GitHub prereleases while Homebrew and the stable `latest` release remain unchanged.