### PR TITLE
feat: add pin command for git dependency pinning

### DIFF
--- a/.changes/unreleased/Added-20260830-pin-command.yaml
+++ b/.changes/unreleased/Added-20260830-pin-command.yaml
@@ -1,0 +1,7 @@
+component: pin
+kind: Added
+body: |-
+  **`trellis pin` pins git dependency refs to commit SHAs, ratchet-style.** A symbolic ref (`ref = "lattice_core-v1"`) is readable but not reproducible; a bare SHA is auditable but loses the intent. `pin` keeps both: it resolves each symbolic ref with `git ls-remote`, rewrites `ref` to the commit SHA, and records the original in a `# trellis:pin <ref>` comment on the dependency's own line, leaving the rest of `gleam.toml` byte-for-byte intact. The locked commit in `manifest.toml` is patched surgically, without `gleam update`.
+
+    `--update` re-resolves every recorded ref and rewrites the SHAs that moved — following a series becomes a reviewable diff instead of a silent re-resolution. `--unpin` restores the symbolic refs. `--check` fails (exit 1, for CI) when a pinned SHA is no longer reachable from its tracked ref — the signal that a tag or branch was force-moved past it; `doctor` reports the same drift as an advisory warning.
+time: 2026-08-30T12:00:00.000000-07:00

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -36,6 +36,7 @@ components:
     - tag
     - publish
     - lockfile
+    - pin
     - doctor
     - ci
     - completions

--- a/assets/man/trellis-pin.1
+++ b/assets/man/trellis-pin.1
@@ -1,0 +1,56 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH trellis-pin 1 "" trellis "Trellis Manual"
+.SH NAME
+trellis\-pin \- Pin git dependency refs to commit SHAs, recording the tracked ref
+.SH SYNOPSIS
+\fBtrellis pin\fR [\fB\-C\fR|\fB\-\-directory\fR] [\fB\-\-update\fR] [\fB\-\-check\fR] [\fB\-\-color\fR] [\fB\-q\fR|\fB\-\-quiet\fR] [\fB\-\-unpin\fR] [\fB\-v\fR|\fB\-\-verbose\fR] [\fB\-\-no\-update\-check\fR] [\fB\-h\fR|\fB\-\-help\fR] [\fIPACKAGES\fR] 
+.SH DESCRIPTION
+Pin git dependency refs to commit SHAs, recording the tracked ref
+.PP
+Rewrites each symbolic `ref` in `[dependencies]`/`[dev\-dependencies]` to the commit it resolves to and records the original in a trailing `# trellis:pin <ref>` comment, ratchet\-style: the dependency becomes reproducible without losing what to bump it to. Following the ref again is a deliberate, reviewable `\-\-update` diff instead of a silent re\-resolution; deleting the comment simply stops updates.
+.SH OPTIONS
+.TP
+\fB\-C\fR, \fB\-\-directory\fR \fI<DIR>\fR
+Run as if started in this directory
+.TP
+\fB\-\-update\fR
+Re\-resolve every recorded `# trellis:pin` ref and rewrite the SHAs that moved
+.TP
+\fB\-\-check\fR
+Verify each pinned SHA is still reachable from its tracked ref; non\-zero exit on drift (for CI)
+.TP
+\fB\-\-color\fR \fI<WHEN>\fR [default: auto]
+When to color output. `auto` follows the terminal, `NO_COLOR`, and `CLICOLOR=0`; the other two override that detection
+.br
+
+.br
+\fIPossible values:\fR
+.RS 14
+.IP \(bu 2
+auto
+.IP \(bu 2
+always
+.IP \(bu 2
+never
+.RE
+.TP
+\fB\-q\fR, \fB\-\-quiet\fR
+Suppress normal\-path output; JSON/report payloads and errors still print
+.TP
+\fB\-\-unpin\fR
+Restore the symbolic refs and remove the pin comments
+.TP
+\fB\-v\fR, \fB\-\-verbose\fR
+Trace every command trellis shells out to, on stderr
+.TP
+\fB\-\-no\-update\-check\fR
+Don\*(Aqt check whether a newer trellis release is available
+
+The check is also skipped in CI, when not attached to a terminal, and when `TRELLIS_NO_UPDATE_CHECK` or `DO_NOT_TRACK` is set.
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+[\fIPACKAGES\fR]
+Packages whose git dependencies to pin; all packages when omitted

--- a/assets/man/trellis.1
+++ b/assets/man/trellis.1
@@ -84,6 +84,9 @@ Publish packages to Hex, in dependency order, with path deps rewritten
 trellis\-lockfile(1)
 Lockfile maintenance
 .TP
+trellis\-pin(1)
+Pin git dependency refs to commit SHAs, recording the tracked ref
+.TP
 trellis\-doctor(1)
 Validate workspace invariants; non\-zero exit on any error
 .TP

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -476,6 +476,55 @@ trellis lockfile refresh [--package <pkg>]
   encoding the "don't refresh the whole workspace or you'll get rate-limited"
   rule from publish.yml:124-133 as behavior instead of a comment.
 
+### Dependency pinning
+
+```
+trellis pin [pkgs...]            # resolve symbolic git refs to SHAs, record intent
+trellis pin --update [pkgs...]   # re-resolve each recorded intent to its latest SHA
+trellis pin --check [pkgs...]    # fail if a pinned SHA is not reachable from its tracked ref
+trellis pin --unpin [pkgs...]    # restore the symbolic refs
+```
+
+The consumer half of series tags. A release force-moves `{name}-v{series}`
+tags so that consumers can track a series (§4); `pin` gives those consumers
+the ratchet workflow for gleam git dependencies. A mutable ref (`ref =
+"lattice_core-v1"`) is readable but not reproducible: the tag moves, and a
+re-resolve follows it silently. An immutable ref (`ref = "a1b2c3d"`) is
+auditable but loses the intent, so nobody knows what to bump it to. `pin`
+keeps both in `gleam.toml`, in the same style as
+[ratchet](https://github.com/sethvargo/ratchet) does for GitHub Actions:
+
+```toml
+[dependencies]
+lattice_core = { git = "https://github.com/x/lattice", ref = "4f2a9c81…", path = "packages/lattice_core" } # trellis:pin lattice_core-v1
+```
+
+- `pin` scans `[dependencies]` and `[dev-dependencies]` of the selected
+  members for git requirements whose `ref` is not a full commit SHA. It
+  resolves each with `git ls-remote <url> <ref>` — no clone, any host,
+  authentication through git's own credential machinery — then rewrites `ref`
+  to the SHA and appends the `# trellis:pin <ref>` comment. `toml_edit`
+  preserves the rest of the file byte for byte, the same surgical approach as
+  the `manifest.toml` version patching (§9).
+- The comment is the record of intent. It lives on the dependency's own line,
+  so it survives copy-paste between manifests and needs no separate table
+  that could orphan when a dependency is removed. A pinned dependency whose
+  comment is deleted simply stops updating — safe by default.
+- `--update` re-resolves every `# trellis:pin` comment and rewrites the SHAs
+  that moved. The result is a plain `gleam.toml` diff to review, which is the
+  point: following a series becomes a deliberate, visible bump instead of a
+  silent re-resolution.
+- `--check` verifies that each pinned SHA is an ancestor of (or equal to) the
+  commit its tracked ref points at now. A SHA no longer reachable from its
+  ref means the tag or branch was force-moved past it — the supply-chain
+  signal this exists to catch. `doctor` runs the same check as a warning;
+  `pin --check` exits non-zero for use as a CI step.
+- After a rewrite, the locked commit in `manifest.toml` is stale. `pin`
+  patches it surgically rather than running `gleam update`, consistent with
+  the rate-limit posture of `lockfile refresh`.
+- Prerelease refs and semver-range tracking (`v1.*`) are out of scope: series
+  tags already give every level a stable name to track.
+
 ### CI glue
 
 ```

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -198,6 +198,7 @@ fn inspect(root: &Path) -> Result<Report> {
         check_exclusions(workspace, &mut report);
         check_tag_collisions(workspace, &mut report);
         check_lockfiles(workspace, &mut report);
+        check_pinned_refs(workspace, &mut report);
         check_changelogs(workspace, &mut report);
         check_fragments(workspace, &mut report);
         check_shared_dependencies(workspace, &mut report);
@@ -216,6 +217,7 @@ pub fn run(root: &Path, options: &DoctorOptions) -> Result<bool> {
             "task exclusion globs match members; no package depends on one unavailable at its release lifecycle",
             "tag format produces a unique tag per releasable package",
             "manifest.toml locked versions match workspace-internal gleam.toml versions",
+            "pinned git dependency SHAs remain reachable from their tracked refs (advisory)",
             "each releasable package's version is not behind its CHANGELOG",
             "unreleased changelog fragments parse and reference valid packages, kinds, and categories",
             "[tools.trellis] carries no unrecognized or deprecated keys",
@@ -824,6 +826,29 @@ fn check_lockfiles(workspace: &Workspace, report: &mut Report) {
             path,
             contents: new_text,
         });
+    }
+}
+
+/// Advisory: each `# trellis:pin` tracked ref should still contain its pinned
+/// SHA. Warnings, not errors — the check needs the network, and re-pinning is
+/// a supply-chain decision `--fix` must not make. `trellis pin --check` is the
+/// enforcing form.
+fn check_pinned_refs(workspace: &Workspace, report: &mut Report) {
+    let indices: Vec<usize> = (0..workspace.members.len()).collect();
+    match crate::commands::pin::check_pins(workspace, &indices) {
+        Ok(drifts) => {
+            for drift in drifts {
+                report.push(
+                    Finding::warning(Check::PinnedRef, drift.message)
+                        .at(&drift.rel_path)
+                        .in_package(&drift.package),
+                );
+            }
+        }
+        Err(err) => report.push(Finding::warning(
+            Check::PinnedRef,
+            format!("could not verify pinned refs: {err:#}"),
+        )),
     }
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod init;
 pub mod list;
 pub mod lockfile;
 pub mod new;
+pub mod pin;
 pub mod publish;
 pub mod release;
 pub mod run;

--- a/src/commands/pin.rs
+++ b/src/commands/pin.rs
@@ -1,0 +1,537 @@
+//! `trellis pin` — the consumer half of series tags: rewrite symbolic git
+//! dependency refs to commit SHAs, recording the tracked ref in a
+//! `# trellis:pin <ref>` comment on the dependency's own line
+//! (ratchet-style). The comment is the record of intent: `--update`
+//! re-resolves it, `--unpin` restores it, `--check` verifies the pinned SHA
+//! is still reachable from it, and a dependency whose comment is deleted
+//! simply stops updating — safe by default.
+
+use crate::workspace::{SelectionFilter, Workspace};
+use anyhow::{Context, Result};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+use toml_edit::{DocumentMut, Value};
+
+/// The comment marker recording a pinned dependency's tracked ref. The
+/// trailing space is part of the marker: `# trellis:pin` with no ref after it
+/// is not a pin.
+const MARKER: &str = "# trellis:pin ";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Resolve symbolic refs to SHAs and record the intent.
+    Pin,
+    /// Re-resolve each recorded intent to its latest SHA.
+    Update,
+    /// Fail if a pinned SHA is not reachable from its tracked ref.
+    Check,
+    /// Restore the symbolic refs.
+    Unpin,
+}
+
+pub struct PinOptions {
+    pub mode: Mode,
+    /// Explicit package names; empty means all members.
+    pub packages: Vec<String>,
+}
+
+/// One pinned dependency whose tracked ref no longer contains its SHA (or
+/// whose pin comment disagrees with its ref). Shared with `doctor`, which
+/// reports these as warnings where `pin --check` exits non-zero.
+pub struct Drift {
+    pub package: String,
+    /// Workspace-relative path of the gleam.toml, forward slashes.
+    pub rel_path: String,
+    pub message: String,
+}
+
+/// A git requirement found in a member's gleam.toml.
+#[derive(Debug, PartialEq, Eq)]
+struct GitDep {
+    section: &'static str,
+    name: String,
+    url: String,
+    git_ref: String,
+    /// The tracked ref from a `# trellis:pin` comment, when present.
+    pinned: Option<String>,
+}
+
+/// What to do to one dependency: set `ref` to `new_ref`, and set the pin
+/// comment to track `comment` (`None` strips the marker).
+struct RefChange {
+    new_ref: String,
+    comment: Option<String>,
+}
+
+fn is_full_sha(text: &str) -> bool {
+    text.len() == 40 && text.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// The tracked ref recorded in a decor suffix, if any. Everything from the
+/// marker to the next whitespace; git refnames cannot contain spaces.
+fn tracked_ref(suffix: &str) -> Option<&str> {
+    let rest = &suffix[suffix.find(MARKER)? + MARKER.len()..];
+    rest.split_whitespace().next()
+}
+
+fn short(sha: &str) -> &str {
+    &sha[..sha.len().min(7)]
+}
+
+/// Every git requirement in `[dependencies]` and `[dev-dependencies]`.
+/// A `path` key alongside `git` selects a subdirectory of the remote repo
+/// (Gleam 1.18+) and changes nothing here; a git requirement without a `ref`
+/// is skipped (gleam itself rejects it).
+fn scan_git_deps(text: &str) -> Result<Vec<GitDep>> {
+    let doc: DocumentMut = text.parse().context("failed to parse gleam.toml")?;
+    let mut deps = Vec::new();
+    for section in ["dependencies", "dev-dependencies"] {
+        let Some(table) = doc.get(section).and_then(|item| item.as_table_like()) else {
+            continue;
+        };
+        for (name, item) in table.iter() {
+            let Some(value) = item.as_value() else {
+                continue;
+            };
+            let Some(dep) = value.as_inline_table() else {
+                continue;
+            };
+            let Some(url) = dep.get("git").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let Some(git_ref) = dep.get("ref").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let pinned = value
+                .decor()
+                .suffix()
+                .and_then(|raw| raw.as_str())
+                .and_then(tracked_ref)
+                .map(str::to_string);
+            deps.push(GitDep {
+                section,
+                name: name.to_string(),
+                url: url.to_string(),
+                git_ref: git_ref.to_string(),
+                pinned,
+            });
+        }
+    }
+    Ok(deps)
+}
+
+/// Apply `changes` (keyed by section and dependency name), touching nothing
+/// else: the `ref` value keeps its decor, and the pin comment is edited
+/// within the line's existing suffix, preserving any unrelated trailing
+/// comment in front of it. Returns the new text and whether anything changed.
+fn apply_changes(
+    text: &str,
+    changes: &BTreeMap<(String, String), RefChange>,
+) -> Result<(String, bool)> {
+    let mut doc: DocumentMut = text.parse().context("failed to parse gleam.toml")?;
+    let mut changed = false;
+    for ((section, name), change) in changes {
+        let Some(value) = doc
+            .get_mut(section)
+            .and_then(|item| item.as_table_like_mut())
+            .and_then(|table| table.get_mut(name))
+            .and_then(|item| item.as_value_mut())
+        else {
+            continue;
+        };
+        if let Some(reference) = value
+            .as_inline_table_mut()
+            .and_then(|dep| dep.get_mut("ref"))
+            && reference.as_str() != Some(change.new_ref.as_str())
+        {
+            let mut replacement = Value::from(change.new_ref.clone());
+            *replacement.decor_mut() = reference.decor().clone();
+            *reference = replacement;
+            changed = true;
+        }
+        let decor = value.decor_mut();
+        let old_suffix = decor
+            .suffix()
+            .and_then(|raw| raw.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let base = match old_suffix.find(MARKER) {
+            Some(idx) => old_suffix[..idx].trim_end(),
+            None => old_suffix.trim_end(),
+        };
+        let new_suffix = match &change.comment {
+            Some(tracked) => format!("{base} {MARKER}{tracked}"),
+            None => base.to_string(),
+        };
+        if new_suffix != old_suffix {
+            decor.set_suffix(new_suffix);
+            changed = true;
+        }
+    }
+    Ok((doc.to_string(), changed))
+}
+
+/// One `ls-remote` per unique (url, ref) across the whole run.
+fn resolve(
+    cache: &mut HashMap<(String, String), Option<String>>,
+    root: &Path,
+    url: &str,
+    refname: &str,
+) -> Result<Option<String>> {
+    let key = (url.to_string(), refname.to_string());
+    if let Some(sha) = cache.get(&key) {
+        return Ok(sha.clone());
+    }
+    let sha = crate::git::ls_remote_commit(root, url, refname)?;
+    cache.insert(key, sha.clone());
+    Ok(sha)
+}
+
+pub fn run(workspace: &Workspace, options: &PinOptions) -> Result<bool> {
+    let indices = workspace.select(&SelectionFilter {
+        names: options.packages.clone(),
+        ..SelectionFilter::default()
+    })?;
+    if options.mode == Mode::Check {
+        let drifts = check_pins(workspace, &indices)?;
+        for drift in &drifts {
+            crate::status!(
+                "{} [{}] {}",
+                crate::term::err("drift:"),
+                crate::term::package(&drift.package),
+                drift.message
+            );
+        }
+        return Ok(drifts.is_empty());
+    }
+
+    let mut cache = HashMap::new();
+    for &idx in &indices {
+        let member = &workspace.members[idx];
+        let path = member.path.join("gleam.toml");
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let mut changes = BTreeMap::new();
+        let mut commits = BTreeMap::new();
+        for dep in
+            scan_git_deps(&text).with_context(|| format!("in {}/gleam.toml", member.rel_path))?
+        {
+            match options.mode {
+                Mode::Pin => {
+                    if is_full_sha(&dep.git_ref) {
+                        continue; // already pinned, or a hand-written SHA
+                    }
+                    let sha = resolve(&mut cache, &workspace.root, &dep.url, &dep.git_ref)?
+                        .with_context(|| {
+                            format!("ref `{}` not found on {}", dep.git_ref, dep.url)
+                        })?;
+                    crate::status!(
+                        "[{}] {} {} {} {}",
+                        crate::term::package(&member.name),
+                        crate::term::ok("pinned"),
+                        dep.name,
+                        short(&sha),
+                        crate::term::dim(&format!("tracking {}", dep.git_ref))
+                    );
+                    commits.insert(dep.name.clone(), sha.clone());
+                    changes.insert(
+                        (dep.section.to_string(), dep.name),
+                        RefChange {
+                            new_ref: sha,
+                            comment: Some(dep.git_ref),
+                        },
+                    );
+                }
+                Mode::Update => {
+                    let Some(tracked) = dep.pinned else {
+                        continue; // no recorded intent; nothing to follow
+                    };
+                    let sha = resolve(&mut cache, &workspace.root, &dep.url, &tracked)?
+                        .with_context(|| {
+                            format!("tracked ref `{tracked}` not found on {}", dep.url)
+                        })?;
+                    if sha == dep.git_ref {
+                        continue;
+                    }
+                    crate::status!(
+                        "[{}] {} {} {} {}",
+                        crate::term::package(&member.name),
+                        crate::term::ok("updated"),
+                        dep.name,
+                        short(&sha),
+                        crate::term::dim(&format!(
+                            "was {}, tracking {tracked}",
+                            short(&dep.git_ref)
+                        ))
+                    );
+                    commits.insert(dep.name.clone(), sha.clone());
+                    changes.insert(
+                        (dep.section.to_string(), dep.name),
+                        RefChange {
+                            new_ref: sha,
+                            comment: Some(tracked),
+                        },
+                    );
+                }
+                Mode::Unpin => {
+                    let Some(tracked) = dep.pinned else {
+                        continue;
+                    };
+                    crate::status!(
+                        "[{}] {} {} {}",
+                        crate::term::package(&member.name),
+                        crate::term::ok("unpinned"),
+                        dep.name,
+                        crate::term::dim(&format!("restored {tracked}"))
+                    );
+                    changes.insert(
+                        (dep.section.to_string(), dep.name),
+                        RefChange {
+                            new_ref: tracked,
+                            comment: None,
+                        },
+                    );
+                }
+                Mode::Check => unreachable!("handled above"),
+            }
+        }
+        if changes.is_empty() {
+            continue;
+        }
+        let (new_text, changed) = apply_changes(&text, &changes)?;
+        if changed {
+            std::fs::write(&path, new_text)
+                .with_context(|| format!("failed to write {}", path.display()))?;
+        }
+        patch_manifest(member, &commits)?;
+    }
+    Ok(true)
+}
+
+/// After a rewrite the locked commit in manifest.toml is stale; patch it
+/// surgically rather than running `gleam update` (same rate-limit posture as
+/// `lockfile refresh`). A missing manifest or entry is fine — gleam will lock
+/// the pinned commit on the next download.
+fn patch_manifest(
+    member: &crate::workspace::Member,
+    commits: &BTreeMap<String, String>,
+) -> Result<()> {
+    let path = member.path.join("manifest.toml");
+    if commits.is_empty() || !path.is_file() {
+        return Ok(());
+    }
+    let text = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let (new_text, patched) = crate::lockfile::patch_locked_commits(&text, commits)
+        .with_context(|| format!("in {}/manifest.toml", member.rel_path))?;
+    if !patched.is_empty() {
+        std::fs::write(&path, new_text)
+            .with_context(|| format!("failed to write {}", path.display()))?;
+    }
+    Ok(())
+}
+
+/// Verify every pinned dependency of the selected members: its tracked ref
+/// must still exist, and its SHA must be an ancestor of (or equal to) the
+/// commit the ref points at now. A SHA no longer reachable means the ref was
+/// force-moved past it — the supply-chain signal this exists to catch.
+/// Ancestry needs the commits locally, so refs whose tip moved are fetched
+/// (commits only) into the workspace's repository.
+pub fn check_pins(workspace: &Workspace, indices: &[usize]) -> Result<Vec<Drift>> {
+    let mut cache = HashMap::new();
+    let mut fetched: HashSet<(String, String)> = HashSet::new();
+    let mut drifts = Vec::new();
+    for &idx in indices {
+        let member = &workspace.members[idx];
+        let path = member.path.join("gleam.toml");
+        let text = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        let rel_path = format!("{}/gleam.toml", member.rel_path);
+        let mut drift = |message: String| {
+            drifts.push(Drift {
+                package: member.name.clone(),
+                rel_path: rel_path.clone(),
+                message,
+            });
+        };
+        for dep in
+            scan_git_deps(&text).with_context(|| format!("in {}/gleam.toml", member.rel_path))?
+        {
+            let Some(tracked) = dep.pinned else {
+                continue; // unpinned deps are not tracked
+            };
+            if !is_full_sha(&dep.git_ref) {
+                drift(format!(
+                    "`{}` has a `# trellis:pin {tracked}` comment but its ref `{}` is not a \
+                     pinned commit SHA (run `trellis pin`)",
+                    dep.name, dep.git_ref
+                ));
+                continue;
+            }
+            let Some(tip) = resolve(&mut cache, &workspace.root, &dep.url, &tracked)? else {
+                drift(format!(
+                    "`{}` tracks `{tracked}`, which no longer exists on {}",
+                    dep.name, dep.url
+                ));
+                continue;
+            };
+            if tip == dep.git_ref {
+                continue; // pinned at the tip itself; no fetch needed
+            }
+            if fetched.insert((dep.url.clone(), tracked.clone())) {
+                crate::git::fetch_ref(&workspace.root, &dep.url, &tracked)?;
+            }
+            if !crate::git::is_ancestor(&workspace.root, &dep.git_ref, &tip)? {
+                drift(format!(
+                    "`{}` is pinned at {} which is not reachable from its tracked ref \
+                     `{tracked}` (now {}) — the ref may have been force-moved",
+                    dep.name,
+                    short(&dep.git_ref),
+                    short(&tip)
+                ));
+            }
+        }
+    }
+    Ok(drifts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SHA: &str = "4f2a9c8144f5c1622fe1e33b21ceca82a67df2ba";
+
+    fn text() -> String {
+        concat!(
+            "name = \"gp_app\"\n",
+            "version = \"0.2.0\"\n",
+            "\n",
+            "[dependencies]\n",
+            "gleam_stdlib = \">= 0.34.0 and < 2.0.0\"\n",
+            "gp_core = { path = \"../gp_core\" }\n",
+            "remote_lib = { git = \"https://example.com/mono.git\", ref = \"main\", path = \"packages/remote_lib\" }\n",
+            "\n",
+            "[dev-dependencies]\n",
+            "fork = { git = \"https://example.com/fork.git\", ref = \"v2\" } # keep\n",
+        )
+        .to_string()
+    }
+
+    fn change(
+        section: &str,
+        name: &str,
+        new_ref: &str,
+        comment: Option<&str>,
+    ) -> BTreeMap<(String, String), RefChange> {
+        BTreeMap::from([(
+            (section.to_string(), name.to_string()),
+            RefChange {
+                new_ref: new_ref.to_string(),
+                comment: comment.map(str::to_string),
+            },
+        )])
+    }
+
+    #[test]
+    fn full_sha_is_forty_hex_chars() {
+        assert!(is_full_sha(SHA));
+        assert!(!is_full_sha("main"));
+        assert!(!is_full_sha("4f2a9c8")); // abbreviated
+        assert!(!is_full_sha(&format!("{}g", &SHA[..39]))); // non-hex
+    }
+
+    #[test]
+    fn tracked_ref_grammar() {
+        assert_eq!(tracked_ref(" # trellis:pin main"), Some("main"));
+        assert_eq!(tracked_ref(" # note # trellis:pin v1 "), Some("v1"));
+        assert_eq!(
+            tracked_ref(" # trellis:pin lattice_core-v1"),
+            Some("lattice_core-v1")
+        );
+        assert_eq!(tracked_ref(""), None);
+        assert_eq!(tracked_ref(" # note"), None);
+        assert_eq!(tracked_ref(" # trellis:pin"), None); // marker needs a ref
+        assert_eq!(tracked_ref(" # trellis:pin "), None);
+    }
+
+    #[test]
+    fn scan_finds_git_deps_in_both_sections() {
+        let deps = scan_git_deps(&text()).unwrap();
+        assert_eq!(deps.len(), 2);
+        assert_eq!(deps[0].name, "remote_lib");
+        assert_eq!(deps[0].section, "dependencies");
+        assert_eq!(deps[0].url, "https://example.com/mono.git");
+        assert_eq!(deps[0].git_ref, "main");
+        assert_eq!(deps[0].pinned, None);
+        assert_eq!(deps[1].name, "fork");
+        assert_eq!(deps[1].section, "dev-dependencies");
+        assert_eq!(deps[1].pinned, None); // "# keep" is not a pin
+    }
+
+    #[test]
+    fn scan_reads_the_pin_comment() {
+        let pinned = text().replace(
+            "ref = \"main\", path = \"packages/remote_lib\" }",
+            &format!("ref = \"{SHA}\", path = \"packages/remote_lib\" }} # trellis:pin main"),
+        );
+        let deps = scan_git_deps(&pinned).unwrap();
+        assert_eq!(deps[0].git_ref, SHA);
+        assert_eq!(deps[0].pinned.as_deref(), Some("main"));
+    }
+
+    #[test]
+    fn pin_rewrites_ref_appends_comment_and_preserves_everything_else() {
+        let (pinned, changed) = apply_changes(
+            &text(),
+            &change("dependencies", "remote_lib", SHA, Some("main")),
+        )
+        .unwrap();
+        assert!(changed);
+        assert_eq!(
+            pinned,
+            text().replace(
+                "remote_lib = { git = \"https://example.com/mono.git\", ref = \"main\", path = \"packages/remote_lib\" }",
+                &format!(
+                    "remote_lib = {{ git = \"https://example.com/mono.git\", ref = \"{SHA}\", path = \"packages/remote_lib\" }} # trellis:pin main"
+                ),
+            )
+        );
+        // Idempotent: applying the same change again touches nothing.
+        let (again, changed) = apply_changes(
+            &pinned,
+            &change("dependencies", "remote_lib", SHA, Some("main")),
+        )
+        .unwrap();
+        assert!(!changed);
+        assert_eq!(again, pinned);
+    }
+
+    #[test]
+    fn pin_preserves_an_existing_trailing_comment() {
+        let (pinned, _) = apply_changes(
+            &text(),
+            &change("dev-dependencies", "fork", SHA, Some("v2")),
+        )
+        .unwrap();
+        assert!(pinned.contains(&format!(
+            "fork = {{ git = \"https://example.com/fork.git\", ref = \"{SHA}\" }} # keep # trellis:pin v2"
+        )));
+        let (unpinned, changed) =
+            apply_changes(&pinned, &change("dev-dependencies", "fork", "v2", None)).unwrap();
+        assert!(changed);
+        assert_eq!(unpinned, text());
+    }
+
+    #[test]
+    fn unpin_restores_the_original_text() {
+        let (pinned, _) = apply_changes(
+            &text(),
+            &change("dependencies", "remote_lib", SHA, Some("main")),
+        )
+        .unwrap();
+        let (unpinned, changed) =
+            apply_changes(&pinned, &change("dependencies", "remote_lib", "main", None)).unwrap();
+        assert!(changed);
+        assert_eq!(unpinned, text());
+    }
+}

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -10,6 +10,7 @@
 //! package's list. Only immutable tags can carry a GitHub Release.
 
 use crate::config::TagLevel;
+use crate::git::git_stdout;
 use crate::github::GitHubClient;
 use crate::gleam::GleamManifest;
 use crate::json::TagPlanDocument;
@@ -798,23 +799,6 @@ fn is_series(token: &str) -> bool {
         && parts
             .iter()
             .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
-}
-
-fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
-    crate::term::trace_command("git", args, cwd);
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .context("failed to run git")?;
-    if !output.status.success() {
-        bail!(
-            "git {} failed: {}",
-            args.join(" "),
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 #[cfg(test)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -236,7 +236,110 @@ pub fn identity_fallback_args(cwd: &Path) -> Vec<String> {
     }
 }
 
-fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
+/// The commit a ref names on `url`, from one `ls-remote` — `None` when the
+/// remote has no such ref. Annotated tags resolve to the peeled commit (the
+/// object gleam locks), not the tag object. A name matching several refs
+/// with different commits (say a branch and a tag) is an error.
+pub fn ls_remote_commit(cwd: &Path, url: &str, refname: &str) -> Result<Option<String>> {
+    // The peeled pattern is queried explicitly: ls-remote only prints the
+    // `^{}` line for an annotated tag when a pattern matches it.
+    let peeled = format!("{refname}^{{}}");
+    let args = ["ls-remote", "--exit-code", url, refname, peeled.as_str()];
+    crate::term::trace_command("git", &args, cwd);
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .context("failed to run git")?;
+    match output.status.code() {
+        Some(0) => {}
+        Some(2) => return Ok(None),
+        _ => bail!(
+            "git ls-remote failed for `{refname}` on {url}: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+    }
+    // "<oid>\t<ref>" lines; an annotated tag contributes a second
+    // "<oid>\t<ref>^{}" line carrying the peeled commit, which wins.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut commits: std::collections::BTreeMap<String, String> = Default::default();
+    for line in stdout.lines() {
+        let Some((oid, reference)) = line.split_once('\t') else {
+            continue;
+        };
+        match reference.strip_suffix("^{}") {
+            Some(base) => {
+                commits.insert(base.to_string(), oid.to_string());
+            }
+            None => {
+                commits
+                    .entry(reference.to_string())
+                    .or_insert_with(|| oid.to_string());
+            }
+        }
+    }
+    let mut distinct: Vec<&String> = commits.values().collect();
+    distinct.sort();
+    distinct.dedup();
+    match distinct.len() {
+        0 => Ok(None),
+        1 => Ok(Some(distinct[0].clone())),
+        _ => bail!(
+            "`{refname}` is ambiguous on {url}: it matches {} — use a full refname",
+            commits.keys().cloned().collect::<Vec<_>>().join(", ")
+        ),
+    }
+}
+
+/// Fetch a ref's history (commits only) from `url` into the local repository
+/// so ancestry can be tested. `--filter=tree:0` keeps it cheap; a server that
+/// rejects filters gets one plain retry.
+pub fn fetch_ref(cwd: &Path, url: &str, refname: &str) -> Result<()> {
+    let filtered = [
+        "fetch",
+        "--quiet",
+        "--no-tags",
+        "--filter=tree:0",
+        url,
+        refname,
+    ];
+    if git_stdout(cwd, &filtered).is_ok() {
+        return Ok(());
+    }
+    git_stdout(cwd, &["fetch", "--quiet", "--no-tags", url, refname]).map(|_| ())
+}
+
+/// Whether `ancestor` is an ancestor of (or equal to) `descendant` among
+/// locally-known objects. A commit git doesn't have counts as "no": after
+/// fetching a tracked ref, a pin absent from its history is exactly the
+/// drift being tested for.
+pub fn is_ancestor(cwd: &Path, ancestor: &str, descendant: &str) -> Result<bool> {
+    let args = ["merge-base", "--is-ancestor", ancestor, descendant];
+    crate::term::trace_command("git", &args, cwd);
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .context("failed to run git")?;
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(1) => Ok(false),
+        _ => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let lower = stderr.to_lowercase();
+            if lower.contains("not a valid")
+                || lower.contains("bad object")
+                || lower.contains("bad revision")
+            {
+                Ok(false)
+            } else {
+                bail!("git merge-base --is-ancestor failed: {}", stderr.trim())
+            }
+        }
+    }
+}
+
+pub(crate) fn git_stdout(cwd: &Path, args: &[&str]) -> Result<String> {
     crate::term::trace_command("git", args, cwd);
     let output = Command::new("git")
         .args(args)

--- a/src/json.rs
+++ b/src/json.rs
@@ -57,6 +57,9 @@ pub enum Check {
     TagCollision,
     /// A `manifest.toml` locks a workspace-internal dep at a stale version.
     LockfileDrift,
+    /// A pinned git dependency's SHA is no longer reachable from its tracked
+    /// ref, or its `# trellis:pin` comment disagrees with its ref.
+    PinnedRef,
     /// A releasable package has no `CHANGELOG.md`.
     ChangelogMissing,
     /// A `CHANGELOG.md` exists but could not be read.
@@ -93,6 +96,7 @@ impl Check {
             Check::ReleaseBoundary => "release_boundary",
             Check::TagCollision => "tag_collision",
             Check::LockfileDrift => "lockfile_drift",
+            Check::PinnedRef => "pinned_ref",
             Check::ChangelogMissing => "changelog_missing",
             Check::ChangelogUnreadable => "changelog_unreadable",
             Check::ChangelogBehind => "changelog_behind",
@@ -116,6 +120,7 @@ impl Check {
         Check::ReleaseBoundary,
         Check::TagCollision,
         Check::LockfileDrift,
+        Check::PinnedRef,
         Check::ChangelogMissing,
         Check::ChangelogUnreadable,
         Check::ChangelogBehind,

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -92,6 +92,69 @@ pub fn patch_locked_versions(
     Ok((doc.to_string(), patched))
 }
 
+/// Update `packages[].commit` for every git-sourced entry whose name appears
+/// in `commits` and whose locked commit differs — the lockfile half of
+/// `trellis pin`, with the same surgical contract as
+/// [`patch_locked_versions`].
+pub fn patch_locked_commits(
+    text: &str,
+    commits: &BTreeMap<String, String>,
+) -> Result<(String, Vec<PatchedEntry>)> {
+    let mut doc: DocumentMut = text.parse().context("failed to parse manifest.toml")?;
+    let mut patched = Vec::new();
+
+    if let Some(array) = doc.get_mut("packages").and_then(|item| item.as_array_mut()) {
+        for item in array.iter_mut() {
+            if let Some(table) = item.as_inline_table_mut() {
+                patch_commit_entry(table, commits, &mut patched);
+            }
+        }
+    } else if let Some(tables) = doc
+        .get_mut("packages")
+        .and_then(|item| item.as_array_of_tables_mut())
+    {
+        for table in tables.iter_mut() {
+            patch_commit_entry(table, commits, &mut patched);
+        }
+    }
+
+    Ok((doc.to_string(), patched))
+}
+
+fn patch_commit_entry(
+    table: &mut dyn toml_edit::TableLike,
+    commits: &BTreeMap<String, String>,
+    patched: &mut Vec<PatchedEntry>,
+) {
+    let Some(name) = table
+        .get("name")
+        .and_then(|item| item.as_str())
+        .map(str::to_string)
+    else {
+        return;
+    };
+    let Some(new) = commits.get(&name) else {
+        return;
+    };
+    if table.get("source").and_then(|item| item.as_str()) != Some("git") {
+        return;
+    }
+    let Some(value) = table.get_mut("commit").and_then(|item| item.as_value_mut()) else {
+        return;
+    };
+    let old = value.as_str().unwrap_or_default().to_string();
+    if old != *new {
+        let mut replacement = Value::from(new.clone());
+        *replacement.decor_mut() = value.decor().clone();
+        *value = replacement;
+        patched.push(PatchedEntry {
+            name,
+            old,
+            new: new.clone(),
+        });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +210,47 @@ mod tests {
             patch_locked_versions(text, &versions(&[("a", "2.0.0")])).unwrap();
         assert_eq!(patched.len(), 1);
         assert!(patched_text.contains("version = \"2.0.0\""));
+    }
+
+    #[test]
+    fn patches_only_git_sourced_commits() {
+        let text = concat!(
+            "packages = [\n",
+            "  { name = \"dep_a\", version = \"1.0.0\", source = \"git\", repo = \"https://example.com/a\", commit = \"aaaa\" },\n",
+            "  { name = \"dep_b\", version = \"1.0.0\", source = \"hex\", outer_checksum = \"aaaa\" },\n",
+            "]\n",
+        );
+        let (patched_text, patched) =
+            patch_locked_commits(text, &versions(&[("dep_a", "bbbb"), ("dep_b", "bbbb")])).unwrap();
+        assert_eq!(
+            patched,
+            vec![PatchedEntry {
+                name: "dep_a".to_string(),
+                old: "aaaa".to_string(),
+                new: "bbbb".to_string(),
+            }]
+        );
+        // Only dep_a's commit changed; the hex entry is untouched even though
+        // its name was requested.
+        assert_eq!(
+            patched_text,
+            text.replace(
+                "repo = \"https://example.com/a\", commit = \"aaaa\"",
+                "repo = \"https://example.com/a\", commit = \"bbbb\""
+            )
+        );
+    }
+
+    #[test]
+    fn commit_patch_is_idempotent_and_handles_array_of_tables() {
+        let inline = "packages = [ { name = \"a\", source = \"git\", commit = \"aaaa\" } ]\n";
+        let (text, patched) = patch_locked_commits(inline, &versions(&[("a", "aaaa")])).unwrap();
+        assert!(patched.is_empty());
+        assert_eq!(text, inline);
+
+        let tables = "[[packages]]\nname = \"a\"\nsource = \"git\"\ncommit = \"aaaa\"\n";
+        let (text, patched) = patch_locked_commits(tables, &versions(&[("a", "bbbb")])).unwrap();
+        assert_eq!(patched.len(), 1);
+        assert!(text.contains("commit = \"bbbb\""));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,6 +241,30 @@ enum Command {
         #[command(subcommand)]
         command: LockfileCommand,
     },
+    /// Pin git dependency refs to commit SHAs, recording the tracked ref
+    ///
+    /// Rewrites each symbolic `ref` in `[dependencies]`/`[dev-dependencies]`
+    /// to the commit it resolves to and records the original in a trailing
+    /// `# trellis:pin <ref>` comment, ratchet-style: the dependency becomes
+    /// reproducible without losing what to bump it to. Following the ref
+    /// again is a deliberate, reviewable `--update` diff instead of a silent
+    /// re-resolution; deleting the comment simply stops updates.
+    Pin {
+        /// Packages whose git dependencies to pin; all packages when omitted
+        #[arg(add = completion::packages())]
+        packages: Vec<String>,
+        /// Re-resolve every recorded `# trellis:pin` ref and rewrite the SHAs
+        /// that moved
+        #[arg(long, conflicts_with_all = ["check", "unpin"])]
+        update: bool,
+        /// Verify each pinned SHA is still reachable from its tracked ref;
+        /// non-zero exit on drift (for CI)
+        #[arg(long, conflicts_with = "unpin")]
+        check: bool,
+        /// Restore the symbolic refs and remove the pin comments
+        #[arg(long)]
+        unpin: bool,
+    },
     /// Validate workspace invariants; non-zero exit on any error
     Doctor {
         /// Apply the mechanically-fixable findings (seed changelog stubs,
@@ -762,6 +786,21 @@ fn dispatch(cli: Cli) -> Result<bool> {
                 commands::lockfile::refresh(&workspace, package.as_deref())
             }
         },
+        Command::Pin {
+            packages,
+            update,
+            check,
+            unpin,
+        } => {
+            let mode = match (update, check, unpin) {
+                (false, false, false) => commands::pin::Mode::Pin,
+                (true, false, false) => commands::pin::Mode::Update,
+                (false, true, false) => commands::pin::Mode::Check,
+                (false, false, true) => commands::pin::Mode::Unpin,
+                _ => unreachable!("clap conflicts prevent combining pin flags"),
+            };
+            commands::pin::run(&workspace, &commands::pin::PinOptions { mode, packages })
+        }
         Command::Doctor { .. }
         | Command::Init
         | Command::MarkdownHelp

--- a/tests/pin.rs
+++ b/tests/pin.rs
@@ -1,0 +1,231 @@
+//! End-to-end tests for `trellis pin`, using real git repos on disk as
+//! remotes — `ls-remote`, `fetch`, and ancestry all work against a local
+//! path, so no network is touched.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn trellis(dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("trellis").unwrap();
+    cmd.current_dir(dir);
+    cmd
+}
+
+fn write(path: &Path, content: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, content).unwrap();
+}
+
+fn git(root: &Path, args: &[&str]) {
+    let status = std::process::Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .unwrap();
+    assert!(status.success(), "git {args:?} failed");
+}
+
+fn git_stdout(dir: &Path, args: &[&str]) -> String {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git {args:?} failed");
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+/// A repository serving as the git remote: one commit on `main`, with an
+/// annotated tag `v1` on it. Returns the tempdir and the commit SHA.
+fn remote_repo() -> (tempfile::TempDir, String) {
+    let remote = tempfile::tempdir().unwrap();
+    write(&remote.path().join("file.txt"), "one\n");
+    git(remote.path(), &["init", "-q", "-b", "main"]);
+    git(remote.path(), &["add", "."]);
+    git(remote.path(), &["commit", "-q", "-m", "one"]);
+    git(remote.path(), &["tag", "-a", "v1", "-m", "v1"]);
+    let sha = git_stdout(remote.path(), &["rev-parse", "v1^{commit}"]);
+    (remote, sha)
+}
+
+/// A workspace with one member depending on the remote twice: `dep_a` tracks
+/// the annotated tag `v1`, `dep_b` tracks the branch `main` and carries an
+/// unrelated trailing comment that must survive pinning.
+fn workspace(url: &str) -> (tempfile::TempDir, PathBuf) {
+    let root = tempfile::tempdir().unwrap();
+    write(
+        &root.path().join("gleam.toml"),
+        "[tools.trellis]\nmembers = [\"packages/*\"]\n",
+    );
+    let manifest = root.path().join("packages/app/gleam.toml");
+    write(
+        &manifest,
+        &format!(
+            "name = \"app\"\nversion = \"0.1.0\"\n\n\
+             [dependencies]\n\
+             gleam_stdlib = \">= 0.34.0 and < 2.0.0\"\n\
+             dep_a = {{ git = \"{url}\", ref = \"v1\" }}\n\n\
+             [dev-dependencies]\n\
+             dep_b = {{ git = \"{url}\", ref = \"main\" }} # keep\n"
+        ),
+    );
+    git(root.path(), &["init", "-q", "-b", "main"]);
+    git(root.path(), &["add", "."]);
+    git(root.path(), &["commit", "-q", "-m", "init"]);
+    (root, manifest)
+}
+
+#[test]
+fn pin_rewrites_refs_records_intent_and_is_idempotent() {
+    let (remote, sha) = remote_repo();
+    let url = remote.path().display().to_string();
+    let (root, manifest) = workspace(&url);
+
+    trellis(root.path()).arg("pin").assert().success();
+    let text = fs::read_to_string(&manifest).unwrap();
+    // The annotated tag pins to the peeled commit, not the tag object.
+    assert!(
+        text.contains(&format!(
+            "dep_a = {{ git = \"{url}\", ref = \"{sha}\" }} # trellis:pin v1"
+        )),
+        "unexpected gleam.toml:\n{text}"
+    );
+    // The branch dep pins too, and its own comment survives in front.
+    assert!(text.contains(&format!(
+        "dep_b = {{ git = \"{url}\", ref = \"{sha}\" }} # keep # trellis:pin main"
+    )));
+    assert!(text.contains("gleam_stdlib = \">= 0.34.0 and < 2.0.0\""));
+
+    trellis(root.path()).arg("pin").assert().success();
+    assert_eq!(
+        fs::read_to_string(&manifest).unwrap(),
+        text,
+        "second pin must be a no-op"
+    );
+}
+
+#[test]
+fn check_passes_when_the_tracked_ref_merely_advances() {
+    let (remote, _) = remote_repo();
+    let url = remote.path().display().to_string();
+    let (root, _) = workspace(&url);
+    trellis(root.path()).arg("pin").assert().success();
+
+    // The pinned commit stays an ancestor: history grew, nothing was rewritten.
+    write(&remote.path().join("file.txt"), "two\n");
+    git(remote.path(), &["commit", "-q", "-am", "two"]);
+    git(remote.path(), &["tag", "-fa", "v1", "-m", "v1"]);
+
+    trellis(root.path())
+        .args(["pin", "--check"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn check_and_doctor_flag_a_force_moved_ref() {
+    let (remote, _) = remote_repo();
+    let url = remote.path().display().to_string();
+    let (root, _) = workspace(&url);
+    trellis(root.path()).arg("pin").assert().success();
+
+    // Rewrite the remote's only commit: the pinned SHA is no longer reachable
+    // from either `v1` or `main`.
+    git(
+        remote.path(),
+        &[
+            "commit",
+            "--amend",
+            "--allow-empty",
+            "-q",
+            "-m",
+            "rewritten",
+        ],
+    );
+    git(remote.path(), &["tag", "-fa", "v1", "-m", "v1"]);
+
+    trellis(root.path())
+        .args(["pin", "--check"])
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "not reachable from its tracked ref",
+        ));
+
+    // doctor reports the same drift as an advisory warning, not a failure.
+    trellis(root.path())
+        .arg("doctor")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "not reachable from its tracked ref",
+        ));
+}
+
+#[test]
+fn update_follows_the_moved_ref_and_unpin_restores_the_original() {
+    let (remote, _) = remote_repo();
+    let url = remote.path().display().to_string();
+    let (root, manifest) = workspace(&url);
+    let original = fs::read_to_string(&manifest).unwrap();
+    trellis(root.path()).arg("pin").assert().success();
+
+    write(&remote.path().join("file.txt"), "two\n");
+    git(remote.path(), &["commit", "-q", "-am", "two"]);
+    git(remote.path(), &["tag", "-fa", "v1", "-m", "v1"]);
+    let new_sha = git_stdout(remote.path(), &["rev-parse", "v1^{commit}"]);
+
+    trellis(root.path())
+        .args(["pin", "--update"])
+        .assert()
+        .success();
+    let text = fs::read_to_string(&manifest).unwrap();
+    assert!(
+        text.contains(&format!(
+            "dep_a = {{ git = \"{url}\", ref = \"{new_sha}\" }} # trellis:pin v1"
+        )),
+        "update did not follow v1:\n{text}"
+    );
+    assert!(text.contains(&format!("ref = \"{new_sha}\" }} # keep # trellis:pin main")));
+
+    trellis(root.path())
+        .args(["pin", "--unpin"])
+        .assert()
+        .success();
+    assert_eq!(fs::read_to_string(&manifest).unwrap(), original);
+}
+
+#[test]
+fn pin_patches_the_locked_manifest_commit() {
+    let (remote, sha) = remote_repo();
+    let url = remote.path().display().to_string();
+    let (root, _) = workspace(&url);
+    let lockfile = root.path().join("packages/app/manifest.toml");
+    write(
+        &lockfile,
+        &format!(
+            "# This file was generated by Gleam\n\
+             packages = [\n  \
+               {{ name = \"dep_a\", version = \"1.0.0\", source = \"git\", repo = \"{url}\", commit = \"0000000000000000000000000000000000000000\" }},\n\
+             ]\n\n\
+             [requirements]\n\
+             dep_a = {{ git = \"{url}\", ref = \"v1\" }}\n"
+        ),
+    );
+
+    trellis(root.path()).arg("pin").assert().success();
+    let text = fs::read_to_string(&lockfile).unwrap();
+    assert!(
+        text.contains(&format!("commit = \"{sha}\"")),
+        "locked commit not patched:\n{text}"
+    );
+    assert!(text.contains("# This file was generated by Gleam"));
+}

--- a/website/src/content/docs/docs/reference.md
+++ b/website/src/content/docs/docs/reference.md
@@ -30,6 +30,7 @@ description: Every trellis command, flag, and argument — generated from the CL
 * [`trellis publish`↴](#trellis-publish)
 * [`trellis lockfile`↴](#trellis-lockfile)
 * [`trellis lockfile refresh`↴](#trellis-lockfile-refresh)
+* [`trellis pin`↴](#trellis-pin)
 * [`trellis doctor`↴](#trellis-doctor)
 * [`trellis ci`↴](#trellis-ci)
 * [`trellis ci matrix`↴](#trellis-ci-matrix)
@@ -58,6 +59,7 @@ A workspace CLI for Gleam monorepos: task fan-out, introspection, and release or
 * `tag` — Compare package versions against git tags; create what's missing
 * `publish` — Publish packages to Hex, in dependency order, with path deps rewritten
 * `lockfile` — Lockfile maintenance
+* `pin` — Pin git dependency refs to commit SHAs, recording the tracked ref
 * `doctor` — Validate workspace invariants; non-zero exit on any error
 * `ci` — Structured output for CI
 * `completions` — Print the shell snippet that enables tab-completion
@@ -431,6 +433,26 @@ Run `gleam deps download`, scoped to one package (with retry/backoff)
 ###### **Options:**
 
 * `--package <PACKAGE>` — Refresh only this package instead of the whole workspace
+
+
+
+## `trellis pin`
+
+Pin git dependency refs to commit SHAs, recording the tracked ref
+
+Rewrites each symbolic `ref` in `[dependencies]`/`[dev-dependencies]` to the commit it resolves to and records the original in a trailing `# trellis:pin <ref>` comment, ratchet-style: the dependency becomes reproducible without losing what to bump it to. Following the ref again is a deliberate, reviewable `--update` diff instead of a silent re-resolution; deleting the comment simply stops updates.
+
+**Usage:** `trellis pin [OPTIONS] [PACKAGES]...`
+
+###### **Arguments:**
+
+* `<PACKAGES>` — Packages whose git dependencies to pin; all packages when omitted
+
+###### **Options:**
+
+* `--update` — Re-resolve every recorded `# trellis:pin` ref and rewrite the SHAs that moved
+* `--check` — Verify each pinned SHA is still reachable from its tracked ref; non-zero exit on drift (for CI)
+* `--unpin` — Restore the symbolic refs and remove the pin comments
 
 
 


### PR DESCRIPTION
Implements the "Dependency pinning" section of docs/DESIGN.md (included here): `trellis pin` rewrites symbolic git dependency refs to commit SHAs and records the tracked ref in a `# trellis:pin <ref>` comment on the dependency's own line, ratchet-style — reproducible without losing the intent of what to bump to.

- `pin` — resolve each symbolic ref via `git ls-remote` (annotated tags pin the peeled commit), rewrite `ref` with toml_edit (rest of the file byte-for-byte), append the pin comment, and patch the locked `commit` in manifest.toml surgically (no `gleam update`)
- `--update` — re-resolve every recorded intent; following a series becomes a reviewable diff instead of a silent re-resolution
- `--unpin` — restore the symbolic refs
- `--check` — exit 1 when a pinned SHA is no longer reachable from its tracked ref (tip-equality fast path, else a commits-only fetch + `merge-base --is-ancestor`) — the force-move supply-chain signal; `doctor` reports the same drift as an advisory warning and degrades network failure to a warning
- dedupes the `git_stdout` helper that tag.rs had copied verbatim from git.rs

Tests: unit tests for the SHA rule, comment grammar, scan, and byte-preservation/idempotence/unpin round-trips; integration tests in tests/pin.rs against local git repos as remotes (no network) covering pin/update/check/unpin, doctor's warning, and manifest patching. CLI reference and man pages regenerated; changie component + fragment added.
