### PR TITLE
test(git): allow temporary bare repositories

### DIFF
--- a/tests/phase3.rs
+++ b/tests/phase3.rs
@@ -734,6 +734,7 @@ fn set_version(root: &Path, package: &str, version: &str) {
 
 fn git_stdout(dir: &Path, args: &[&str]) -> String {
     let output = std::process::Command::new("git")
+        .args(["-c", "safe.bareRepository=all"])
         .args(args)
         .current_dir(dir)
         .output()


### PR DESCRIPTION
## Summary

- allow phase 3 Git assertions to inspect temporary bare remotes when `safe.bareRepository` is `explicit`
- scope the override to the test helper process
