### PR TITLE
fix: suppress cached update notices

### DIFF
--- a/.changes/unreleased/Fixed-20260901-update-notice-frequency.yaml
+++ b/.changes/unreleased/Fixed-20260901-update-notice-frequency.yaml
@@ -1,0 +1,5 @@
+component: trellis
+kind: Fixed
+body: |-
+  **Update notices no longer repeat on cache hits.** Trellis shows the available-release notice only after a fresh check instead of after every successful interactive command.
+time: 2026-09-01T13:04:23.013-07:00

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 # Pure-Rust rustls (via the ureq we already depend on) instead of the default
 # native-tls, so release binaries stay OpenSSL-free per the zero-runtime-deps promise.
-tiny-update-check = { version = "1.1.3", default-features = false, features = ["rustls", "do-not-track"] }
+tiny-update-check = { version = "1.1.3", default-features = false, features = ["rustls", "do-not-track", "response-body"] }
 toml = "1.1.2"
 toml_edit = "0.25.12"
 ureq = { version = "3.3.0", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -95,12 +95,13 @@ shells and for man pages, which ship in the release archives under `man/`.
 ### Update checks
 
 Interactive commands print a one-line notice to stderr when a newer trellis
-has been published to crates.io. The check is best-effort — cached for a day,
-capped at a short timeout, and silent on any error — so it never slows a
-command or changes its exit status. It runs only when stderr is a terminal, so
-scripts and structured output are never touched. It is additionally skipped in
-CI and when `DO_NOT_TRACK` or `TRELLIS_NO_UPDATE_CHECK` is set in the
-environment, and `--no-update-check` suppresses it for a single invocation.
+has been published to crates.io. Successful checks are cached for a day, and
+the notice appears only after a fresh check. The check is best-effort — capped
+at a short timeout and silent on any error — so it never slows a command or
+changes its exit status. It runs only when stderr is a terminal, so scripts and
+structured output are never touched. It is additionally skipped in CI and when
+`DO_NOT_TRACK` or `TRELLIS_NO_UPDATE_CHECK` is set in the environment, and
+`--no-update-check` suppresses it for a single invocation.
 
 ## Configuration
 

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -12,6 +12,7 @@
 
 use std::io::IsTerminal;
 use std::time::Duration;
+use tiny_update_check::DetailedUpdateInfo;
 
 /// crates.io crate name. The binary is `trellis`, but the crate publishes as
 /// `trellis-gleam` (see Cargo.toml), so the version lives under that name.
@@ -42,6 +43,14 @@ fn notice_enabled(stderr_is_terminal: bool, env: impl Fn(&str) -> Option<String>
     true
 }
 
+fn notice_versions(info: &DetailedUpdateInfo) -> Option<(&str, &str)> {
+    // The response body is absent on cache hits, so only a fresh daily check
+    // produces a notice.
+    info.response_body
+        .as_ref()
+        .map(|_| (info.current.as_str(), info.latest.as_str()))
+}
+
 /// Print a notice to stderr if a newer trellis has been published. Best-effort:
 /// returns quietly on any error or when suppressed.
 pub fn notify() {
@@ -54,12 +63,11 @@ pub fn notify() {
     let checker = tiny_update_check::UpdateChecker::new(CRATE_NAME, env!("CARGO_PKG_VERSION"))
         .timeout(CHECK_TIMEOUT);
 
-    if let Ok(Some(info)) = checker.check() {
+    if let Ok(Some(info)) = checker.check_detailed()
+        && let Some((current, latest)) = notice_versions(&info)
+    {
         eprintln!();
-        eprintln!(
-            "A new release of trellis is available: {} → {}",
-            info.current, info.latest
-        );
+        eprintln!("A new release of trellis is available: {current} → {latest}");
         eprintln!("{RELEASES_URL}");
     }
 }
@@ -68,6 +76,7 @@ pub fn notify() {
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use tiny_update_check::UpdateInfo;
 
     fn env_from(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
         let map: HashMap<String, String> = pairs
@@ -103,5 +112,27 @@ mod tests {
             true,
             env_from(&[("TRELLIS_NO_UPDATE_CHECK", "1")])
         ));
+    }
+
+    fn update_info(response_body: Option<&str>) -> DetailedUpdateInfo {
+        let mut info = DetailedUpdateInfo::from(UpdateInfo {
+            current: "0.13.0".to_string(),
+            latest: "0.14.0".to_string(),
+        });
+        info.response_body = response_body.map(str::to_string);
+        info
+    }
+
+    #[test]
+    fn suppresses_update_notice_on_cache_hit() {
+        assert_eq!(notice_versions(&update_info(None)), None);
+    }
+
+    #[test]
+    fn shows_update_notice_after_fresh_check() {
+        assert_eq!(
+            notice_versions(&update_info(Some("{}"))),
+            Some(("0.13.0", "0.14.0"))
+        );
     }
 }


### PR DESCRIPTION
## Summary

- show the upgrade notice only after a fresh crates.io check
- suppress repeated notices when the dependency serves its cached result
- document and test the cache-hit behavior

