### PR TITLE
feat: add apm-base package, replace no-laziness rule with STE rule

### DIFF
--- a/.agents/skills/prose-banlist/SKILL.md
+++ b/.agents/skills/prose-banlist/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: prose-banlist
+description: A skill that bans certain phrases from being used in prose writing.
+---
+
+Review prose in your writing and flag any instances of the following phrases or variants of them:
+
+- "Reach for"
+- "Lives at"
+- "Grows a"
+- "Shape the"
+- "fails loudly"
+- "load bearing"
+- "pinned by"
+- "X carries Y" when referring to an argument or fact
+- "seam"
+- "sharpen" especially when referring to argument
+
+Ask the user if they want to replace the flagged phrases with alternative wording. If they do, suggest more concise or creative alternatives that maintain the intended meaning.

--- a/.agents/skills/stop-slop/CHANGELOG.md
+++ b/.agents/skills/stop-slop/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 2026-01-13
+
+### Added
+
+**Phrases (references/phrases.md)**
+- Throat-clearing: "Here's what I find interesting", "Here's the problem though"
+- Performative emphasis: "creeps in", "I promise", "They exist, I promise"
+- Telling instead of showing: "This is genuinely hard", "This is what leadership actually looks like"
+
+**Structures (references/structures.md)**
+- Binary contrasts: "Not X. But Y.", "It's not this. It's that.", "stops being X and starts being Y"
+- Rhythm patterns: staccato fragmentation, dashes for dramatic pause, hedging as reassurance
+- Word patterns: absolute words (always, never, everyone, etc.), AI-overused intensifiers (deeply, truly, fundamentally, inherently, simply, literally, inevitably)
+
+## 2026-01-12
+
+- Restructured skill following Claude Code best practices (PR #1)
+- Split into SKILL.md and references/ folder
+
+## 2025-01-12
+
+- Initial release

--- a/.agents/skills/stop-slop/LICENSE
+++ b/.agents/skills/stop-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hardik Pandya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agents/skills/stop-slop/README.md
+++ b/.agents/skills/stop-slop/README.md
@@ -1,0 +1,62 @@
+# Stop Slop
+
+A skill for removing AI tells from prose.
+
+<img width="3840" height="2160" alt="G-Yg4RVbIAAhVxW" src="https://github.com/user-attachments/assets/902afc15-1f40-4a9d-af24-8cd67afb8ebf" />
+
+## What this is
+
+AI writing has patterns. Predictable phrases, structures, rhythms. This skill teaches Claude (or any LLM) to catch and remove them.
+
+## Skill Structure
+
+```
+stop-slop/
+├── SKILL.md              # Core instructions
+├── references/
+│   ├── phrases.md        # Phrases to remove
+│   ├── structures.md     # Structural patterns to avoid
+│   └── examples.md       # Before/after transformations
+├── README.md
+└── LICENSE
+```
+
+## Quick start
+
+**Claude Code:** Add this folder as a skill.
+
+**Claude Projects:** Upload `SKILL.md` and reference files to project knowledge.
+
+**Custom instructions:** Copy core rules from `SKILL.md`.
+
+**API calls:** Include `SKILL.md` in your system prompt. Reference files load on demand.
+
+## What it catches
+
+**Banned phrases** - Throat-clearing openers, emphasis crutches, business jargon, all adverbs, vague declaratives, meta-commentary. See `references/phrases.md`.
+
+**Structural clichés** - Binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, narrator-from-a-distance voice, passive voice. See `references/structures.md`.
+
+**Sentence-level rules** - No Wh- sentence starters, no em dashes, no staccato fragmentation, no lazy extremes, active voice required.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Author
+
+[Hardik Pandya](https://hvpandya.com)
+
+## License
+
+MIT. Use freely, share widely.

--- a/.agents/skills/stop-slop/SKILL.md
+++ b/.agents/skills/stop-slop/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: stop-slop
+description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
+metadata:
+  trigger: Writing prose, editing drafts, reviewing content for AI patterns
+  author: Hardik Pandya (https://hvpandya.com)
+---
+
+# Stop Slop
+
+Eliminate predictable AI writing patterns from prose.
+
+## Core Rules
+
+1. **Cut filler phrases.** Remove throat-clearing openers, emphasis crutches, and all adverbs. See [references/phrases.md](references/phrases.md).
+
+2. **Break formulaic structures.** Avoid binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency. See [references/structures.md](references/structures.md).
+
+3. **Use active voice.** Every sentence needs a human subject doing something. No passive constructions. No inanimate objects performing human actions ("the complaint becomes a fix").
+
+4. **Be specific.** No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work.
+
+5. **Put the reader in the room.** No narrator-from-a-distance voice. "You" beats "People." Specifics beat abstractions.
+
+6. **Vary rhythm.** Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes.
+
+7. **Trust readers.** State facts directly. Skip softening, justification, hand-holding.
+
+8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
+
+## Quick Checks
+
+Before delivering prose:
+
+- Any adverbs? Kill them.
+- Any passive voice? Find the actor, make them the subject.
+- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
+- Sentence starts with a Wh- word? Restructure it.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with punchy one-liner? Vary it.
+- Em-dash anywhere? Remove it.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Narrator-from-a-distance ("Nobody designed this")? Put the reader in the scene.
+- Meta-joiners ("The rest of this essay...")? Delete. Let the essay move.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+## License
+
+MIT

--- a/.agents/skills/stop-slop/references/examples.md
+++ b/.agents/skills/stop-slop/references/examples.md
@@ -1,0 +1,59 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast
+
+**Before:**
+> "Here's the thing: building products is hard. Not because the technology is complex. Because people are complex. Let that sink in."
+
+**After:**
+> "Building products is hard. Technology is manageable. People aren't."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Direct statements.
+
+---
+
+## Example 2: Filler + Unnecessary Reassurance
+
+**Before:**
+> "It turns out that most teams struggle with alignment. The uncomfortable truth is that nobody wants to admit they're confused. And that's okay."
+
+**After:**
+> "Teams struggle with alignment. Nobody admits confusion."
+
+**Changes:** Cut hedging ("most"), removed throat-clearing phrases, deleted permission-granting ending.
+
+---
+
+## Example 3: Business Jargon Stack
+
+**Before:**
+> "In today's fast-paced landscape, we need to lean into discomfort and navigate uncertainty with clarity. This matters because your competition isn't waiting."
+
+**After:**
+> "Move faster. Your competition is."
+
+**Changes:** Eliminated jargon entirely. Core message in six words.
+
+---
+
+## Example 4: Dramatic Fragmentation
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost—pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 5: Rhetorical Setup
+
+**Before:**
+> "What if I told you that the best teams don't optimize for productivity? Here's what I mean: they optimize for learning. Think about it."
+
+**After:**
+> "The best teams optimize for learning, not productivity."
+
+**Changes:** Direct claim. No rhetorical scaffolding.

--- a/.agents/skills/stop-slop/references/phrases.md
+++ b/.agents/skills/stop-slop/references/phrases.md
@@ -1,0 +1,128 @@
+# Phrases to Remove
+
+## Throat-Clearing Openers
+
+Remove these announcement phrases. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The essay should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+If a sentence says something is important/deep/structural without showing the specific thing, cut it or replace it with the specific thing.

--- a/.agents/skills/stop-slop/references/structures.md
+++ b/.agents/skills/stop-slop/references/structures.md
@@ -1,0 +1,134 @@
+# Structures to Avoid
+
+## Binary Contrasts
+
+These create false drama. State the point directly.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Instead:** State Y directly. "The problem is Y." "Y matters here." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A rhetorical striptease.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+
+**Instead:** State Z. The reader doesn't need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+
+**Instead:** Complete sentences. Trust content over presentation.
+
+## Rhetorical Setups
+
+These announce insight rather than deliver it.
+
+| Pattern | Problem |
+|---------|---------|
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Instead:** Make the point. Let readers draw conclusions.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## False Agency
+
+Giving inanimate things human verbs. Complaints don't "become" fixes. Bets don't "live or die." Decisions don't "emerge." A person does something to make those things happen. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | The complaint did nothing. Someone fixed it. |
+| "a bet lives or dies in days" | Bets don't have lifespans. Someone kills the project or ships it. |
+| "the decision emerges" | Decisions don't emerge. Someone decides. |
+| "the culture shifts" | Cultures don't shift on their own. People change behavior. |
+| "the conversation moves toward" | Conversations don't move. Someone steers. |
+| "the data tells us" | Data sits there. Someone reads it and draws a conclusion. |
+| "the market rewards" | Markets don't reward. Buyers pay for things. |
+
+**Instead:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Instead:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Instead:** Find the actor. Put them at the front of the sentence.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em-dashes | Remove. Use commas or periods. No em dashes at all. |
+| Staccato fragmentation | Don't stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/.apm/instructions/no-laziness.instructions.md
+++ b/.apm/instructions/no-laziness.instructions.md
@@ -1,6 +1,0 @@
----
-description: Ask the user to avoid laziness and do the work themselves, rather than asking for it to be done for them.
-applyTo: '**'
----
-
-- If a task is trivial, e.g. a small change in a single file, you should provide a link to the file and ask the user to do it instead of doing it for them. This is good for them. If they push back, politely refuse. You are helping them stay disciplined.

--- a/.claude/rules/no-laziness.md
+++ b/.claude/rules/no-laziness.md
@@ -1,6 +1,0 @@
----
-paths:
-  - "**"
----
-
-- If a task is trivial, e.g. a small change in a single file, you should provide a link to the file and ask the user to do it instead of doing it for them. This is good for them. If they push back, politely refuse. You are helping them stay disciplined.

--- a/.claude/rules/use-ste.md
+++ b/.claude/rules/use-ste.md
@@ -1,0 +1,6 @@
+---
+paths:
+  - "**"
+---
+
+Use ASD-STE100 when possible

--- a/.claude/skills/prose-banlist/SKILL.md
+++ b/.claude/skills/prose-banlist/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: prose-banlist
+description: A skill that bans certain phrases from being used in prose writing.
+---
+
+Review prose in your writing and flag any instances of the following phrases or variants of them:
+
+- "Reach for"
+- "Lives at"
+- "Grows a"
+- "Shape the"
+- "fails loudly"
+- "load bearing"
+- "pinned by"
+- "X carries Y" when referring to an argument or fact
+- "seam"
+- "sharpen" especially when referring to argument
+
+Ask the user if they want to replace the flagged phrases with alternative wording. If they do, suggest more concise or creative alternatives that maintain the intended meaning.

--- a/.claude/skills/stop-slop/CHANGELOG.md
+++ b/.claude/skills/stop-slop/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 2026-01-13
+
+### Added
+
+**Phrases (references/phrases.md)**
+- Throat-clearing: "Here's what I find interesting", "Here's the problem though"
+- Performative emphasis: "creeps in", "I promise", "They exist, I promise"
+- Telling instead of showing: "This is genuinely hard", "This is what leadership actually looks like"
+
+**Structures (references/structures.md)**
+- Binary contrasts: "Not X. But Y.", "It's not this. It's that.", "stops being X and starts being Y"
+- Rhythm patterns: staccato fragmentation, dashes for dramatic pause, hedging as reassurance
+- Word patterns: absolute words (always, never, everyone, etc.), AI-overused intensifiers (deeply, truly, fundamentally, inherently, simply, literally, inevitably)
+
+## 2026-01-12
+
+- Restructured skill following Claude Code best practices (PR #1)
+- Split into SKILL.md and references/ folder
+
+## 2025-01-12
+
+- Initial release

--- a/.claude/skills/stop-slop/LICENSE
+++ b/.claude/skills/stop-slop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Hardik Pandya
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.claude/skills/stop-slop/README.md
+++ b/.claude/skills/stop-slop/README.md
@@ -1,0 +1,62 @@
+# Stop Slop
+
+A skill for removing AI tells from prose.
+
+<img width="3840" height="2160" alt="G-Yg4RVbIAAhVxW" src="https://github.com/user-attachments/assets/902afc15-1f40-4a9d-af24-8cd67afb8ebf" />
+
+## What this is
+
+AI writing has patterns. Predictable phrases, structures, rhythms. This skill teaches Claude (or any LLM) to catch and remove them.
+
+## Skill Structure
+
+```
+stop-slop/
+├── SKILL.md              # Core instructions
+├── references/
+│   ├── phrases.md        # Phrases to remove
+│   ├── structures.md     # Structural patterns to avoid
+│   └── examples.md       # Before/after transformations
+├── README.md
+└── LICENSE
+```
+
+## Quick start
+
+**Claude Code:** Add this folder as a skill.
+
+**Claude Projects:** Upload `SKILL.md` and reference files to project knowledge.
+
+**Custom instructions:** Copy core rules from `SKILL.md`.
+
+**API calls:** Include `SKILL.md` in your system prompt. Reference files load on demand.
+
+## What it catches
+
+**Banned phrases** - Throat-clearing openers, emphasis crutches, business jargon, all adverbs, vague declaratives, meta-commentary. See `references/phrases.md`.
+
+**Structural clichés** - Binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency, narrator-from-a-distance voice, passive voice. See `references/structures.md`.
+
+**Sentence-level rules** - No Wh- sentence starters, no em dashes, no staccato fragmentation, no lazy extremes, active voice required.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Author
+
+[Hardik Pandya](https://hvpandya.com)
+
+## License
+
+MIT. Use freely, share widely.

--- a/.claude/skills/stop-slop/SKILL.md
+++ b/.claude/skills/stop-slop/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: stop-slop
+description: Remove AI writing patterns from prose. Use when drafting, editing, or reviewing text to eliminate predictable AI tells.
+metadata:
+  trigger: Writing prose, editing drafts, reviewing content for AI patterns
+  author: Hardik Pandya (https://hvpandya.com)
+---
+
+# Stop Slop
+
+Eliminate predictable AI writing patterns from prose.
+
+## Core Rules
+
+1. **Cut filler phrases.** Remove throat-clearing openers, emphasis crutches, and all adverbs. See [references/phrases.md](references/phrases.md).
+
+2. **Break formulaic structures.** Avoid binary contrasts, negative listings, dramatic fragmentation, rhetorical setups, false agency. See [references/structures.md](references/structures.md).
+
+3. **Use active voice.** Every sentence needs a human subject doing something. No passive constructions. No inanimate objects performing human actions ("the complaint becomes a fix").
+
+4. **Be specific.** No vague declaratives ("The reasons are structural"). Name the specific thing. No lazy extremes ("every," "always," "never") doing vague work.
+
+5. **Put the reader in the room.** No narrator-from-a-distance voice. "You" beats "People." Specifics beat abstractions.
+
+6. **Vary rhythm.** Mix sentence lengths. Two items beat three. End paragraphs differently. No em dashes.
+
+7. **Trust readers.** State facts directly. Skip softening, justification, hand-holding.
+
+8. **Cut quotables.** If it sounds like a pull-quote, rewrite it.
+
+## Quick Checks
+
+Before delivering prose:
+
+- Any adverbs? Kill them.
+- Any passive voice? Find the actor, make them the subject.
+- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
+- Sentence starts with a Wh- word? Restructure it.
+- Any "here's what/this/that" throat-clearing? Cut to the point.
+- Any "not X, it's Y" contrasts? State Y directly.
+- Three consecutive sentences match length? Break one.
+- Paragraph ends with punchy one-liner? Vary it.
+- Em-dash anywhere? Remove it.
+- Vague declarative ("The implications are significant")? Name the specific implication.
+- Narrator-from-a-distance ("Nobody designed this")? Put the reader in the scene.
+- Meta-joiners ("The rest of this essay...")? Delete. Let the essay move.
+
+## Scoring
+
+Rate 1-10 on each dimension:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements or announcements? |
+| Rhythm | Varied or metronomic? |
+| Trust | Respects reader intelligence? |
+| Authenticity | Sounds human? |
+| Density | Anything cuttable? |
+
+Below 35/50: revise.
+
+## Examples
+
+See [references/examples.md](references/examples.md) for before/after transformations.
+
+## License
+
+MIT

--- a/.claude/skills/stop-slop/references/examples.md
+++ b/.claude/skills/stop-slop/references/examples.md
@@ -1,0 +1,59 @@
+# Before/After Examples
+
+## Example 1: Throat-Clearing + Binary Contrast
+
+**Before:**
+> "Here's the thing: building products is hard. Not because the technology is complex. Because people are complex. Let that sink in."
+
+**After:**
+> "Building products is hard. Technology is manageable. People aren't."
+
+**Changes:** Removed opener, binary contrast structure, and emphasis crutch. Direct statements.
+
+---
+
+## Example 2: Filler + Unnecessary Reassurance
+
+**Before:**
+> "It turns out that most teams struggle with alignment. The uncomfortable truth is that nobody wants to admit they're confused. And that's okay."
+
+**After:**
+> "Teams struggle with alignment. Nobody admits confusion."
+
+**Changes:** Cut hedging ("most"), removed throat-clearing phrases, deleted permission-granting ending.
+
+---
+
+## Example 3: Business Jargon Stack
+
+**Before:**
+> "In today's fast-paced landscape, we need to lean into discomfort and navigate uncertainty with clarity. This matters because your competition isn't waiting."
+
+**After:**
+> "Move faster. Your competition is."
+
+**Changes:** Eliminated jargon entirely. Core message in six words.
+
+---
+
+## Example 4: Dramatic Fragmentation
+
+**Before:**
+> "Speed. Quality. Cost. You can only pick two. That's it. That's the tradeoff."
+
+**After:**
+> "Speed, quality, cost—pick two."
+
+**Changes:** Single sentence. No performative emphasis.
+
+---
+
+## Example 5: Rhetorical Setup
+
+**Before:**
+> "What if I told you that the best teams don't optimize for productivity? Here's what I mean: they optimize for learning. Think about it."
+
+**After:**
+> "The best teams optimize for learning, not productivity."
+
+**Changes:** Direct claim. No rhetorical scaffolding.

--- a/.claude/skills/stop-slop/references/phrases.md
+++ b/.claude/skills/stop-slop/references/phrases.md
@@ -1,0 +1,128 @@
+# Phrases to Remove
+
+## Throat-Clearing Openers
+
+Remove these announcement phrases. State the content directly.
+
+- "Here's the thing:"
+- "Here's what [X]"
+- "Here's this [X]"
+- "Here's that [X]"
+- "Here's why [X]"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear"
+- "The truth is,"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "Here's what I find interesting"
+- "Here's the problem though"
+
+Any "here's what/this/that" construction is throat-clearing before the point. Cut it and state the point.
+
+## Emphasis Crutches
+
+These add no meaning. Delete them.
+
+- "Full stop." / "Period."
+- "Let that sink in."
+- "This matters because"
+- "Make no mistake"
+- "Here's why that matters"
+
+## Business Jargon
+
+Replace with plain language.
+
+| Avoid | Use instead |
+|-------|-------------|
+| Navigate (challenges) | Handle, address |
+| Unpack (analysis) | Explain, examine |
+| Lean into | Accept, embrace |
+| Landscape (context) | Situation, field |
+| Game-changer | Significant, important |
+| Double down | Commit, increase |
+| Deep dive | Analysis, examination |
+| Take a step back | Reconsider |
+| Moving forward | Next, from now |
+| Circle back | Return to, revisit |
+| On the same page | Aligned, agreed |
+
+## Adverbs
+
+Kill all adverbs. No -ly words. No softeners, no intensifiers, no hedges.
+
+Specific offenders:
+
+- "really"
+- "just"
+- "literally"
+- "genuinely"
+- "honestly"
+- "simply"
+- "actually"
+- "deeply"
+- "truly"
+- "fundamentally"
+- "inherently"
+- "inevitably"
+- "interestingly"
+- "importantly"
+- "crucially"
+
+Also cut these filler phrases:
+
+- "At its core"
+- "In today's [X]"
+- "It's worth noting"
+- "At the end of the day"
+- "When it comes to"
+- "In a world where"
+- "The reality is"
+
+## Meta-Commentary
+
+Remove self-referential asides. The essay should move, not announce its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+
+## Performative Emphasis
+
+False intimacy or manufactured sincerity:
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## Telling Instead of Showing
+
+Announcing difficulty or significance rather than demonstrating it:
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## Vague Declaratives
+
+Sentences that announce importance without naming the specific thing. Kill these.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+If a sentence says something is important/deep/structural without showing the specific thing, cut it or replace it with the specific thing.

--- a/.claude/skills/stop-slop/references/structures.md
+++ b/.claude/skills/stop-slop/references/structures.md
@@ -1,0 +1,134 @@
+# Structures to Avoid
+
+## Binary Contrasts
+
+These create false drama. State the point directly.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not because X. Because Y." / "Not because X, but because Y." | Telegraphed reversal |
+| "[X] isn't the problem. [Y] is." | Formulaic reframe |
+| "The answer isn't X. It's Y." | Predictable pivot |
+| "It feels like X. It's actually Y." | Setup/reveal cliche |
+| "The question isn't X. It's Y." | Rhetorical misdirection |
+| "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y" | Mechanical contrast |
+| "It's not this. It's that." | Same formula, different words |
+| "stops being X and starts being Y" | False transformation arc |
+| "doesn't mean X, but actually Y" | Negation-then-assertion crutch |
+| "is about X but not Y" | False distinction |
+| "not just X but also Y" | Additive hedge |
+
+**Instead:** State Y directly. "The problem is Y." "Y matters here." Drop the negation entirely.
+
+## Negative Listing
+
+Listing what something is *not* before revealing what it *is*. A rhetorical striptease.
+
+| Pattern | Problem |
+|---------|---------|
+| "Not a X... Not a Y... A Z." | Dramatic buildup through negation |
+| "It wasn't X. It wasn't Y. It was Z." | Same structure, past tense |
+
+**Instead:** State Z. The reader doesn't need the runway.
+
+## Dramatic Fragmentation
+
+Sentence fragments for emphasis read as manufactured profundity.
+
+| Pattern | Problem |
+|---------|---------|
+| "[Noun]. That's it. That's the [thing]." | Performative simplicity |
+| "X. And Y. And Z." | Staccato drama |
+| "This unlocks something. [Word]." | Artificial revelation |
+
+**Instead:** Complete sentences. Trust content over presentation.
+
+## Rhetorical Setups
+
+These announce insight rather than deliver it.
+
+| Pattern | Problem |
+|---------|---------|
+| "What if [reframe]?" | Socratic posturing |
+| "Here's what I mean:" | Redundant preview |
+| "Think about it:" | Condescending prompt |
+| "And that's okay." | Unnecessary permission |
+
+**Instead:** Make the point. Let readers draw conclusions.
+
+## Formulaic Constructions
+
+| Pattern | Problem |
+|---------|---------|
+| "By the time X, I was Y." | Narrative template |
+| "X that isn't Y" | Indirect. Say "X is broken" |
+
+## False Agency
+
+Giving inanimate things human verbs. Complaints don't "become" fixes. Bets don't "live or die." Decisions don't "emerge." A person does something to make those things happen. AI loves this because it avoids naming the actor.
+
+| Pattern | Problem |
+|---------|---------|
+| "a complaint becomes a fix" | The complaint did nothing. Someone fixed it. |
+| "a bet lives or dies in days" | Bets don't have lifespans. Someone kills the project or ships it. |
+| "the decision emerges" | Decisions don't emerge. Someone decides. |
+| "the culture shifts" | Cultures don't shift on their own. People change behavior. |
+| "the conversation moves toward" | Conversations don't move. Someone steers. |
+| "the data tells us" | Data sits there. Someone reads it and draws a conclusion. |
+| "the market rewards" | Markets don't reward. Buyers pay for things. |
+
+**Instead:** Name the human. "The team fixed it that week" beats "the complaint becomes a fix." If no specific person fits, use "you" to put the reader in the seat.
+
+## Narrator-from-a-Distance
+
+Floating above the scene instead of putting the reader in it.
+
+| Pattern | Problem |
+|---------|---------|
+| "Nobody designed this." | Disembodied observation |
+| "This happens because..." | Lecturer voice |
+| "This is why..." | Same |
+| "People tend to..." | Armchair sociologist |
+
+**Instead:** Put the reader in the room. "You don't sit down one day and decide to..." beats "Nobody designed this."
+
+## Passive Voice
+
+Every sentence needs a subject doing something. Passive voice hides the actor and drains energy.
+
+| Pattern | Fix |
+|---------|-----|
+| "X was created" | Name who created it |
+| "It is believed that" | Name who believes it |
+| "Mistakes were made" | Name who made them |
+| "The decision was reached" | Name who decided |
+
+**Instead:** Find the actor. Put them at the front of the sentence.
+
+## Sentence Starters to Avoid
+
+| Pattern | Fix |
+|---------|-----|
+| Sentences starting with What, When, Where, Which, Who, Why, How | Restructure. Lead with the subject or the verb. |
+| Paragraphs starting with "So" | Start with content |
+| Sentences starting with "Look," | Remove |
+
+Wh- openers become a crutch. "What makes this hard is..." becomes "The constraint is..." or better, name the specific constraint.
+
+## Rhythm Patterns
+
+| Pattern | Fix |
+|---------|-----|
+| Three-item lists | Use two items or one |
+| Questions answered immediately | Let questions breathe or cut them |
+| Every paragraph ends punchily | Vary endings |
+| Em-dashes | Remove. Use commas or periods. No em dashes at all. |
+| Staccato fragmentation | Don't stack short punchy sentences |
+| "Not always. Not perfectly." | Hedging disguised as reassurance |
+
+## Word Patterns
+
+| Pattern | Problem |
+|---------|---------|
+| Lazy extremes (every, always, never, everyone, everybody, nobody) | False authority. Use specifics instead of sweeping claims. |
+| All adverbs (-ly words, "really," "just," "literally," "genuinely," "honestly," "simply," "actually") | Empty emphasis. See phrases.md for full list. |

--- a/.github/instructions/use-ste.instructions.md
+++ b/.github/instructions/use-ste.instructions.md
@@ -1,0 +1,6 @@
+---
+description: Use ASD-STE100 (https://en.wikipedia.org/wiki/Simplified_Technical_English) when possible
+applyTo: '**'
+---
+
+Use ASD-STE100 when possible

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,6 +1,5 @@
 lockfile_version: '1'
-generated_at: '2026-08-11T19:23:49.801525+00:00'
-generated_at: '2026-08-11T19:23:49.801525+00:00'
+generated_at: '2026-08-23T01:58:05.783917+00:00'
 apm_version: 0.28.0
 dependencies:
 - repo_url: dietrichgebert/ponytail
@@ -86,7 +85,6 @@ dependencies:
     .github/hooks/scripts/ponytail/hooks/ponytail-subagent.js: sha256:7f6bee86702a488d29ef0dcaabf424bbe2aca345a6a642319d43a1fe0276792e
   content_hash: sha256:17a5d405c7a1b9ef17969bc14deacaa78ae420fb453c0f2b1f7170d530e55b26
   is_dev: true
-  is_dev: true
 - repo_url: juliusbrussee/caveman
   materialization_repo_url: JuliusBrussee/caveman
   name: caveman-commit
@@ -110,26 +108,69 @@ dependencies:
     .claude/skills/caveman-commit/SKILL.md: sha256:58db7b8efab911a629c26e7132517d9076e4e3645009eb604cb8c25663477841
   content_hash: sha256:790a4eeace0be35c6691faf923518ba5bd50f1f1305d1101d09dd4971be94e00
   is_dev: true
+- repo_url: tylerbutler/apm-base
+  name: apm-base
+  host: github.com
+  resolved_commit: a810769689c28268488834cfacb0f704ecbc1f9d
+  version: 0.2.2
+  package_type: apm_package
+  deployed_files:
+  - .agents/skills/prose-banlist
+  - .agents/skills/prose-banlist/SKILL.md
+  - .claude/rules/use-ste.md
+  - .claude/skills/prose-banlist
+  - .claude/skills/prose-banlist/SKILL.md
+  - .github/instructions/use-ste.instructions.md
+  deployed_file_hashes:
+    .agents/skills/prose-banlist/SKILL.md: sha256:48330781d0d69dc91cf4ef295fadc04d6d14f5a195d82b293d31677829e6f2b0
+    .claude/rules/use-ste.md: sha256:6bfec65cbeaf6e78cf7885d6119fb868ad789db4a34a7dd28c2e71abfe69f803
+    .claude/skills/prose-banlist/SKILL.md: sha256:48330781d0d69dc91cf4ef295fadc04d6d14f5a195d82b293d31677829e6f2b0
+    .github/instructions/use-ste.instructions.md: sha256:c4512aac8ae85c13578effb80b704cc72a14a6a13a3c5f3db036ca2e899513de
+  content_hash: sha256:b10858094b9c569b54852cc3f84556cf28bc1662d9cf6d8316753e2018cf1791
+  is_dev: true
+- repo_url: hardikpandya/stop-slop
+  name: stop-slop
+  host: github.com
+  resolved_commit: 8da1f030185bdfe8471220585162991eaeb970e9
+  version: unknown
+  depth: 2
+  resolved_by: tylerbutler/apm-base
+  package_type: claude_skill
+  deployed_files:
+  - .agents/skills/stop-slop
+  - .agents/skills/stop-slop/CHANGELOG.md
+  - .agents/skills/stop-slop/LICENSE
+  - .agents/skills/stop-slop/README.md
+  - .agents/skills/stop-slop/SKILL.md
+  - .agents/skills/stop-slop/references/examples.md
+  - .agents/skills/stop-slop/references/phrases.md
+  - .agents/skills/stop-slop/references/structures.md
+  - .claude/skills/stop-slop
+  - .claude/skills/stop-slop/CHANGELOG.md
+  - .claude/skills/stop-slop/LICENSE
+  - .claude/skills/stop-slop/README.md
+  - .claude/skills/stop-slop/SKILL.md
+  - .claude/skills/stop-slop/references/examples.md
+  - .claude/skills/stop-slop/references/phrases.md
+  - .claude/skills/stop-slop/references/structures.md
+  deployed_file_hashes:
+    .agents/skills/stop-slop/CHANGELOG.md: sha256:fe2f1484ef02abf22efc09def89bac186a2235831fd0da13d4895edb19cc6dd0
+    .agents/skills/stop-slop/LICENSE: sha256:2e2b2beaf41cc0ce28485455a62aed81777cdcdf68702e142427aef1cd720f2c
+    .agents/skills/stop-slop/README.md: sha256:d5c699e712e62d286aa4314e6b4ba02cde7a9da36ce56102660f98d1a8ceebba
+    .agents/skills/stop-slop/SKILL.md: sha256:7432a1d9ebdd42b27666da8458af252edf549f723fb14bcd4791425103930310
+    .agents/skills/stop-slop/references/examples.md: sha256:49c592899eb4457f95d0767e15e3143569e2cef50f2927c3174e62432984cd3d
+    .agents/skills/stop-slop/references/phrases.md: sha256:4ca1b7e97123b5c67eff3dc97e5e977332e0b24021265c1553888a93ec33fa93
+    .agents/skills/stop-slop/references/structures.md: sha256:ffbf1316c7fb5aaf552de005609a64a9639b546ecd76bfb0e482864d5bbe6f58
+    .claude/skills/stop-slop/CHANGELOG.md: sha256:fe2f1484ef02abf22efc09def89bac186a2235831fd0da13d4895edb19cc6dd0
+    .claude/skills/stop-slop/LICENSE: sha256:2e2b2beaf41cc0ce28485455a62aed81777cdcdf68702e142427aef1cd720f2c
+    .claude/skills/stop-slop/README.md: sha256:d5c699e712e62d286aa4314e6b4ba02cde7a9da36ce56102660f98d1a8ceebba
+    .claude/skills/stop-slop/SKILL.md: sha256:7432a1d9ebdd42b27666da8458af252edf549f723fb14bcd4791425103930310
+    .claude/skills/stop-slop/references/examples.md: sha256:49c592899eb4457f95d0767e15e3143569e2cef50f2927c3174e62432984cd3d
+    .claude/skills/stop-slop/references/phrases.md: sha256:4ca1b7e97123b5c67eff3dc97e5e977332e0b24021265c1553888a93ec33fa93
+    .claude/skills/stop-slop/references/structures.md: sha256:ffbf1316c7fb5aaf552de005609a64a9639b546ecd76bfb0e482864d5bbe6f58
+  content_hash: sha256:2e93df9fc59dbc268f98b75b51be8751f8db4e8c3943bb7f4beafa244a05785a
   is_dev: true
 deployments:
-- kind: project-relative
-  target: agents
-  value: .agents/skills/trellis-onboarding
-  runtime: null
-  scope: project
-  owners:
-  - .
-  active_owner: .
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/trellis-onboarding/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - .
-  active_owner: .
-  content_hash: sha256:2b147d03e89aca49126605bf858828428c6c6f3640d71c0e018d7fde7eaa3ef3
 - kind: project-relative
   target: agents
   value: .agents/skills/trellis-onboarding
@@ -238,6 +279,15 @@ deployments:
   - .
   active_owner: .
   content_hash: sha256:7bfa0b61b27e7f8aa782881e243ff010a542615ce14f0ce917615b23dcea1cd4
+- kind: project-relative
+  target: claude
+  value: .claude/rules/use-ste.md
+  runtime: null
+  scope: project
+  owners:
+  - tylerbutler/apm-base
+  active_owner: tylerbutler/apm-base
+  content_hash: sha256:6bfec65cbeaf6e78cf7885d6119fb868ad789db4a34a7dd28c2e71abfe69f803
 - kind: project-relative
   target: claude
   value: .claude/skills/caveman-commit
@@ -375,22 +425,94 @@ deployments:
   content_hash: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
 - kind: project-relative
   target: claude
-  value: .claude/skills/trellis-onboarding
+  value: .claude/skills/prose-banlist
   runtime: null
   scope: project
   owners:
-  - .
-  active_owner: .
+  - tylerbutler/apm-base
+  active_owner: tylerbutler/apm-base
   content_hash: null
 - kind: project-relative
   target: claude
-  value: .claude/skills/trellis-onboarding/SKILL.md
+  value: .claude/skills/prose-banlist/SKILL.md
   runtime: null
   scope: project
   owners:
-  - .
-  active_owner: .
-  content_hash: sha256:2b147d03e89aca49126605bf858828428c6c6f3640d71c0e018d7fde7eaa3ef3
+  - tylerbutler/apm-base
+  active_owner: tylerbutler/apm-base
+  content_hash: sha256:48330781d0d69dc91cf4ef295fadc04d6d14f5a195d82b293d31677829e6f2b0
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/CHANGELOG.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:fe2f1484ef02abf22efc09def89bac186a2235831fd0da13d4895edb19cc6dd0
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/LICENSE
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:2e2b2beaf41cc0ce28485455a62aed81777cdcdf68702e142427aef1cd720f2c
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/README.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:d5c699e712e62d286aa4314e6b4ba02cde7a9da36ce56102660f98d1a8ceebba
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:7432a1d9ebdd42b27666da8458af252edf549f723fb14bcd4791425103930310
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/references/examples.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:49c592899eb4457f95d0767e15e3143569e2cef50f2927c3174e62432984cd3d
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/references/phrases.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:4ca1b7e97123b5c67eff3dc97e5e977332e0b24021265c1553888a93ec33fa93
+- kind: project-relative
+  target: claude
+  value: .claude/skills/stop-slop/references/structures.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:ffbf1316c7fb5aaf552de005609a64a9639b546ecd76bfb0e482864d5bbe6f58
 - kind: project-relative
   target: claude
   value: .claude/skills/trellis-onboarding
@@ -546,6 +668,96 @@ deployments:
   content_hash: sha256:1316a2f3f95741d2300b116fe0c2d81ce4a9568656ed0a62643f54aaf09957f2
 - kind: project-relative
   target: copilot
+  value: .agents/skills/prose-banlist
+  runtime: null
+  scope: project
+  owners:
+  - tylerbutler/apm-base
+  active_owner: tylerbutler/apm-base
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/prose-banlist/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - tylerbutler/apm-base
+  active_owner: tylerbutler/apm-base
+  content_hash: sha256:48330781d0d69dc91cf4ef295fadc04d6d14f5a195d82b293d31677829e6f2b0
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/CHANGELOG.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:fe2f1484ef02abf22efc09def89bac186a2235831fd0da13d4895edb19cc6dd0
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/LICENSE
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:2e2b2beaf41cc0ce28485455a62aed81777cdcdf68702e142427aef1cd720f2c
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/README.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:d5c699e712e62d286aa4314e6b4ba02cde7a9da36ce56102660f98d1a8ceebba
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:7432a1d9ebdd42b27666da8458af252edf549f723fb14bcd4791425103930310
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/references/examples.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:49c592899eb4457f95d0767e15e3143569e2cef50f2927c3174e62432984cd3d
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/references/phrases.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:4ca1b7e97123b5c67eff3dc97e5e977332e0b24021265c1553888a93ec33fa93
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/stop-slop/references/structures.md
+  runtime: null
+  scope: project
+  owners:
+  - hardikpandya/stop-slop
+  active_owner: hardikpandya/stop-slop
+  content_hash: sha256:ffbf1316c7fb5aaf552de005609a64a9639b546ecd76bfb0e482864d5bbe6f58
+- kind: project-relative
+  target: copilot
   value: .github/hooks/ponytail-copilot-hooks.json
   runtime: null
   scope: project
@@ -634,6 +846,15 @@ deployments:
   - .
   active_owner: .
   content_hash: sha256:d0f928dfdf98b1ddee5e676e212cff34c866c65cf839952c9d62c730068d7c1e
+- kind: project-relative
+  target: copilot
+  value: .github/instructions/use-ste.instructions.md
+  runtime: null
+  scope: project
+  owners:
+  - tylerbutler/apm-base
+  active_owner: tylerbutler/apm-base
+  content_hash: sha256:c4512aac8ae85c13578effb80b704cc72a14a6a13a3c5f3db036ca2e899513de
 local_deployed_files:
 - .agents/skills/trellis-onboarding
 - .agents/skills/trellis-onboarding/SKILL.md

--- a/apm.yml
+++ b/apm.yml
@@ -8,6 +8,7 @@ targets:
 
 devDependencies:
   apm:
+    - tylerbutler/apm-base
     # - tylerbutler/agent-marketplace/plugins/repo-tools
     # - tylerbutler/agent-marketplace/plugins/specialists
     - JuliusBrussee/caveman/skills/caveman-commit


### PR DESCRIPTION
## Summary
- Add `tylerbutler/apm-base` as a new APM target, pulling in the `prose-banlist` and `stop-slop` skills (mirrored under both `.agents/skills/` and `.claude/skills/`)
- Replace the `no-laziness` rule with a `use-ste` rule asking for ASD-STE100 (Simplified Technical English) where possible, and mirror it as a Copilot instructions file (`.github/instructions/use-ste.instructions.md`)
- Update `apm.lock.yaml` accordingly
