### PR TITLE
docs(website): add dependency pinning page

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -23,6 +23,7 @@ export default defineConfig({
         { label: "Task running", slug: "docs/task-running" },
         { label: "Changelog & versioning", slug: "docs/changelog" },
         { label: "Publishing", slug: "docs/publishing" },
+        { label: "Dependency pinning", slug: "docs/pinning" },
         { label: "CI recipes", slug: "docs/ci" },
         { label: "JSON output", slug: "docs/json-output" },
         { label: "Compatibility", slug: "docs/compatibility" },

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -105,6 +105,11 @@ that changes a package without logging it:
 - run: trellis changelog check --base "origin/${{ github.base_ref }}"
 ```
 
+A workspace with [pinned git dependencies](/docs/pinning/) can add
+`trellis pin --check`, which fails the PR when a pinned SHA is no longer
+reachable from its tracked ref — `doctor` reports the same drift, but only
+as a warning.
+
 When the tripwire fires on a mechanical finding, such as a missing
 `CHANGELOG.md` or a stale `manifest.toml` locked version, clear it locally with
 `trellis doctor --fix`, which applies exactly those fixes and re-reports the

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -255,7 +255,7 @@ per tag. An entry names how much of the version the tag keeps:
 | `major` | `lat_cli-v0` | `lat_cli-v1` | moving — re-pointed at each release in the series |
 | `minor` | `lat_cli-v0.10` | `lat_cli-v1.2` | moving |
 
-The moving ones are what let a consumer pin `lat_cli-v0.10` once instead of
+The moving ones are what let a consumer track `lat_cli-v0.10` once instead of
 chasing `0.10.1`, `0.10.2`, `0.10.3`. `exact` substitutes into
 `exact_tag_format`, the series levels into `series_tag_format` — the entry name
 tells you which. A prerelease belongs to no series, so it gets an `exact` tag
@@ -549,5 +549,6 @@ are never reported.
 Run `trellis doctor` after any config change. It validates that member globs
 resolve, the graph is acyclic, task exclusion globs match members, release
 boundaries are safe, the tag format produces unique tags, locked versions
-match, packages agree on their shared dependencies, and `[tools.trellis]`
+match, [pinned git dependencies](/docs/pinning/) have not drifted from their
+tracked refs, packages agree on their shared dependencies, and `[tools.trellis]`
 carries no unrecognized or deprecated keys — exiting non-zero on any error.

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -71,6 +71,8 @@ assert on.
 | [Task running](/docs/task-running/) | `run` and `exec`: built-in and custom tasks, graph-parallel scheduling, selecting packages with `--since`. |
 | [Changelog & versioning](/docs/changelog/) | TOML change fragments, PR enforcement, planning and applying version bumps. |
 | [Publishing](/docs/publishing/) | Release PRs, per-package tags, publishing to Hex in dependency order with path deps rewritten. |
+| [Dependency pinning](/docs/pinning/) | `trellis pin`: git dependency refs rewritten to commit SHAs, updated as a reviewable diff, checked for force-moves. |
 | [CI recipes](/docs/ci/) | GitHub Actions shapes: affected-only matrices, PR gates, and the release pipeline. |
 | [JSON output](/docs/json-output/) | What the `--json` payloads guarantee: the `schema` field, what a stable shape permits, and where it stops. |
+| [Compatibility](/docs/compatibility/) | The exit-code contract, what semver covers, and the minimum supported Rust version. |
 | [CLI reference](/docs/reference/) | Every command, flag, and argument, generated from the CLI itself. |

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -126,6 +126,7 @@ is prose, not stable — branch on `check`:
 | `release_boundary` | a package's runtime path dependency is less capable than it is (a `hex` package depending on `git_only`/`workspace`, or `git_only` on `workspace`) |
 | `tag_collision` | two releasable packages produce the same tag |
 | `lockfile_drift` | a `manifest.toml` locks a workspace-internal dep at a stale version |
+| `pinned_ref` | a [pinned git dependency](/docs/pinning/) SHA is no longer reachable from its tracked ref, its pin comment disagrees with its ref, or the refs could not be verified — always a warning |
 | `changelog_missing` | a releasable package has no `CHANGELOG.md` |
 | `changelog_unreadable` | a `CHANGELOG.md` exists but could not be read |
 | `changelog_behind` | a package's version is behind the newest one in its changelog |

--- a/website/src/content/docs/docs/pinning.mdx
+++ b/website/src/content/docs/docs/pinning.mdx
@@ -1,0 +1,116 @@
+---
+title: Dependency pinning
+description: trellis pin rewrites symbolic git dependency refs to commit SHAs and records the tracked ref in a comment, so builds are reproducible without losing what to bump to.
+---
+
+import Callout from "../../../components/Callout.astro";
+
+A Gleam git dependency names a ref, and there are two ways to spell it, both
+wrong. A symbolic ref (`ref = "v0.4"`) is readable but not reproducible — the
+tag moves and the next resolve silently follows it. A bare commit SHA is
+reproducible but loses the intent, so nobody knows what to bump it to.
+`trellis pin` keeps both, in the same style
+[ratchet](https://github.com/sethvargo/ratchet) uses for GitHub Actions: the
+`ref` becomes the SHA, and the ref it tracks moves into a comment on the same
+line.
+
+```txt wrap
+trellis pin [pkgs...]            # resolve symbolic refs to SHAs, record the intent
+trellis pin --update [pkgs...]   # re-resolve each recorded intent to its latest SHA
+trellis pin --check [pkgs...]    # fail if a pinned SHA drifted from its tracked ref
+trellis pin --unpin [pkgs...]    # restore the symbolic refs
+```
+
+This is the consumer half of [series tags](/docs/configuration/#tags): a
+release force-moves `lat_cli-v0.4` so consumers can track the series, and
+`pin` is how a consumer follows that tag deliberately instead of silently.
+It works the same on any moving ref — a branch, or another tool's tags.
+
+## Pinning
+
+`pin` scans `[dependencies]` and `[dev-dependencies]` of the selected
+packages — all of them when none are named — for git requirements whose `ref`
+is not already a full commit SHA. Each ref is resolved with
+`git ls-remote <url> <ref>`: no clone, any host, authentication through git's
+own credential machinery. An annotated tag pins the commit it points at, not
+the tag object. Then `ref` is rewritten and the original recorded in a
+`# trellis:pin` comment on the dependency's own line:
+
+```diff lang="toml" title="packages/lat_cli/gleam.toml" wrap
+  [dependencies]
+- vestibule = { git = "https://github.com/example/monorepo.git", ref = "v0.4", path = "packages/vestibule" }
++ vestibule = { git = "https://github.com/example/monorepo.git", ref = "93deb4c38d4b3f5848681ff7e9d59883db751c67", path = "packages/vestibule" } # trellis:pin v0.4
+```
+
+```console
+$ trellis pin
+[lat_cli] pinned vestibule 93deb4c tracking v0.4
+```
+
+The rest of the file is preserved byte for byte, and the locked commit in
+`manifest.toml` is patched surgically — no `gleam update`, no Hex traffic. A
+package without a manifest is fine: gleam locks the pinned commit on its next
+download.
+
+The comment is the record of intent. It lives on the dependency's own line,
+so it survives copy-paste between manifests, and there is no separate table
+to orphan when a dependency is removed. A dependency whose comment is deleted
+simply stops updating — still pinned, no longer followed. The converse also
+holds: a hand-written SHA with no comment is left alone, because there is no
+recorded ref to follow.
+
+## Following the ref
+
+`--update` re-resolves every recorded ref and rewrites the SHAs that moved:
+
+```console
+$ trellis pin --update
+[lat_cli] updated vestibule 51cbad6 was 93deb4c, tracking v0.4
+```
+
+The result is a plain `gleam.toml` diff to review — following a moving tag
+becomes a deliberate, visible bump instead of a silent re-resolution. A
+dependency already at its ref's tip is untouched.
+
+`--unpin` restores every recorded ref and removes the comments, returning the
+manifest to its pre-pin text:
+
+```console
+$ trellis pin --unpin
+[lat_cli] unpinned vestibule restored v0.4
+```
+
+## Catching a force-moved ref
+
+`--check` verifies that each pinned SHA is an ancestor of (or equal to) the
+commit its tracked ref points at now. A SHA no longer reachable from its ref
+means the tag or branch was force-moved *past* it — the supply-chain signal
+this exists to catch:
+
+```console
+$ trellis pin --check
+drift: [lat_cli] `vestibule` is pinned at 51cbad6 which is not reachable from its tracked ref `v0.4` (now 8b9acd6) — the ref may have been force-moved
+```
+
+It exits `1` on any drift, so it drops straight into a PR gate:
+
+```yaml
+# on: pull_request
+- run: trellis pin --check
+```
+
+`doctor` runs the same check, but as an advisory warning: it needs the
+network, and re-pinning past a force-move is a supply-chain decision
+`doctor --fix` must not make. A network failure degrades to a warning too,
+so an offline `doctor` run stays useful. In `--format json` these findings
+carry `check: pinned_ref` — see [JSON output](/docs/json-output/#doctor-findings).
+
+<Callout>
+
+A pin that is merely *behind* its ref does not drift. A series tag moves
+forward once per release, and the old release commit stays an ancestor of
+the new one, so `--check` stays green through ordinary releases — being
+behind is what `--update` is for. Drift means the ref's history was actually
+rewritten, which is why it warrants an alarm rather than a bump.
+
+</Callout>

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -74,8 +74,9 @@ Each entry in a package's `package_tags` falls into one of two lifecycles:
   disagreeing about what one names is an error, not something to reconcile.
 - **Series tags** (`{name}-v{series}`) move. Releasing a new version in the
   series force-moves its tag to the release commit and force-pushes it, so
-  consumers can pin `lat_cli-v0.4` and follow the series instead of chasing
-  patch tags. The signal is the package's manifest version stored at the tag,
+  consumers can track `lat_cli-v0.4` and follow the series instead of chasing
+  patch tags — [`trellis pin`](/docs/pinning/) gives git-dependency consumers
+  a reviewable way to do exactly that. The signal is the package's manifest version stored at the tag,
   so a commit that does not release the package — another package's release, a
   docs change — leaves its series tags alone. The series is derived from the
   version — see [series tags](/docs/configuration/#tags).


### PR DESCRIPTION
Adds a /docs/pinning/ guide for `trellis pin` (transcripts generated against a live git fixture), plus audit fixes: `pinned_ref` added to the doctor check table, missing Compatibility row in the overview page table, and cross-links from publishing/configuration/ci.
