### PR TITLE
docs: correct stale README claims and document pin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,14 @@ Every user-visible change needs one: a YAML file in `.changes/unreleased/` named
 `<Kind>-<YYYYMMDD>-<slug>.yaml`, with `component`, `kind`, `body`, and `time`. The
 audience is a stranger reading the release notes, not the reviewer of your PR.
 
+**This section is about trellis's own changelog, which changie manages — not
+about the fragments trellis writes.** The two formats are different and easy to
+confuse: changie fragments are YAML keyed on `component`, while trellis's native
+engine reads TOML keyed on `package`, `kind`, an optional `category`, and `body`
+(`src/changelog.rs`). Everything below applies to this repository's
+`.changes/unreleased/`; a Gleam workspace consuming trellis uses the TOML shape,
+documented on the [changelog page](website/src/content/docs/docs/changelog.mdx).
+
 Write the body as a `|-` block scalar with a **bolded lead-in sentence**, then
 paragraphs:
 
@@ -124,3 +132,31 @@ looking is a wire-format break accepted without looking.
 
 `website/src/content/docs/docs/reference.md` and `assets/man/` are generated.
 Edit the clap definitions, then run `just docs`.
+
+## Releasing trellis
+
+Releases are fully automated, fragment-driven, and hands-off after merge —
+the same pipeline as [repoverlay](https://github.com/tylerbutler/repoverlay):
+
+1. Every user-facing change lands with a changie fragment (`changie new`);
+   fragments accumulate in `.changes/unreleased/`.
+2. On each push to `main`, `changie-release.yml` batches the fragments into a
+   release PR that bumps `Cargo.toml`, regenerates `Cargo.lock`, and updates
+   `CHANGELOG.md`.
+3. Merging the release PR triggers `release-plz.yml`, which creates the
+   `v{version}` tag and publishes the crate to crates.io as `trellis-gleam`
+   (the `trellis` name itself is taken by an unrelated project — the `[[bin]]`
+   in `Cargo.toml` keeps the installed binary named `trellis`).
+4. The tag triggers the dist-generated `release.yml`: cargo-dist builds
+   binaries for five targets (Linux gnu, macOS, Windows; x86_64 and aarch64),
+   generates the shell/PowerShell installers and the Homebrew formula,
+   attaches SLSA provenance attestations, and creates the GitHub Release.
+   `publish-homebrew-tap.yml` then pushes the formula to
+   `tylerbutler/homebrew-tap` using a GitHub App token.
+
+The release workflows expect the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`
+secrets (a GitHub App with `contents:write` here and on the tap), plus a
+`CARGO_REGISTRY_TOKEN` secret (a crates.io API token with publish access to
+`trellis-gleam`) for `release-plz.yml` to publish the crate. After changing
+`dist-workspace.toml`, regenerate the release workflow with `dist generate`
+and validate with `dist plan`.

--- a/README.md
+++ b/README.md
@@ -21,14 +21,20 @@ version, and path dependencies. The dependency graph — topological order,
 publish order, change impact, path-dep rewrite maps — is computed, never
 declared.
 
+Throughout, a **package** is one Gleam package — a directory with its own
+`gleam.toml` — and a **member** is a package belonging to the workspace. The
+second word appears where membership itself is the point, as in the `members`
+key and the `@members` exclusion.
+
 See [docs/DESIGN.md](docs/DESIGN.md) for the full design.
 
 ## Status
 
 The full [rollout plan](docs/DESIGN.md#10-rollout-in-lattice) is implemented:
-the workspace model plus `list`, `graph`, `info`, `run`, `exec`, `doctor`,
-`ci`, `changelog`, `version`, `tag`, `publish`, and `lockfile`, with prebuilt
-release binaries for distribution.
+the workspace model plus `list`, `graph`, `info`, `run`, `exec`, `init`,
+`doctor`, `ci`, `changelog`, `version`, `release`, `tag`, `publish`,
+`lockfile`, `pin`, and `completions`, with prebuilt release binaries for
+distribution.
 
 ## Installation
 
@@ -62,19 +68,22 @@ is how a consuming workspace pins trellis in `.tool-versions` alongside its
 other tools:
 
 ```sh
-mise use "github:tylerbutler/trellis@0.2.0"
+mise use "github:tylerbutler/trellis@0.13.0"
 ```
 
-**From source:**
+**From source:** the crate is `trellis-gleam` on crates.io — `trellis` was
+taken — but the installed binary is named `trellis` either way:
 
 ```sh
+cargo install trellis-gleam
+# or straight from the repository:
 cargo install --git https://github.com/tylerbutler/trellis
 ```
 
 Prebuilt archives for every target are on the
 [releases page](https://github.com/tylerbutler/trellis/releases). Pin a
 specific version in CI by replacing `latest/download` with
-`download/v0.1.0` in the installer URL.
+`download/v0.13.0` in the installer URL.
 
 ### Shell completions
 
@@ -89,7 +98,7 @@ Completions are computed by the binary as you type, so they offer real package
 names, task names, and changelog kinds from the workspace you're in. Evaluate
 the snippet on startup rather than saving it to a file: it talks to `trellis`
 over an interface that can change between releases. See
-[installation](https://trellis.tylerbutler.com/docs/installation) for the other
+[installation](https://trellis.tylerbutler.com/docs/installation/) for the other
 shells and for man pages, which ship in the release archives under `man/`.
 
 ### Update checks
@@ -154,8 +163,7 @@ repository_tag_format = "v{series}"
 repository_tags = ["major", "minor"]
 ```
 
-Each member is a directory with a `gleam.toml`. Path dependencies between
-members define the graph; cycles and path deps escaping the workspace are
+Path dependencies between members define the graph; cycles and path deps escaping the workspace are
 rejected, and a `[tools.trellis]` table in a *member* manifest is a doctor
 error (it would hijack root discovery).
 
@@ -200,8 +208,8 @@ spinners into it.
 
 `-q` and `-v` are mutually exclusive. `-q` changes nothing about exit codes:
 errors still go to stderr and a failing task still fails the command. `-v`
-writes a `+ ` trace to stderr for each `gleam`, `git`, and `gh` invocation,
-naming the directory it ran in.
+writes a `+ ` trace to stderr for each `gleam` and `git` invocation, naming the
+directory it ran in, and for each GitHub API request as `+ METHOD url`.
 
 ### Exit codes
 
@@ -213,7 +221,7 @@ workspace that has problems from a broken environment.
 | `0` | Success, no findings | `doctor` found nothing; every task passed |
 | `1` | Ran correctly, found problems | `doctor` findings, missing changelog fragments, a failed task |
 | `2` | Usage error | Unknown flag, missing argument, bad subcommand |
-| `3` | Trellis itself could not run | Unparseable config, not a git repository, missing `gleam`/`gh`, Hex unreachable after retries |
+| `3` | Trellis itself could not run | Unparseable config, not a git repository, missing `gleam`, no GitHub token, Hex unreachable after retries |
 
 A failed task exits `1`; trellis does not propagate the child's exit code. See
 [Compatibility](https://trellis.tylerbutler.com/docs/compatibility/) for what
@@ -322,6 +330,7 @@ exempting dev-only path deps, which never ship in any distribution.
 
 ```
 trellis changelog new [--package <pkg>] --kind <kind> --body <text>
+                      [--category <category>]
 trellis changelog check --base <ref> [--head <ref>] [--format text|json|github]
                        [--strictness error|warn|off]
 trellis version plan  [--bump <level>|<pkg>=<level>] [--set <pkg>=<version>]
@@ -332,8 +341,9 @@ trellis version apply [--bump <level>|<pkg>=<level>] [--set <pkg>=<version>]
 
 The changelog engine is native — no second tool to install, no config file
 to keep in sync. Changes are recorded as TOML fragments in
-`.changes/unreleased/` (`project`, `kind`, `body`); `changelog new` writes
-one, non-interactively, which suits CI and agents as well as shells.
+`.changes/unreleased/` — `package`, `kind`, `body`, and an optional
+`category`; `changelog new` writes one, non-interactively, which suits CI and
+agents as well as shells.
 `changelog check` maps a `base...head` diff to packages and fails if a
 changed releasable package has no unreleased fragment. How much that costs is
 configurable — `changelog.strictness` is `error` by default, `warn` to report
@@ -362,6 +372,13 @@ lat_core: 1.2.0 -> 1.3.0 (1 fragment(s))
 lat_mid: 0.5.0 -> 0.5.1 (dependencies: lat_core)
 lat_cli: 0.3.1 -> 0.3.2 (dependencies: lat_core, lat_mid)
 ```
+
+A dependent needs no fragment of its own to ripple, and a package that has one
+keeps its own, larger bump. Ripples follow `[dev-dependencies]` path deps as
+well as `[dependencies]`. Packages excluded by `@release` never bump, and a
+ripple stops at one rather than skipping past it to its dependents. This is a
+correctness requirement, not a convenience —
+[why](https://trellis.tylerbutler.com/docs/changelog/#dependents-bump-too).
 
 #### Overriding the derived version
 
@@ -411,27 +428,16 @@ explicit. A prerelease belongs to no series, so it moves no
 [series tag](#release--publish); exact tags apply as usual, and Hex accepts
 prerelease versions.
 
-This is not a convenience. A path dep's Hex requirement is derived from the
-dependency's version at publish time, so leaving `lat_mid` at 0.5.0 would let
-one published version resolve two different ways depending on whether it was
-fetched before or after `lat_core`'s release. A dependent needs no fragment of
-its own to ripple; a package that has one keeps its own, larger bump. Packages
-excluded by `@release` never bump, and a ripple stops at one rather than
-skipping past it to its dependents.
-
-Rendering is controlled by minijinja templates in `[tools.trellis.changelog]`, each with a
-small context (`name`, `version`, `date`, `tag`, `kind`, `body` as applicable):
+Rendering is controlled by minijinja templates in `[tools.trellis.changelog]`,
+each with a small context drawn from `name`, `version`, `date`, `tag`,
+`series`, `category`, `kind`, and `body`:
 
 ```toml
 [tools.trellis.changelog]
+header_format = "# {{ name }} changelog"              # default
 version_format = "## v{{ version }} - {{ date }}"     # default
-kind_format = "### {{ kind }}"                         # default
-change_format = "- {{ body }}"                         # default
-kinds = [
-  { label = "Breaking", bump = "major" },
-  { label = "Added", bump = "minor" },
-  { label = "Fixed", bump = "patch" },
-]
+kind_format = "### {{ kind }}"                        # default
+change_format = "- {{ body }}"                        # default
 
 # Generated ripple entries are ordinary entries of one configured kind, so
 # they sort and render like any other. `dependency_kind` must name one of
@@ -441,7 +447,14 @@ dependency_kind = "Dependencies"                                  # default
 dependency_body = "Updated {{ dependency }} to {{ dependency_version }}"  # default
 ```
 
-Note that each package's CHANGELOG.md is a generated file: the source of
+`kinds` sets the change kinds and the bump each implies; setting it replaces
+the whole default list rather than adding to it, so copy the list before
+trimming it — a kind you drop turns every fragment naming it invalid. An
+optional `categories` list adds a second grouping axis above the kind
+headings, carrying no bump. Both are on
+[configuration](https://trellis.tylerbutler.com/docs/configuration/#changelog-configuration).
+
+Each package's CHANGELOG.md is a generated file: the source of
 truth is the version sections under `.changes/<package>/`, and `apply`
 reassembles the changelog from them. A package that already had a changelog
 when it adopted trellis keeps it: on its first release, whatever sits below
@@ -460,16 +473,20 @@ trellis lockfile refresh [--package <pkg>]
 ```
 
 `release pr` turns pending changelog fragments into a release pull request:
-it runs `version apply` on a release branch, commits the bumps, force-pushes
-(so the branch is regenerated each run), and creates — or, when one is
-already open, updates — the PR via the `gh` CLI. The body carries the bump
-table and each package's new CHANGELOG section. Requires a clean working
-tree; a no-op when there are no fragments.
+it runs `version apply` on a release branch (default `release/pending`),
+commits the bumps, force-pushes (so the branch is regenerated each run), and
+creates — or, when one is already open, updates — the PR through the GitHub
+REST API. The body carries the bump table and each package's new CHANGELOG
+section. Requires a clean working tree and a token from `GITHUB_TOKEN`
+(ambient in GitHub Actions), `GH_TOKEN`, or a logged-in `gh` CLI; a no-op when
+there are no fragments.
 
 `tag plan` lists the tags the current versions call for and don't have yet;
 `tag create` reconciles them in topological order, optionally pushing them and
-creating GitHub Releases (via the `gh` CLI) with the matching CHANGELOG
-section as the body.
+creating GitHub Releases — through the same API and token as `release pr` —
+with the matching CHANGELOG section as the body. `release bootstrap` is the
+same reconciliation without a version bump, for adopting trellis on a
+repository that already has the versions it wants but no tags.
 
 `package_tags` lists the tags a release maintains per package, one entry per
 tag, each naming how much of the version it keeps: `exact` keeps the whole
@@ -501,10 +518,10 @@ Repository tags are mutable, never get GitHub Releases, and cannot be passed to
 
 It replaces the older way of reaching a repository-wide tag: dropping `{name}`
 from `series_tag_format`. That form is deprecated and removed at 1.0, because
-a package template with the discriminator taken out matches every member — so
-`ci tag-package` cannot resolve it, and adding a second series-mode package
-turns a working config ambiguous without touching the format. `doctor` warns
-on it whether or not that has happened yet.
+without the discriminator every package's series tag matches every member and
+`ci tag-package` can no longer resolve one. `doctor` warns on it. To migrate,
+restore `{name}` in `series_tag_format` and declare the three repository tag
+keys above.
 
 `publish` runs, per package and in dependency order: an idempotency check
 against the Hex API (already-published versions are skipped, so re-running a
@@ -525,6 +542,34 @@ encoding the "don't refresh the whole workspace or you'll get rate-limited"
 rule as behavior. `trellis ci tag-package <tag>` resolves `$GITHUB_REF_NAME`
 to a package name for shell substitution.
 
+### Dependency pinning
+
+```
+trellis pin [pkgs...]            # resolve symbolic refs to SHAs, record the intent
+trellis pin --update [pkgs...]   # re-resolve each recorded ref to its latest SHA
+trellis pin --check [pkgs...]    # fail if a pinned SHA drifted from its tracked ref
+trellis pin --unpin [pkgs...]    # restore the symbolic refs
+```
+
+A Gleam git dependency names a ref, and both spellings are wrong: `ref = "v0.4"`
+is readable but re-resolves silently when the tag moves, and a bare SHA is
+reproducible but loses what to bump to. `pin` keeps both — the `ref` becomes
+the commit SHA and the ref it tracks moves into a `# trellis:pin` comment on
+the same line, the style
+[ratchet](https://github.com/sethvargo/ratchet) uses for GitHub Actions:
+
+```toml
+vestibule = { git = "https://github.com/example/monorepo.git", ref = "93deb4c38d4b3f5848681ff7e9d59883db751c67", path = "packages/vestibule" } # trellis:pin v0.4
+```
+
+Refs resolve through `git ls-remote` — no clone, any host — and `manifest.toml`
+is patched surgically. `--update` re-resolves each recorded ref, so following a
+moving tag becomes a reviewable diff instead of a silent re-resolution.
+`--check` fails when a pinned SHA is no longer reachable from its tracked ref,
+which means the ref was force-moved past it; a pin merely *behind* its ref is
+not drift. `doctor` runs the same check as an advisory warning, since
+re-pinning past a force-move is a supply-chain call `--fix` must not make.
+
 ### Validation
 
 ```
@@ -533,14 +578,16 @@ trellis doctor [--fix] [--dry-run] [--format text|json|github]
 
 Checks every workspace invariant and reports all problems at once: member
 globs resolve and parse, path deps stay inside the workspace, the graph is
-acyclic, task exclusion globs match real members, every package's runtime
-path deps are available at its release lifecycle, tag formats don't collide, `manifest.toml`
-locked versions match workspace-internal `gleam.toml` versions, no package's
-version is behind its CHANGELOG, and every unreleased changelog fragment
-parses and references a valid package and kind. When `.tool-versions` pins
-gleam, a mismatched gleam on PATH is reported as an advisory warning
-(enforcing toolchains stays mise/asdf's job). Non-zero exit on any error —
-run it on every PR.
+acyclic, task exclusion globs match real members, every package's runtime path
+deps are available at its release lifecycle, tag formats don't collide,
+`manifest.toml` locked versions match workspace-internal `gleam.toml`
+versions, no package's version is behind its CHANGELOG, and every unreleased
+changelog fragment parses and references a valid package, kind, and category.
+Two checks are advisory warnings rather than errors, because both need the
+network or the machine's own toolchain: pinned git dependency SHAs still
+reachable from their tracked refs, and a gleam on PATH matching the
+`.tool-versions` pin (enforcing toolchains stays mise/asdf's job). Non-zero
+exit on any error — run it on every PR.
 
 Two further checks cover things that must agree because they are duplicated:
 
@@ -627,33 +674,8 @@ against the fixture workspace in `tests/fixtures/`. `cargo fmt` and
 from the clap definitions — regenerate both with `just docs` after changing any
 command, flag, or help string. `cargo test` fails if they're stale.
 
-## Releasing trellis
-
-Releases are fully automated, fragment-driven, and hands-off after merge —
-the same pipeline as [repoverlay](https://github.com/tylerbutler/repoverlay):
-
-1. Every user-facing change lands with a changie fragment (`changie new`);
-   fragments accumulate in `.changes/unreleased/`.
-2. On each push to `main`, `changie-release.yml` batches the fragments into a
-   release PR that bumps `Cargo.toml`, regenerates `Cargo.lock`, and updates
-   `CHANGELOG.md`.
-3. Merging the release PR triggers `release-plz.yml`, which creates the
-   `v{version}` tag and publishes the crate to crates.io as `trellis-gleam`
-   (the `trellis` name itself is taken by an unrelated project — the `[[bin]]`
-   in `Cargo.toml` keeps the installed binary named `trellis`).
-4. The tag triggers the dist-generated `release.yml`: cargo-dist builds
-   binaries for five targets (Linux gnu, macOS, Windows; x86_64 and aarch64),
-   generates the shell/PowerShell installers and the Homebrew formula,
-   attaches SLSA provenance attestations, and creates the GitHub Release.
-   `publish-homebrew-tap.yml` then pushes the formula to
-   `tylerbutler/homebrew-tap` using a GitHub App token.
-
-The release workflows expect the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`
-secrets (a GitHub App with `contents:write` here and on the tap), plus a
-`CARGO_REGISTRY_TOKEN` secret (a crates.io API token with publish access to
-`trellis-gleam`) for `release-plz.yml` to publish the crate. After changing
-`dist-workspace.toml`, regenerate the release workflow with `dist generate`
-and validate with `dist plan`.
+Contributor conventions — naming, changelog fragments, and how trellis itself
+is released — are in [AGENTS.md](AGENTS.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 A workspace CLI for Gleam monorepos. A trellis is the frame a lattice grows on.
 
-Gleam has no native workspace concept — `gleam build`, `gleam test`, and
-`gleam publish` operate on a single package directory. Multi-package repos end
-up hand-building workspace features out of bash loops, YAML glue, and
+Gleam has no native workspace concept: `gleam build`, `gleam test`, and
+`gleam publish` each operate on a single package directory. Multi-package
+repos end up hand-building workspace features out of bash loops, YAML glue, and
 duplicated config. Trellis replaces that glue with one binary that runs
 identically locally and in CI.
 
@@ -17,12 +17,12 @@ The design principle:
 Everything trellis knows comes from one file format the ecosystem already
 uses: `gleam.toml`. The workspace root's manifest carries a `[tools.trellis]`
 table (member globs and options); each member's manifest supplies its name,
-version, and path dependencies. The dependency graph — topological order,
-publish order, change impact, path-dep rewrite maps — is computed, never
+version, and path dependencies. The dependency graph (topological order,
+publish order, change impact, path-dep rewrite maps) is computed, never
 declared.
 
-Throughout, a **package** is one Gleam package — a directory with its own
-`gleam.toml` — and a **member** is a package belonging to the workspace. The
+Throughout, a **package** is one Gleam package, a directory with its own
+`gleam.toml`, and a **member** is a package belonging to the workspace. The
 second word appears where membership itself is the point, as in the `members`
 key and the `@members` exclusion.
 
@@ -38,9 +38,9 @@ distribution.
 
 ## Installation
 
-Trellis ships as a single prebuilt binary — the same distribution model as
-`just`, `changie`, and `ratchet` — so it installs in CI in about a second
-with zero runtime dependencies. Releases are built and published by
+Trellis ships as a single prebuilt binary, the same distribution model as
+`just`, `changie`, and `ratchet`, so it installs in CI in about a second with
+zero runtime dependencies. Releases are built and published by
 [cargo-dist](https://opensource.axo.dev/cargo-dist/), with SLSA build
 provenance attestations.
 
@@ -71,8 +71,8 @@ other tools:
 mise use "github:tylerbutler/trellis@0.13.0"
 ```
 
-**From source:** the crate is `trellis-gleam` on crates.io — `trellis` was
-taken — but the installed binary is named `trellis` either way:
+**From source:** on crates.io the crate is `trellis-gleam` (`trellis` was
+taken), but the installed binary is named `trellis` either way:
 
 ```sh
 cargo install trellis-gleam
@@ -87,7 +87,7 @@ specific version in CI by replacing `latest/download` with
 
 ### Shell completions
 
-Add one line to your shell's startup file — `bash`, `zsh`, `fish`,
+Add one line to your shell's startup file. `bash`, `zsh`, `fish`,
 `powershell`, and `elvish` are supported:
 
 ```sh
@@ -105,24 +105,24 @@ shells and for man pages, which ship in the release archives under `man/`.
 
 Interactive commands print a one-line notice to stderr when a newer trellis
 has been published to crates.io. Successful checks are cached for a day, and
-the notice appears only after a fresh check. The check is best-effort — capped
-at a short timeout and silent on any error — so it never slows a command or
-changes its exit status. It runs only when stderr is a terminal, so scripts and
-structured output are never touched. It is additionally skipped in CI and when
-`DO_NOT_TRACK` or `TRELLIS_NO_UPDATE_CHECK` is set in the environment, and
-`--no-update-check` suppresses it for a single invocation.
+the notice appears only after a fresh check. The check is best-effort, capped
+at a short timeout and silent on any error, so it never slows a command or
+changes its exit status. It runs only when stderr is a terminal, so scripts
+and structured output are never touched. It is additionally skipped in CI and
+when `DO_NOT_TRACK` or `TRELLIS_NO_UPDATE_CHECK` is set in the environment,
+and `--no-update-check` suppresses it for a single invocation.
 
 ## Configuration
 
 Configuration is optional. With no configuration at all, the git repository
 root is the workspace root and every non-gitignored `gleam.toml` (outside
-`build/`) marks a member — a fresh Gleam monorepo, or a single-package repo,
+`build/`) marks a member. A fresh Gleam monorepo, or a single-package repo,
 works with zero setup.
 
 When you need to configure something, a `[tools.trellis]` table in a
-`gleam.toml` marks the workspace root — no separate config file. The root
-manifest may be config-only, or a regular gleam package that also anchors the
-workspace. Every key is optional, including `members`: omit it to keep
+`gleam.toml` marks the workspace root. There is no separate config file. The
+root manifest may be config-only, or a regular gleam package that also anchors
+the workspace. Every key is optional, including `members`: omit it to keep
 auto-discovering members from git while configuring everything else:
 
 ```toml
@@ -235,7 +235,7 @@ trellis graph [--format text|dot|mermaid|json]
 trellis info <package> [--json]
 ```
 
-`list` prints members in topological order — dependencies first. `--since
+`list` prints members in topological order, dependencies first. `--since
 origin/main` filters to packages owning changed files (committed, uncommitted,
 and untracked); `--with-dependents` adds the reverse-dependency closure. This
 is the primitive behind "only test what a PR touched."
@@ -309,11 +309,11 @@ packages = { "packages/experimental/**" = "workspace", "packages/providers/**" =
 ```
 
 Each member resolves to one of three lifecycles: `workspace` (build and test
-only — no changelog, version, tag, or publish), `git_only` (changelog,
+only, with no changelog, version, tag, or publish), `git_only` (changelog,
 version, and git tags/releases, but never published to Hex), or `hex` (the
 full pipeline, and the default). `default` sets the workspace-wide fallback;
-`packages` overrides it per member, keyed by member-path glob — a member
-matched by globs resolving to different lifecycles is a `doctor` error, but
+`packages` overrides it per member, keyed by member-path glob. A member
+matched by globs that resolve to different lifecycles is a `doctor` error, but
 globs agreeing on the same lifecycle are fine. `exclude.@release` keeps
 resolving matching packages to `workspace`, but an explicit `packages` rule
 for the same member takes precedence, so a package can graduate from
@@ -321,10 +321,10 @@ for the same member takes precedence, so a package can graduate from
 
 `--releasable` (on `list`, `ci matrix`, and elsewhere) still means `git_only`
 **or** `hex`; `publish` narrows further, since only `hex` packages ever reach
-Hex. `doctor` additionally enforces that a runtime path dependency is at
-least as capable as its dependent — `hex` may depend only on `hex`, `git_only`
-may depend on `git_only` or `hex`, and `workspace` may depend on anything —
-exempting dev-only path deps, which never ship in any distribution.
+Hex. `doctor` additionally enforces that a runtime path dependency is at least
+as capable as its dependent: `hex` may depend only on `hex`, `git_only` may
+depend on `git_only` or `hex`, and `workspace` may depend on anything.
+Dev-only path deps are exempt, since they never ship in any distribution.
 
 ### Changelog & versioning
 
@@ -339,29 +339,29 @@ trellis version apply [--bump <level>|<pkg>=<level>] [--set <pkg>=<version>]
                       [--pre <label>|none] [--json]
 ```
 
-The changelog engine is native — no second tool to install, no config file
-to keep in sync. Changes are recorded as TOML fragments in
+The changelog engine is native, so there is no second tool to install and no
+config file to keep in sync. Changes are recorded as TOML fragments in
 `.changes/unreleased/` — `package`, `kind`, `body`, and an optional
 `category`; `changelog new` writes one, non-interactively, which suits CI and
-agents as well as shells.
-`changelog check` maps a `base...head` diff to packages and fails if a
-changed releasable package has no unreleased fragment. How much that costs is
-configurable — `changelog.strictness` is `error` by default, `warn` to report
-without failing, `off` not to check (an *invalid* fragment fails either way).
-`--format json` emits the payload, including a markdown `preview` for a PR
-sticky comment; `--format github` emits the same facts as `key=value` lines for
-`$GITHUB_OUTPUT`, so a workflow can post that comment without a `jq` pipeline.
+agents as well as shells. `changelog check` maps a `base...head` diff to
+packages and fails if a changed releasable package has no unreleased fragment.
+How much that costs is set by `changelog.strictness`: `error` by default,
+`warn` to report without failing, `off` not to check (an *invalid* fragment
+fails either way). `--format json` emits the payload, including a markdown
+`preview` for a PR sticky comment; `--format github` emits the same facts as
+`key=value` lines for `$GITHUB_OUTPUT`, so a workflow can post that comment
+without a `jq` pipeline.
 
 `version plan` computes each pending package's next version from its
 fragments' kinds (the largest bump wins; kinds and their bumps are
-configurable under `[tools.trellis.changelog]`). `version apply` renders each package's
-version section (minijinja templates, see below), stores it under
+configurable under `[tools.trellis.changelog]`). `version apply` renders each
+package's version section (minijinja templates, see below), stores it under
 `.changes/<package>/`, reassembles the package's CHANGELOG.md newest-first,
-bumps `gleam.toml` with a surgical TOML edit — no regex — and finally patches
-each member's `manifest.toml` so locked workspace-internal deps match. Zero
-Hex network calls throughout. Invalid fragments (unknown package or kind,
+bumps `gleam.toml` with a surgical TOML edit rather than a regex, and finally
+patches each member's `manifest.toml` so locked workspace-internal deps match.
+Zero Hex network calls throughout. Invalid fragments (unknown package or kind,
 empty body, unparseable TOML) are hard errors for `plan`/`apply`: silently
-dropping a change is exactly the drift trellis exists to prevent.
+dropping a change is the drift trellis exists to prevent.
 
 A bump ripples to the bumping package's workspace dependents. When `lat_core`
 goes 1.2.0 → 1.3.0, every package that path-depends on it is released too —
@@ -377,7 +377,7 @@ A dependent needs no fragment of its own to ripple, and a package that has one
 keeps its own, larger bump. Ripples follow `[dev-dependencies]` path deps as
 well as `[dependencies]`. Packages excluded by `@release` never bump, and a
 ripple stops at one rather than skipping past it to its dependents. This is a
-correctness requirement, not a convenience —
+correctness requirement rather than a convenience;
 [why](https://trellis.tylerbutler.com/docs/changelog/#dependents-bump-too).
 
 #### Overriding the derived version
@@ -409,7 +409,7 @@ trellis version apply --pre none                      # 1.0.0
 ```
 
 **Fragments survive a prerelease.** The candidate renders its changelog
-section, but the fragments behind it stay in `.changes/unreleased/` — they are
+section, but the fragments behind it stay in `.changes/unreleased/`: they are
 still unreleased as far as `1.0.0` is concerned, and retiring them at `rc.1`
 would leave the final release with nothing to say. `--pre none` promotes the
 candidate to its final version and consumes them. This means an entry appears
@@ -423,7 +423,7 @@ after the RC was cut still bumps normally under `--pre none`, so a late arrival
 never blocks the promotion.
 
 Once a package is at a prerelease, a plain `version apply` is an error rather
-than a silent bump to the next release — resolving the cycle has to be
+than a silent bump to the next release; resolving the cycle has to be
 explicit. A prerelease belongs to no series, so it moves no
 [series tag](#release--publish); exact tags apply as usual, and Hex accepts
 prerelease versions.
@@ -449,7 +449,7 @@ dependency_body = "Updated {{ dependency }} to {{ dependency_version }}"  # defa
 
 `kinds` sets the change kinds and the bump each implies; setting it replaces
 the whole default list rather than adding to it, so copy the list before
-trimming it — a kind you drop turns every fragment naming it invalid. An
+trimming it. A kind you drop turns every fragment naming it invalid. An
 optional `categories` list adds a second grouping axis above the kind
 headings, carrying no bump. Both are on
 [configuration](https://trellis.tylerbutler.com/docs/configuration/#changelog-configuration).
@@ -472,14 +472,14 @@ trellis publish <pkg | --tag <tag> | --all-untagged> [--dry-run]
 trellis lockfile refresh [--package <pkg>]
 ```
 
-`release pr` turns pending changelog fragments into a release pull request:
-it runs `version apply` on a release branch (default `release/pending`),
-commits the bumps, force-pushes (so the branch is regenerated each run), and
-creates — or, when one is already open, updates — the PR through the GitHub
-REST API. The body carries the bump table and each package's new CHANGELOG
-section. Requires a clean working tree and a token from `GITHUB_TOKEN`
-(ambient in GitHub Actions), `GH_TOKEN`, or a logged-in `gh` CLI; a no-op when
-there are no fragments.
+`release pr` turns pending changelog fragments into a release pull request: it
+runs `version apply` on a release branch (default `release/pending`), commits
+the bumps, force-pushes (so the branch is regenerated each run), and creates
+the PR through the GitHub REST API, or updates it when one is already open.
+The body carries the bump table and each package's new CHANGELOG section.
+Requires a clean working tree and a token from `GITHUB_TOKEN` (ambient in
+GitHub Actions), `GH_TOKEN`, or a logged-in `gh` CLI; a no-op when there are
+no fragments.
 
 `tag plan` lists the tags the current versions call for and don't have yet;
 `tag create` reconciles them in topological order, optionally pushing them and
@@ -496,15 +496,15 @@ to two (`{name}-v1.2`). It defaults to `["exact"]`, and
 levels rather than templates so that `ci tag-package` can resolve a pushed tag
 back to its package.
 
-The level also picks the lifecycle. `exact` tags are immutable — created once,
-never rewritten — and substitute into `exact_tag_format`. Series levels move:
-releasing a new version in the series force-moves the tag to the release commit
-and force-pushes it, substituting into `series_tag_format`. A commit that does
-not change the package's version leaves its series tags where they are, so one
-package's release never drags another's forward. Because a moving tag names no
-particular version, it never carries a GitHub Release and `publish --tag`
-refuses it; `ci tag-package` still resolves it, and a workspace with no `exact`
-entry publishes with `--all-untagged`.
+The level also picks the lifecycle. `exact` tags are immutable, created once
+and never rewritten, and substitute into `exact_tag_format`. Series levels
+move: releasing a new version in the series force-moves the tag to the release
+commit and force-pushes it, substituting into `series_tag_format`. A commit
+that does not change the package's version leaves its series tags where they
+are, so one package's release never drags another's forward. Because a moving
+tag names no particular version, it never carries a GitHub Release and
+`publish --tag` refuses it; `ci tag-package` still resolves it, and a
+workspace with no `exact` entry publishes with `--all-untagged`.
 
 An optional repository tag is separate from every package's list.
 `repository_tag_package` is the anchor: trellis creates `repository_tag_format`
@@ -537,10 +537,10 @@ publish if the tag version doesn't match `gleam.toml`; `--all-untagged`
 publishes everything not yet on Hex, enabling a single publish run per release
 instead of one per tag.
 
-`lockfile refresh` scopes `gleam deps download` to one package (with retry),
-encoding the "don't refresh the whole workspace or you'll get rate-limited"
-rule as behavior. `trellis ci tag-package <tag>` resolves `$GITHUB_REF_NAME`
-to a package name for shell substitution.
+`lockfile refresh` scopes `gleam deps download` to one package, with retry.
+Refreshing the whole workspace at once is what gets a runner rate-limited by
+Hex. `trellis ci tag-package <tag>` resolves `$GITHUB_REF_NAME` to a package
+name for shell substitution.
 
 ### Dependency pinning
 
@@ -551,24 +551,25 @@ trellis pin --check [pkgs...]    # fail if a pinned SHA drifted from its tracked
 trellis pin --unpin [pkgs...]    # restore the symbolic refs
 ```
 
-A Gleam git dependency names a ref, and both spellings are wrong: `ref = "v0.4"`
-is readable but re-resolves silently when the tag moves, and a bare SHA is
-reproducible but loses what to bump to. `pin` keeps both — the `ref` becomes
-the commit SHA and the ref it tracks moves into a `# trellis:pin` comment on
-the same line, the style
+A Gleam git dependency names a ref, and the two values you can give it are
+wrong in opposite ways. `ref = "v0.4"` is readable but re-resolves silently
+when the tag moves, and a bare SHA is reproducible but loses what to bump to.
+`pin` keeps both: the `ref` becomes the commit SHA and the ref it tracks moves
+into a `# trellis:pin` comment on the same line, the style
 [ratchet](https://github.com/sethvargo/ratchet) uses for GitHub Actions:
 
 ```toml
 vestibule = { git = "https://github.com/example/monorepo.git", ref = "93deb4c38d4b3f5848681ff7e9d59883db751c67", path = "packages/vestibule" } # trellis:pin v0.4
 ```
 
-Refs resolve through `git ls-remote` — no clone, any host — and `manifest.toml`
-is patched surgically. `--update` re-resolves each recorded ref, so following a
-moving tag becomes a reviewable diff instead of a silent re-resolution.
-`--check` fails when a pinned SHA is no longer reachable from its tracked ref,
-which means the ref was force-moved past it; a pin merely *behind* its ref is
-not drift. `doctor` runs the same check as an advisory warning, since
-re-pinning past a force-move is a supply-chain call `--fix` must not make.
+Refs resolve through `git ls-remote`, so there is no clone and any host works,
+and `manifest.toml` is patched surgically. `--update` re-resolves each
+recorded ref, so following a moving tag becomes a reviewable diff instead of a
+silent re-resolution. `--check` fails when a pinned SHA is no longer reachable
+from its tracked ref, which means the ref was force-moved past it; a pin
+merely *behind* its ref is not drift. `doctor` runs the same check as an
+advisory warning, since re-pinning past a force-move is a supply-chain call
+`--fix` must not make.
 
 ### Validation
 
@@ -587,7 +588,7 @@ Two checks are advisory warnings rather than errors, because both need the
 network or the machine's own toolchain: pinned git dependency SHAs still
 reachable from their tracked refs, and a gleam on PATH matching the
 `.tool-versions` pin (enforcing toolchains stays mise/asdf's job). Non-zero
-exit on any error — run it on every PR.
+exit on any error. Run it on every PR.
 
 Two further checks cover things that must agree because they are duplicated:
 

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -173,8 +173,8 @@ applied, and matches the exit code. `fragments`, `has_entry`, and `has_entries`
 count only the fragments this branch wrote (see [Scope](#scope)). The `schema`
 field is there so a workflow
 can assert on the shape it expects; the [JSON output](/docs/json-output/) page
-covers what it promises. Note that `preview` is guaranteed to be present and a
-string, but its Markdown is prose — render it rather than parsing it.
+covers what it promises. `preview` is guaranteed to be present and a string,
+but its Markdown is prose — render it rather than parsing it.
 
 <Callout>
 

--- a/website/src/content/docs/docs/changelog.mdx
+++ b/website/src/content/docs/docs/changelog.mdx
@@ -5,10 +5,10 @@ description: Trellis has a native changelog engine — TOML fragments in .change
 
 import Callout from "../../../components/Callout.astro";
 
-The changelog engine is native — no second tool to install in CI, no config
-file to keep in sync with the workspace. Changes are recorded as small TOML
-fragments, one per change; version bumps and changelog sections are derived
-from them.
+The changelog engine is native, so there is no second tool to install in CI
+and no config file to keep in sync with the workspace. Changes are recorded as
+small TOML fragments, one per change; version bumps and changelog sections are
+derived from them.
 
 ```txt wrap
 trellis changelog new [--package <pkg>] --kind <kind> --body <text>
@@ -19,7 +19,7 @@ trellis version apply [--json]
 
 ## Fragments
 
-A fragment is one file in `.changes/unreleased/` with three keys — the package
+A fragment is one file in `.changes/unreleased/` with three keys: the package
 it belongs to, a configured change kind, and the entry text:
 
 ```toml title=".changes/unreleased/lat_core-add-graph-parallel-task.toml"
@@ -36,7 +36,7 @@ fragments already sitting in `.changes/unreleased/` keep working, but
 
 </Callout>
 
-`changelog new` writes one non-interactively — `--kind` and `--body` are
+`changelog new` writes one non-interactively. `--kind` and `--body` are
 explicit flags, which suits CI and agents as well as shells (`--package` can
 be omitted when the workspace has exactly one releasable package):
 
@@ -52,14 +52,14 @@ rarely pick the same name. A clash takes the next free `-2`, `-3` suffix.
 
 <Callout>
 
-Invalid fragments — unknown package, kind, or category, empty body,
-unparseable TOML — are hard errors for `check`, `plan`, and `apply`, and
+Invalid fragments (an unknown package, kind, or category, an empty body,
+unparseable TOML) are hard errors for `check`, `plan`, and `apply`, and
 `doctor` flags them on every PR.
 
 </Callout>
 
 A fragment takes one more optional key, `category`, when the workspace
-configures [categories](/docs/configuration/#categories) — a second grouping
+configures [categories](/docs/configuration/#categories), a second grouping
 axis that carries no version bump and sections the changelog by which part of
 a package changed:
 
@@ -80,9 +80,9 @@ lat_cli: needs a changelog entry
 ```
 
 A package counts as changed when the diff touches *any* file under its
-directory — a README edit trips the same gate as a behavior change. That makes
-the gate stricter than some repositories want; [`strictness`](#strictness)
-turns it down.
+directory, so a README edit trips the same gate as a behavior change. That
+makes the gate stricter than some repositories want;
+[`strictness`](#strictness) turns it down.
 
 ### Scope
 
@@ -92,10 +92,10 @@ outright or edited what the base branch already had. Fragments the branch left
 untouched document the PRs that added them.
 
 This is what makes the gate per-PR. A package with an unreleased fragment from
-an earlier PR does not satisfy the check for a *later* PR that touches the same
-package — otherwise one entry excuses every change until the next release. It
-also keeps the [PR comment](#driving-a-pr-comment) honest: `version` is the bump
-this PR causes rather than what the accumulated backlog adds up to, and a
+an earlier PR does not satisfy the check for a *later* PR that touches the
+same package; otherwise one entry excuses every change until the next release.
+It also keeps the [PR comment](#driving-a-pr-comment) honest: `version` is the
+bump this PR causes rather than what the accumulated backlog adds up to, and a
 package whose only unreleased fragment came from the base branch shows `—`.
 
 Comparing contents rather than reading the diff means an uncommitted fragment
@@ -105,8 +105,8 @@ CI gives afterwards.
 <Callout>
 
 **Invalid fragments are not scoped.** A fragment that does not parse fails
-`check` wherever it came from, because it blocks the next release for everyone
-— scoping it would leave every PR green while the release stayed stuck.
+`check` wherever it came from, because it blocks the next release for everyone.
+Scoping it would leave every PR green while the release stayed stuck.
 
 </Callout>
 
@@ -127,7 +127,7 @@ land the reporting without failing builds while the open PRs catch up.
 | Value | Effect |
 | --- | --- |
 | `error` | Default. A missing entry fails the run. |
-| `warn` | Reported, exit 0 — advisory, so the comment still appears but the check stays green. |
+| `warn` | Reported, exit 0. Advisory, so the comment still appears but the check stays green. |
 | `off` | Not checked. Packages and fragment counts are still reported. |
 
 ```toml title="gleam.toml"
@@ -143,7 +143,7 @@ the manifest.
 
 **Strictness governs missing entries, not broken ones.** A fragment that does
 not parse, or that names an unknown package or kind, fails `check` at every
-setting including `off` — that is malformed input, not a policy call.
+setting including `off`. That is malformed input, not a policy call.
 
 </Callout>
 
@@ -169,12 +169,12 @@ sticky comment:
 ```
 
 `needs_entry` states the fact; `ok` states the verdict after strictness is
-applied, and matches the exit code. `fragments`, `has_entry`, and `has_entries`
-count only the fragments this branch wrote (see [Scope](#scope)). The `schema`
-field is there so a workflow
-can assert on the shape it expects; the [JSON output](/docs/json-output/) page
-covers what it promises. `preview` is guaranteed to be present and a string,
-but its Markdown is prose — render it rather than parsing it.
+applied, and matches the exit code. `fragments`, `has_entry`, and
+`has_entries` count only the fragments this branch wrote (see
+[Scope](#scope)). The `schema` field is there so a workflow can assert on the
+shape it expects; the [JSON output](/docs/json-output/) page covers what it
+promises. `preview` is guaranteed to be present and a string, but its Markdown
+is prose, so render it rather than parsing it.
 
 <Callout>
 
@@ -239,9 +239,9 @@ TRELLIS_PREVIEW
 `fromJSON()`; `preview` uses GitHub's heredoc form because it is multi-line.
 See [CI recipes](/docs/ci/#the-changelog-comment) for the workflow.
 
-The table covers the packages the PR's diff touched; the release preview covers
-every package this PR's fragments would release, computed the same way
-`version plan` computes it — so a dependent that merely ripples (like `lat_cli`
+The table covers the packages the PR's diff touched; the release preview
+covers every package this PR's fragments would release, computed the same way
+`version plan` computes it, so a dependent that merely ripples (like `lat_cli`
 above) appears with its generated `Dependencies` entry. Each collapsed section
 is the version section `version apply` would write for these fragments. When a
 fragment does not parse, no plan can be computed, so the versions and the
@@ -266,12 +266,12 @@ lat_cli: 0.4.2 -> 0.4.3 (1 fragment(s), dependencies: lat_core, lat_mid)
 `lat_mid` owns no fragment, yet it is in that plan. When a package bumps, so
 does everything that path-depends on it, transitively.
 
-This is a correctness requirement, not a convenience. A path dependency carries
-no version in the repository; it becomes a Hex requirement at publish time,
-derived from whatever version the dependency is on *then*. Holding `lat_mid` at
-0.5.0 while `lat_core` moved would leave one published `lat_mid` 0.5.0 meaning
-two different things — `>= 1.1.0` to whoever fetched it before the release,
-`>= 1.2.0` to whoever fetched it after.
+This is a correctness requirement, not a convenience. A path dependency
+carries no version in the repository; it becomes a Hex requirement at publish
+time, derived from whatever version the dependency is on *then*. Holding
+`lat_mid` at 0.5.0 while `lat_core` moved would leave one published `lat_mid`
+0.5.0 meaning two different things: `>= 1.1.0` to whoever fetched it before
+the release, `>= 1.2.0` to whoever fetched it after.
 
 The rules:
 
@@ -279,7 +279,7 @@ The rules:
   patch by default. It needs no fragment of its own.
 - A package with its own fragments keeps its own bump; a ripple never lowers
   it. `lat_cli` above is `0.4.3` from its own fragment, not `0.4.3` from the
-  ripple — whichever is larger wins.
+  ripple; whichever is larger wins.
 - Ripples follow `[dev-dependencies]` path deps as well as `[dependencies]`.
 - A package excluded by `@release` never bumps, and a ripple stops there rather
   than skipping past it to its dependents.
@@ -295,10 +295,10 @@ Each rippled package gets a generated changelog entry, rendered like any other:
 ```
 
 The entries are generated at plan time and never written to
-`.changes/unreleased/` — the body embeds the dependency's new version, which is
-only settled once the whole plan is computed. Hand-written entries of the same
-kind share the heading rather than producing a second section. A ripple entry
-names no category, so in a workspace using them it files under
+`.changes/unreleased/`, because the body embeds the dependency's new version,
+which is only settled once the whole plan is computed. Hand-written entries of
+the same kind share the heading rather than producing a second section. A
+ripple entry names no category, so in a workspace using them it files under
 `uncategorized_label`.
 
 ## Applying it
@@ -310,8 +310,8 @@ package, it:
    configurable) and stores it under `.changes/<package>/`.
 2. Reassembles the package's `CHANGELOG.md` from its stored sections, newest
    first.
-3. Bumps the version in `gleam.toml` with a surgical TOML edit — no regex,
-   formatting preserved.
+3. Bumps the version in `gleam.toml` with a surgical TOML edit rather than a
+   regex, preserving the formatting.
 4. Patches every package's `manifest.toml` so locked workspace-internal
    dependencies match the new versions.
 
@@ -372,10 +372,10 @@ but the fragments behind it stay in `.changes/unreleased/`: they are still
 unreleased as far as `1.0.0` is concerned, and retiring them at `rc.1` would
 leave the final release with nothing to say.
 
-The consequence is that an entry appears twice in `CHANGELOG.md` — once under
+The consequence is that an entry appears twice in `CHANGELOG.md`: once under
 the RC that shipped it, once under the final version. `version --json` reports
-[`fragments_retained`](/docs/json-output/) so a workflow can tell a cut RC from
-a completed release.
+[`fragments_retained`](/docs/json-output/) so a workflow can tell a cut RC
+from a completed release.
 
 </Callout>
 
@@ -384,8 +384,9 @@ included, so the workspace moves as one coherent candidate. A package that only
 gained fragments *after* the RC was cut still bumps normally under `--pre none`,
 so a late arrival never blocks the promotion.
 
-Once a package sits at a prerelease, a plain `version apply` is an error rather
-than a silent bump to the next release — leaving a cycle has to be explicit:
+Once a package sits at a prerelease, a plain `version apply` is an error
+rather than a silent bump to the next release; leaving a cycle has to be
+explicit:
 
 ```console
 $ trellis version plan
@@ -401,7 +402,7 @@ prerelease versions.
 
 Because `CHANGELOG.md` is regenerated from `.changes/<package>/`, a package
 that already had a changelog before adopting trellis would lose it the first
-time it was released — there is nothing under `.changes/<package>/` to
+time it was released, since there is nothing under `.changes/<package>/` to
 reassemble from.
 
 Trellis handles this on a package's first release: everything below the header
@@ -414,9 +415,9 @@ bumped lat_core: 1.2.0 -> 1.3.0
 adopted existing changelog history as .changes/lat_core/v1.2.0.md
 ```
 
-The captured block is byte-for-byte — no heading parsing, no reformatting — and
-sorts below every section trellis goes on to write. It happens once; after that
-the changelog is fully generated.
+The captured block is byte-for-byte, with no heading parsing and no
+reformatting, and sorts below every section trellis goes on to write. It
+happens once; after that the changelog is fully generated.
 
 `doctor` reports pending adoptions so this is never a surprise mid-release, and
 `doctor --fix` performs the capture up front, so the restructuring lands in its

--- a/website/src/content/docs/docs/ci.mdx
+++ b/website/src/content/docs/docs/ci.mdx
@@ -8,9 +8,9 @@ import Callout from "../../../components/Callout.astro";
 import { TRELLIS_VERSION } from "../../../lib/version";
 
 Trellis runs identically locally and in CI, and emits the exact structures
-GitHub Actions consumes — so workspace workflows shrink to thin triggers
-around a few commands. The recipes below are the shapes a Gleam workspace
-actually needs.
+GitHub Actions consumes, so workspace workflows shrink to thin triggers around
+a few commands. The recipes below are the shapes a Gleam workspace actually
+needs.
 
 ## Installing trellis
 
@@ -105,10 +105,7 @@ that changes a package without logging it:
 - run: trellis changelog check --base "origin/${{ github.base_ref }}"
 ```
 
-A workspace with [pinned git dependencies](/docs/pinning/) can add
-`trellis pin --check`, which fails the PR when a pinned SHA is no longer
-reachable from its tracked ref — `doctor` reports the same drift, but only
-as a warning.
+A workspace with [pinned git dependencies](/docs/pinning/) can add `trellis pin --check`, which fails the PR when a pinned SHA is no longer reachable from its tracked ref. `doctor` reports the same drift, but only as a warning.
 
 When the tripwire fires on a mechanical finding, such as a missing
 `CHANGELOG.md` or a stale `manifest.toml` locked version, clear it locally with
@@ -120,8 +117,8 @@ anywhere; keep the bare `trellis doctor` in CI as the gate.
 ### The changelog comment
 
 A failing gate in a log is easy to miss. `changelog check --format github`
-emits `key=value` lines for `$GITHUB_OUTPUT`, so the same run that gates the PR
-also drives a sticky comment — no `jq`, no second tool:
+emits `key=value` lines for `$GITHUB_OUTPUT`, so the same run that gates the
+PR also drives a sticky comment, with no `jq` and no second tool:
 
 ```yaml
 # on: pull_request
@@ -164,17 +161,16 @@ steps:
     run: exit 1
 ```
 
-The comment appears when there is something to say — entries to preview, an
-entry missing, or a fragment that doesn't parse — and is deleted when there
+The comment appears when there is something to say (entries to preview, an
+entry missing, or a fragment that doesn't parse) and is deleted when there
 isn't, so a fixed PR doesn't keep a stale complaint. It shows each changed
 package's fragment count and planned next version, plus a collapsible release
-preview of the changelog sections this PR's own fragments would produce, ripple
-bumps included. Everything it counts is
-[scoped to the branch](/docs/changelog/#scope) — fragments already unreleased on
-the base branch answer for the PRs that added them, not this one. `ok` carries
-the verdict
-`continue-on-error` swallowed, and is empty if trellis could not run at all,
-which fails the job either way.
+preview of the changelog sections this PR's own fragments would produce,
+ripple bumps included. Everything it counts is [scoped to the
+branch](/docs/changelog/#scope): fragments already unreleased on the base
+branch answer for the PRs that added them, not this one. `ok` carries the
+verdict `continue-on-error` swallowed, and is empty if trellis could not run
+at all, which fails the job either way.
 
 `preview` is already the comment body, rendered from the same data as the
 `--format json` field of that name. `needs_entry_packages` and
@@ -191,10 +187,7 @@ A workspace that wants the comment without the gate sets
 
 ### Annotating the diff
 
-A `doctor` failure in a log tells a contributor a file is wrong; an annotation
-puts the message on the file itself in the PR's Files tab. `--format github`
-emits one workflow command per finding and nothing else, so it drops straight
-into the gate:
+A `doctor` failure in a log tells a contributor a file is wrong; an annotation puts the message on the file itself in the PR's Files tab. `--format github` emits one workflow command per finding and nothing else, so it drops straight into the gate:
 
 ```yaml
 # on: pull_request
@@ -202,13 +195,13 @@ into the gate:
 ```
 
 Errors become `::error`, advisory warnings become `::warning`, and the exit
-code is unchanged — the job still fails on any error. A healthy workspace
+code is unchanged, so the job still fails on any error. A healthy workspace
 prints nothing at all.
 
-For anything richer than annotations — grouping findings by package, rendering
-them into a sticky comment, filtering to the ones `--fix` would clear — use
-`--format json` and read `check`, `severity`, `file`, and `fixable` off each
-finding:
+For anything richer than annotations, such as grouping findings by package,
+rendering them into a sticky comment, or filtering to the ones `--fix` would
+clear, use `--format json` and read `check`, `severity`, `file`, and `fixable`
+off each finding:
 
 ```yaml
 - id: doctor
@@ -227,9 +220,7 @@ On every push to `main`, regenerate the release PR from pending fragments:
 - run: trellis release pr
 ```
 
-When the release PR merges, pick one of the
-[two release shapes](/docs/publishing/#two-release-shapes). Tags as trigger —
-a tag-push workflow publishes each package:
+When the release PR merges, pick one of the [two release shapes](/docs/publishing/#two-release-shapes). With tags as trigger, a tag-push workflow publishes each package:
 
 ```yaml title=".github/workflows/publish.yml"
 # on tag push '*-v*': publish the tagged package
@@ -237,14 +228,13 @@ a tag-push workflow publishes each package:
 - run: trellis lockfile refresh --package "$(trellis ci tag-package "$GITHUB_REF_NAME")"
 ```
 
-This shape needs per-version tags. A moving
-[series tag](/docs/configuration/#tags) matches `*-v*` too, but
-names no particular version, so `publish --tag` rejects it by design —
-`ci tag-package` still resolves it, so the workflow can route on it. Packages
-tagged `series`-only belong in the publish-then-tag shape below.
+This shape needs per-version tags. A moving [series
+tag](/docs/configuration/#tags) matches `*-v*` too, but names no particular
+version, so `publish --tag` rejects it by design. `ci tag-package` still
+resolves it, so the workflow can route on it. Packages tagged `series`-only
+belong in the publish-then-tag shape below.
 
-Or publish-then-tag — one idempotent run publishes everything not yet on Hex,
-in topological order, then records what shipped:
+Or publish-then-tag: one idempotent run publishes everything not yet on Hex, in topological order, then records what shipped.
 
 ```yaml
 # on release-PR merge: publish everything, then record tags

--- a/website/src/content/docs/docs/compatibility.mdx
+++ b/website/src/content/docs/docs/compatibility.mdx
@@ -10,9 +10,7 @@ can bind a workflow to, and what may change under you.
 
 ## Exit codes
 
-Every command uses the same four codes. Branch on **1 versus 3** to tell a
-workspace that has problems from an environment where trellis could not run at
-all — a missing GitHub token, an unparseable config, or Hex being unreachable.
+Every command uses the same four codes. Branch on **1 versus 3** to tell a workspace that has problems from an environment where trellis could not run at all, such as a missing GitHub token, an unparseable config, or Hex being unreachable.
 
 | Code | Meaning | Examples |
 | --- | --- | --- |
@@ -42,23 +40,20 @@ against:
 
 **Covered.** A breaking change to any of these bumps the major version.
 
-- **The CLI surface** — command names, subcommands, flags, and arguments.
+- **The CLI surface.** Command names, subcommands, flags, and arguments.
 - **Configuration keys** — the `[tools.trellis]` table in your root
   `gleam.toml`.
 - **The exit codes** above.
 - **The `--json` payloads**, under the rules in the [JSON output
-  contract](/docs/json-output/) — those carry their own `schema` identifiers
-  and may bump independently of the CLI's version.
+  contract](/docs/json-output/) — those carry their own `schema` identifiers and may bump independently of the CLI's version.
 
 **Not covered.** These change freely in any release.
 
-- **Human-readable output.** Terminal text is TTY-dependent and not a parsing
-  target — parse the `--json` form instead.
+- **Human-readable output.** Terminal text is TTY-dependent and not a parsing target, so parse the `--json` form instead.
 - **Anything inside `src/`.** Trellis is a binary, not a library.
 
 <Callout>
-  **Trellis publishes no Rust API.** The crate is bin-only — there is no
-  `lib.rs`, and nothing in `src/` is reachable by a dependent crate.
+  **Trellis publishes no Rust API.** The crate is bin-only: there is no `lib.rs`, and nothing in `src/` is reachable by a dependent crate.
 </Callout>
 
 ## Minimum supported Rust version
@@ -68,5 +63,5 @@ bump is a minor version.
 
 This matters only if you build from source, where `cargo install` on an older
 toolchain reports the version it needs. The [installation
-methods](/docs/installation/) that most people use — the installer scripts and
-the Homebrew tap — ship prebuilt binaries and need no Rust toolchain at all.
+methods](/docs/installation/) that most people use, the installer scripts and
+the Homebrew tap, ship prebuilt binaries and need no Rust toolchain at all.

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -382,8 +382,9 @@ use the repository tag only for git path-dep consumers.
 
 The changelog engine is native — no second tool to install, no config file to
 keep in sync. Changes live as TOML fragments in `.changes/unreleased/`;
-rendering is controlled by small minijinja templates, each with a context of
-`name`, `version`, `date`, `tag`, `series`, `kind`, and `body` as applicable:
+rendering is controlled by small minijinja templates, each with a context
+drawn from `name`, `version`, `date`, `tag`, `series`, `category`, `kind`, and
+`body`:
 
 ```toml wrap
 [tools.trellis.changelog]

--- a/website/src/content/docs/docs/configuration.mdx
+++ b/website/src/content/docs/docs/configuration.mdx
@@ -7,16 +7,16 @@ import Callout from "../../../components/Callout.astro";
 
 Configuration is optional. With no configuration at all, the git repository
 root is the workspace root and every non-gitignored `gleam.toml` (outside
-`build/`) marks a member — a fresh Gleam monorepo, or a single-package repo,
+`build/`) marks a member. A fresh Gleam monorepo, or a single-package repo,
 works with zero setup.
 
 When you need to configure something, trellis uses a `[tools.trellis]` table
 in a `gleam.toml` to identify the workspace root, so it does not need a
-separate config file. The root manifest may be config-only, or a regular
-Gleam package that also anchors the workspace. Every key is optional,
-including `members` — omit it to keep auto-discovering members from git while
-configuring everything else; trellis derives the rest of its workspace model
-from the member manifests.
+separate config file. The root manifest may be config-only, or a regular Gleam
+package that also anchors the workspace. Every key is optional, including
+`members`: omit it to keep auto-discovering members from git while configuring
+everything else; trellis derives the rest of its workspace model from the
+member manifests.
 
 ```toml title="gleam.toml" wrap
 # gleam.toml at the repo root
@@ -48,9 +48,9 @@ error.
 
 ## Bootstrapping with `trellis init`
 
-`trellis init` writes the table for you, at the repository root — creating a
-config-only `gleam.toml` if the root is not itself a package, and adding to the
-existing manifest if it is.
+`trellis init` writes the table for you, at the repository root, creating a
+config-only `gleam.toml` if the root is not itself a package, and adding to
+the existing manifest if it is.
 
 ```console
 $ trellis init
@@ -71,7 +71,7 @@ finishes by running [`doctor`](#verifying-it).
 
 <Callout>
 
-You do not need `init` to start using trellis — configless mode already works.
+You do not need `init` to start using trellis. Configless mode already works.
 Reach for it when you want to configure something, or to make the workspace
 root explicit rather than inferred.
 
@@ -194,7 +194,7 @@ validates dependency availability across the release lifecycle: see
 
 `exclude.@release` is a single on/off switch: a package either participates in
 the full release pipeline or is invisible to all of it. Real monorepos often
-have packages in between — versioned and tagged in git, but never meant for
+have packages in between: versioned and tagged in git, but never meant for
 Hex, or not ready to release at all yet. `publish.lifecycle` resolves each
 member to one of three states:
 
@@ -213,7 +213,7 @@ packages = { "packages/experimental/**" = "workspace", "packages/providers/**" =
 `default` is the lifecycle for a member matched by no `packages` glob and no
 legacy `exclude.@release` glob. `packages` is a map of member-path glob to
 lifecycle; a member matched by globs resolving to *different* lifecycles is a
-`doctor` error, but matching several globs that agree is fine — that's how a
+`doctor` error, but matching several globs that agree is fine. That's how a
 directory-wide glob and a narrower one inside it can both claim a member.
 
 Resolution order, so a workspace can adopt `publish.lifecycle` incrementally
@@ -239,7 +239,7 @@ publishing something unresolvable.
 **A dependency must be at least as capable as its dependent.** `hex` may
 depend only on `hex`; `git_only` may depend on `git_only` or `hex`; `workspace`
 may depend on anything. `doctor`'s `release_boundary` check enforces this for
-runtime (`[dependencies]`) path deps only — a dev-only path dep never ships in
+runtime (`[dependencies]`) path deps only. A dev-only path dep never ships in
 any distribution, so it is exempt regardless of lifecycle.
 
 </Callout>
@@ -380,11 +380,11 @@ use the repository tag only for git path-dep consumers.
 
 ## Changelog configuration
 
-The changelog engine is native — no second tool to install, no config file to
-keep in sync. Changes live as TOML fragments in `.changes/unreleased/`;
-rendering is controlled by small minijinja templates, each with a context
-drawn from `name`, `version`, `date`, `tag`, `series`, `category`, `kind`, and
-`body`:
+The changelog engine is native, so there is no second tool to install and no
+config file to keep in sync. Changes live as TOML fragments in
+`.changes/unreleased/`; rendering is controlled by small minijinja templates,
+each with a context drawn from `name`, `version`, `date`, `tag`, `series`,
+`category`, `kind`, and `body`:
 
 ```toml wrap
 [tools.trellis.changelog]
@@ -417,7 +417,7 @@ dependency_body = "Updated {{ dependency }} to {{ dependency_version }}"  # defa
 `dependency_kind` must name one of `kinds`; that kind's bump is what a package
 bumps by when a dependency bump is the only reason it is being released. If
 you replace the default `kinds` list, include a kind for it or point
-`dependency_kind` at one of yours — trellis refuses to load otherwise rather
+`dependency_kind` at one of yours. Trellis refuses to load otherwise rather
 than drop the entries silently.
 
 ### Categories
@@ -492,7 +492,7 @@ a changelog before adopting trellis keeps it — see
 ## Shared dependency agreement
 
 Nothing outside trellis notices when packages drift apart on an external
-dependency they share — `lat_core` requiring `gleam_stdlib >= 0.44.0` while
+dependency they share: `lat_core` requiring `gleam_stdlib >= 0.44.0` while
 `lat_cli` requires `>= 0.60.0`. `doctor` catches it:
 
 ```console
@@ -503,8 +503,8 @@ counts
 ```
 
 Requirements are compared **as written**, never parsed as ranges, so `>= 1.0`
-and `>=1.0` read as divergent. Path dependencies are out of scope — they carry
-no requirement to agree on, and lockfile drift already covers them.
+and `>=1.0` read as divergent. Path dependencies are out of scope, since they
+carry no requirement to agree on, and lockfile drift already covers them.
 
 Divergence is sometimes intended, so this warns rather than failing by
 default:
@@ -514,7 +514,7 @@ default:
 shared_dependencies = "error"   # warn (default), error, or off
 ```
 
-There is no `doctor --fix` for it — which requirement to unify on is a judgment
+There is no `doctor --fix` for it: which requirement to unify on is a judgment
 call.
 
 ## Deprecated and unrecognized keys
@@ -529,7 +529,7 @@ warning: [tools.trellis] key `publish.tag-format` is deprecated; rename it to
 `publish.tag_format` (trellis config keys are snake_case)
 ```
 
-A warning, not an error — the old spelling still configures what it always did.
+A warning, not an error. The old spelling still configures what it always did.
 Plan on the aliases going away at 1.0.
 
 A key that is not recognized in *any* spelling is also a warning, since it may
@@ -551,5 +551,6 @@ Run `trellis doctor` after any config change. It validates that member globs
 resolve, the graph is acyclic, task exclusion globs match members, release
 boundaries are safe, the tag format produces unique tags, locked versions
 match, [pinned git dependencies](/docs/pinning/) have not drifted from their
-tracked refs, packages agree on their shared dependencies, and `[tools.trellis]`
-carries no unrecognized or deprecated keys — exiting non-zero on any error.
+tracked refs, packages agree on their shared dependencies, and
+`[tools.trellis]` carries no unrecognized or deprecated keys, exiting non-zero
+on any error.

--- a/website/src/content/docs/docs/index.mdx
+++ b/website/src/content/docs/docs/index.mdx
@@ -8,7 +8,7 @@ is the workspace layer on top: it fans those commands across a whole
 repository and adds changelogs, versioning, and publishing, deriving its model
 of the workspace from the `gleam.toml` files already in it.
 
-Throughout these docs, a **package** is one Gleam package — a directory with
+Throughout these docs, a **package** is one Gleam package, a directory with
 its own `gleam.toml`. A **member** is a package that belongs to the workspace;
 that word appears where membership itself is the point, as in the `members`
 key and the `@members` exclusion.
@@ -17,11 +17,11 @@ key and the `@members` exclusion.
 
 The member set, its topological order, change impact, and publish order all
 come from manifests that already exist. What can't be derived has to be
-duplicated somewhere — locked versions, changelogs, tags, toolchain pins — and
+duplicated somewhere: locked versions, changelogs, tags, toolchain pins.
 `trellis doctor` checks those, exiting non-zero when one breaks.
 
-Some findings are mechanically fixable — a releasable package missing its
-`CHANGELOG.md`, a `manifest.toml` locked version that drifted from its
+Some findings are mechanically fixable, such as a releasable package missing
+its `CHANGELOG.md`, or a `manifest.toml` locked version that drifted from its
 package's `gleam.toml`. For those, `trellis doctor --fix` writes the fix and
 re-reports whatever's left. `--dry-run` lists the same fixes without touching
 a file.
@@ -37,26 +37,25 @@ nothing requires the piece above it, so you can adopt trellis a layer at a
 time:
 
 - **Just the task runner.** `run`, `exec`, `list`, and `graph` need no
-  configuration at all — members are auto-discovered from git. Keep your
+  configuration at all, because members are auto-discovered from git. Keep your
   existing changelog tool and CI untouched.
 - **Add changelogs and versioning.** Fragments, `version plan`, and
   `version apply` manage bumps and changelogs without trellis owning your
-  release workflow — or any CI at all.
+  release workflow, or any CI at all.
 - **Add publishing.** `tag` and `publish` push to Hex in dependency order,
   from your own scripts or workflows.
 - **The full pipeline.** `ci`, `changelog check`, and `release pr` turn
   GitHub Actions workflows into thin triggers around trellis commands.
 
-Commands that feed automation emit structured JSON (`--json`,
-`trellis ci`), so any single piece slots into whatever tooling already
-surrounds it — under a [versioned guarantee](/docs/json-output/) you can
-assert on.
+Commands that feed automation emit structured JSON (`--json`, `trellis ci`),
+so any single piece slots into whatever tooling already surrounds it, under a
+[versioned guarantee](/docs/json-output/) you can assert on.
 
 ## Getting started
 
-1. [Install trellis](/docs/installation/) — a single prebuilt binary; shell
+1. [Install trellis](/docs/installation/): a single prebuilt binary; shell
    installer, Homebrew, mise/asdf, or cargo.
-2. [Configure the workspace](/docs/configuration/) if you need to — with no
+2. [Configure the workspace](/docs/configuration/) if you need to. With no
    configuration, members are auto-discovered from git; one optional
    `[tools.trellis]` table in `gleam.toml` covers everything else.
 3. Run `trellis doctor` to verify the setup, then

--- a/website/src/content/docs/docs/installation.mdx
+++ b/website/src/content/docs/docs/installation.mdx
@@ -82,8 +82,10 @@ Evaluate the snippet on startup rather than saving it into a completions
 directory: an `eval` always matches the binary you have, while a saved copy
 silently goes stale after an upgrade.
 
-One limitation worth knowing: completing after `-C` uses the directory you're
-standing in, not the one you passed.
+Two limitations worth knowing. Completing after `-C` uses the directory you're
+standing in, not the one you passed. And `--bump` offers the three bare levels
+only — the `<pkg>=<level>` form is not completed, since the completer is handed
+just the partial word.
 
 ## Man pages
 

--- a/website/src/content/docs/docs/installation.mdx
+++ b/website/src/content/docs/docs/installation.mdx
@@ -6,10 +6,10 @@ description: Trellis ships as a single prebuilt binary that installs in about a 
 import { Code } from "@astrojs/starlight/components";
 import { TRELLIS_VERSION } from "../../../lib/version";
 
-One prebuilt binary, no runtime dependencies, about a second to install on a CI
-runner. Every release ships five targets — Linux (glibc) and macOS on x86_64
-and aarch64, Windows on x86_64 — with SLSA build provenance attestations
-attached.
+One prebuilt binary, no runtime dependencies, about a second to install on a
+CI runner. Every release ships five targets, with SLSA build provenance
+attestations attached: Linux (glibc) and macOS on x86_64 and aarch64, and
+Windows on x86_64.
 
 ## Shell installer
 
@@ -43,8 +43,7 @@ its other tools, so every contributor and CI runner gets the same version:
 
 ## From source
 
-On crates.io the crate is `trellis-gleam` — `trellis` was taken — but the
-installed binary is named `trellis` either way:
+On crates.io the crate is `trellis-gleam` (`trellis` was taken), but the installed binary is named `trellis` either way:
 
 ```sh
 cargo install trellis-gleam
@@ -55,9 +54,9 @@ cargo install --git https://github.com/tylerbutler/trellis
 ## Shell completions
 
 Completions are computed by the binary as you type rather than baked into a
-static script, so they never drift from the flags you actually have — and they
-offer real values: package names, task names, and changelog kinds read from the
-workspace you're standing in.
+static script, so they never drift from the flags you actually have. They also
+offer real values: package names, task names, and changelog kinds read from
+the workspace you're standing in.
 
 Add one line to your shell's startup file:
 
@@ -84,7 +83,7 @@ silently goes stale after an upgrade.
 
 Two limitations worth knowing. Completing after `-C` uses the directory you're
 standing in, not the one you passed. And `--bump` offers the three bare levels
-only — the `<pkg>=<level>` form is not completed, since the completer is handed
+only. The `<pkg>=<level>` form is not completed, since the completer is handed
 just the partial word.
 
 ## Man pages
@@ -116,9 +115,7 @@ Prebuilt archives for every target are on the
 
 ## Verifying it
 
-From anywhere inside a workspace — trellis finds the root by walking up, like
-`git` or `cargo`, to the first `gleam.toml` carrying a `[tools.trellis]` table,
-or to the git repository root when no manifest carries one:
+From anywhere inside a workspace. Trellis finds the root by walking up, like `git` or `cargo`, to the first `gleam.toml` carrying a `[tools.trellis]` table, or to the git repository root when no manifest carries one:
 
 <Code
   lang="console"

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -25,7 +25,7 @@ its major version:
 }
 ```
 
-An unrecognized `schema` means an unsupported version — assert on it.
+An unrecognized `schema` means an unsupported version, so assert on it.
 
 ## What "stable" permits
 
@@ -33,7 +33,7 @@ An unrecognized `schema` means an unsupported version — assert on it.
 | --- | --- |
 | Adding a field | **Yes**, without a version bump — ignore fields you don't know. |
 | Adding an array element | **Yes**, per the command's documented selection rules. |
-| Renaming, removing, or retyping a field; changing a documented enum's values (`kind`, `action`, `tag_kind`) | **No** — bumps the major (`trellis.list/1` → `/2`). |
+| Renaming, removing, or retyping a field; changing a documented enum's values (`kind`, `action`, `tag_kind`) | **No.** Bumps the major (`trellis.list/1` → `/2`). |
 
 Not guaranteed: **key order** (parse as JSON) or **whitespace** (some
 commands pretty-print, some emit one line for shell-variable capture).
@@ -70,7 +70,7 @@ Notes:
   `current`, `next`, `fragments`, `updated_dependencies[]`).
   `fragments_retained` is true only under
   [`--pre <label>`](/docs/changelog/#prereleases).
-- `run`/`exec` share the `results[]` shape — `package`, `path`, `status`
+- `run`/`exec` share the `results[]` shape: `package`, `path`, `status`
   (`success` | `failed` | `skipped`), `duration_ms`. A failed entry also
   carries `exit_code` and `command`. `duration_ms`'s presence is stable, its
   value isn't.
@@ -112,8 +112,8 @@ summary renders the same data as compact counts:
 ```
 
 `severity` is `error` or `warning` (only `error` fails the run). `file`/
-`package` are absent, not null, when a finding isn't tied to one file. `message`
-is prose, not stable — branch on `check`:
+`package` are absent, not null, when a finding isn't tied to one file.
+`message` is prose, not stable, so branch on `check`:
 
 | `check` | Raised when |
 | --- | --- |
@@ -136,8 +136,7 @@ is prose, not stable — branch on `check`:
 | `toolchain` | the gleam on PATH disagrees with the `.tool-versions` pin |
 | `shared_dependency` | packages require different versions of the same external dependency |
 
-New `check` values may appear without a bump — handle unrecognized ones by
-reporting them, not dropping them.
+New `check` values may appear without a bump, so handle unrecognized ones by reporting them rather than dropping them.
 
 <Callout>
   **`--format github` is not JSON.** It emits workflow commands

--- a/website/src/content/docs/docs/json-output.mdx
+++ b/website/src/content/docs/docs/json-output.mdx
@@ -132,7 +132,7 @@ is prose, not stable — branch on `check`:
 | `changelog_behind` | a package's version is behind the newest one in its changelog |
 | `changelog_adoption` | a package has pre-trellis changelog history the next release will adopt |
 | `package_version` | a package's version is not valid semver |
-| `changelog_fragment` | an unreleased fragment does not parse, or names an unknown package or kind |
+| `changelog_fragment` | an unreleased fragment does not parse, or names an unknown package, kind, or category |
 | `toolchain` | the gleam on PATH disagrees with the `.tool-versions` pin |
 | `shared_dependency` | packages require different versions of the same external dependency |
 

--- a/website/src/content/docs/docs/pinning.mdx
+++ b/website/src/content/docs/docs/pinning.mdx
@@ -55,7 +55,7 @@ download.
 The comment is the record of intent. It lives on the dependency's own line,
 so it survives copy-paste between manifests, and there is no separate table
 to orphan when a dependency is removed. A dependency whose comment is deleted
-simply stops updating — still pinned, no longer followed. The converse also
+stops updating — still pinned, no longer followed. The converse also
 holds: a hand-written SHA with no comment is left alone, because there is no
 recorded ref to follow.
 

--- a/website/src/content/docs/docs/pinning.mdx
+++ b/website/src/content/docs/docs/pinning.mdx
@@ -5,11 +5,11 @@ description: trellis pin rewrites symbolic git dependency refs to commit SHAs an
 
 import Callout from "../../../components/Callout.astro";
 
-A Gleam git dependency names a ref, and there are two ways to spell it, both
-wrong. A symbolic ref (`ref = "v0.4"`) is readable but not reproducible — the
-tag moves and the next resolve silently follows it. A bare commit SHA is
-reproducible but loses the intent, so nobody knows what to bump it to.
-`trellis pin` keeps both, in the same style
+A Gleam git dependency names a ref, and the two values you can give it are
+wrong in opposite ways. A symbolic ref (`ref = "v0.4"`) is readable but not
+reproducible: the tag moves and the next resolve silently follows it. A bare
+commit SHA is reproducible but loses the intent, so nobody knows what to bump
+it to. `trellis pin` keeps both, in the same style
 [ratchet](https://github.com/sethvargo/ratchet) uses for GitHub Actions: the
 `ref` becomes the SHA, and the ref it tracks moves into a comment on the same
 line.
@@ -29,12 +29,13 @@ It works the same on any moving ref — a branch, or another tool's tags.
 ## Pinning
 
 `pin` scans `[dependencies]` and `[dev-dependencies]` of the selected
-packages — all of them when none are named — for git requirements whose `ref`
-is not already a full commit SHA. Each ref is resolved with
-`git ls-remote <url> <ref>`: no clone, any host, authentication through git's
-own credential machinery. An annotated tag pins the commit it points at, not
-the tag object. Then `ref` is rewritten and the original recorded in a
-`# trellis:pin` comment on the dependency's own line:
+packages, all of them when none are named, for git requirements whose `ref` is
+not already a full commit SHA. Each ref is resolved with
+`git ls-remote <url> <ref>`, so there is no clone, any host works, and
+authentication goes through git's own credential machinery. An annotated tag
+pins the commit it points at, not the tag object. Then `ref` is rewritten and
+the original recorded in a `# trellis:pin` comment on the dependency's own
+line:
 
 ```diff lang="toml" title="packages/lat_cli/gleam.toml" wrap
   [dependencies]
@@ -48,14 +49,14 @@ $ trellis pin
 ```
 
 The rest of the file is preserved byte for byte, and the locked commit in
-`manifest.toml` is patched surgically — no `gleam update`, no Hex traffic. A
-package without a manifest is fine: gleam locks the pinned commit on its next
-download.
+`manifest.toml` is patched surgically, with no `gleam update` and no Hex
+traffic. A package without a manifest is fine: gleam locks the pinned commit
+on its next download.
 
-The comment is the record of intent. It lives on the dependency's own line,
-so it survives copy-paste between manifests, and there is no separate table
-to orphan when a dependency is removed. A dependency whose comment is deleted
-stops updating — still pinned, no longer followed. The converse also
+The comment is the record of intent. It lives on the dependency's own line, so
+it survives copy-paste between manifests, and there is no separate table to
+orphan when a dependency is removed. A dependency whose comment is deleted
+stops updating: it is still pinned, but no longer followed. The converse also
 holds: a hand-written SHA with no comment is left alone, because there is no
 recorded ref to follow.
 
@@ -68,7 +69,7 @@ $ trellis pin --update
 [lat_cli] updated vestibule 51cbad6 was 93deb4c, tracking v0.4
 ```
 
-The result is a plain `gleam.toml` diff to review — following a moving tag
+The result is a plain `gleam.toml` diff to review, so following a moving tag
 becomes a deliberate, visible bump instead of a silent re-resolution. A
 dependency already at its ref's tip is untouched.
 
@@ -84,8 +85,8 @@ $ trellis pin --unpin
 
 `--check` verifies that each pinned SHA is an ancestor of (or equal to) the
 commit its tracked ref points at now. A SHA no longer reachable from its ref
-means the tag or branch was force-moved *past* it — the supply-chain signal
-this exists to catch:
+means the tag or branch was force-moved *past* it, which is the supply-chain
+signal this exists to catch:
 
 ```console
 $ trellis pin --check

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -63,9 +63,9 @@ and is a no-op when there are no fragments.
 `tag plan` lists the tags the current versions call for and don't have yet.
 `tag create` reconciles them in topological order; `--push` pushes them, and
 `--github-release` (which implies `--push` and needs the same GitHub token
-as `release pr`) also
-creates a GitHub Release per tag with the matching CHANGELOG section as the
-body.
+as `release pr`) also creates a GitHub Release per *exact* tag, with the
+matching CHANGELOG section as the body. `--dry-run` reports every tag, push,
+and release it would perform without doing any of them.
 
 Each entry in a package's `package_tags` falls into one of two lifecycles:
 
@@ -117,9 +117,8 @@ releases, so neither `publish --tag` nor `ci tag-package` resolves them.
 ## Publishing to Hex
 
 `publish` selects members whose [release lifecycle](/docs/configuration/#release-lifecycle)
-is `hex` — `--package <name>` and `--tag <tag>` refuse a `workspace` or
-`git_only` package by name, and `--all-untagged` only ever considers `hex`
-members. It runs, per package and in dependency order:
+is `hex` — a named package and `--tag <tag>` both refuse a `workspace` or
+`git_only` package, and `--all-untagged` only ever considers `hex` members. It runs, per package and in dependency order:
 
 1. **Idempotency check** — one Hex API query; versions already published are
    skipped.

--- a/website/src/content/docs/docs/publishing.mdx
+++ b/website/src/content/docs/docs/publishing.mdx
@@ -5,12 +5,11 @@ description: Trellis turns changelog fragments into a release PR, creates per-pa
 
 import Callout from "../../../components/Callout.astro";
 
-Publishing a workspace means turning pending
-[changelog fragments](/docs/changelog/) into version bumps, recording what
-shipped as git tags, and pushing packages to Hex in dependency order with
-workspace path dependencies rewritten to real Hex requirements. Trellis
-covers each step, and every step is idempotent — re-running a partially
-failed release is safe.
+Publishing a workspace means turning pending [changelog
+fragments](/docs/changelog/) into version bumps, recording what shipped as git
+tags, and pushing packages to Hex in dependency order with workspace path
+dependencies rewritten to real Hex requirements. Trellis covers each step, and
+every step is idempotent, so re-running a partially failed release is safe.
 
 ```txt wrap
 trellis release pr [--base <branch>] [--branch <branch>]
@@ -70,16 +69,16 @@ and release it would perform without doing any of them.
 Each entry in a package's `package_tags` falls into one of two lifecycles:
 
 - **Exact tags** (`{name}-v{version}`) are immutable. They are created once,
-  fetched when origin already has them, and never rewritten — local and remote
+  fetched when origin already has them, and never rewritten. Local and remote
   disagreeing about what one names is an error, not something to reconcile.
 - **Series tags** (`{name}-v{series}`) move. Releasing a new version in the
   series force-moves its tag to the release commit and force-pushes it, so
   consumers can track `lat_cli-v0.4` and follow the series instead of chasing
-  patch tags — [`trellis pin`](/docs/pinning/) gives git-dependency consumers
+  patch tags. [`trellis pin`](/docs/pinning/) gives git-dependency consumers
   a reviewable way to do exactly that. The signal is the package's manifest version stored at the tag,
-  so a commit that does not release the package — another package's release, a
-  docs change — leaves its series tags alone. The series is derived from the
-  version — see [series tags](/docs/configuration/#tags).
+  so a commit that does not release the package, such as another package's
+  release or a docs change, leaves its series tags alone. The series is
+  derived from the version; see [series tags](/docs/configuration/#tags).
 - **Repository tags** are independent of any package's list. Trellis moves the
   configured tag only when the anchor package's manifest version differs from
   the version at that tag. A series change creates a new tag and leaves the
@@ -106,32 +105,34 @@ to a moving tag would silently retarget on the next release, so only immutable
 per-version tags carry one.
 </Callout>
 
-With no `exact` entry a package has no per-version tags at all, so there
-is no tag to trigger a publish from: run `trellis publish --all-untagged` on
-release-PR merge instead. Passing a series tag to `publish --tag` is an error
-— it names a package, but no particular version.
+With no `exact` entry a package has no per-version tags at all, so there is no
+tag to trigger a publish from: run `trellis publish --all-untagged` on
+release-PR merge instead. Passing a series tag to `publish --tag` is an error,
+because it names a package but no particular version.
 
 Repository tags identify repository snapshots rather than package
 releases, so neither `publish --tag` nor `ci tag-package` resolves them.
 
 ## Publishing to Hex
 
-`publish` selects members whose [release lifecycle](/docs/configuration/#release-lifecycle)
-is `hex` — a named package and `--tag <tag>` both refuse a `workspace` or
-`git_only` package, and `--all-untagged` only ever considers `hex` members. It runs, per package and in dependency order:
+`publish` selects members whose [release
+lifecycle](/docs/configuration/#release-lifecycle) is `hex`. A named package
+and `--tag <tag>` both refuse a `workspace` or `git_only` package, and
+`--all-untagged` only ever considers `hex` members. It runs, per package and
+in dependency order:
 
-1. **Idempotency check** — one Hex API query; versions already published are
+1. **Idempotency check.** One Hex API query; versions already published are
    skipped.
-2. **Validation** — `gleam format --check`, `gleam build --warnings-as-errors`,
-   `gleam test`, run against the original manifest with path deps intact.
-3. **Path-dep rewrite** — computed from the graph, never hand-listed: each
+2. **Validation.** `gleam format --check`, `gleam build --warnings-as-errors`,
+   and `gleam test`, run against the original manifest with path deps intact.
+3. **Path-dep rewrite.** Computed from the graph, never hand-listed: each
    workspace path dependency becomes the Hex requirement derived from that
    dep's current version, per `path_dep_requirement`. The version map only
    ever holds `hex` members, so a path dependency on a `git_only` or
    `workspace` member fails the rewrite rather than publishing something Hex
    could never resolve.
-4. **Publish** — `gleam publish --yes`.
-5. **Restore** — the original `gleam.toml` comes back even when publishing
+4. **Publish.** `gleam publish --yes`.
+5. **Restore.** The original `gleam.toml` comes back even when publishing
    fails; the repo never shows rewritten files.
 
 Every Hex-touching step runs under the configured `retry` backoff policy.
@@ -154,11 +155,11 @@ release instead of one per tag.
 
 <Callout>
 
-Dev-only path deps to a non-`hex` package are left alone — Hex doesn't ship
-dev dependencies. A regular `[dependencies]` path dep to a package whose
+Dev-only path deps to a non-`hex` package are left alone, because Hex doesn't
+ship dev dependencies. A regular `[dependencies]` path dep to a package whose
 lifecycle is less capable than its dependent's refuses to publish, and
-`doctor` catches that boundary on every PR — see
-[Release lifecycle](/docs/configuration/#release-lifecycle).
+`doctor` catches that boundary on every PR; see [Release
+lifecycle](/docs/configuration/#release-lifecycle).
 
 </Callout>
 

--- a/website/src/content/docs/docs/task-running.mdx
+++ b/website/src/content/docs/docs/task-running.mdx
@@ -18,7 +18,7 @@ trellis exec [pkgs...] [--since <ref>] [--serial] [--keep-going] -- <command...>
 
 ## Built-in tasks
 
-Built-in tasks map 1:1 onto gleam verbs — no declaration needed:
+Built-in tasks map 1:1 onto gleam verbs, and need no declaration:
 
 | Task | Runs |
 | --- | --- |
@@ -79,8 +79,8 @@ failure instead of stopping at the first one.
 ## Selecting packages
 
 Name packages explicitly (`trellis run test lat_core`) or select them from git
-history. `--since <ref>` filters to packages owning changed files — committed,
-uncommitted, and untracked — and `--with-dependents` adds the
+history. `--since <ref>` filters to packages owning changed files (committed,
+uncommitted, and untracked), and `--with-dependents` adds the
 reverse-dependency closure:
 
 ```sh

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -75,10 +75,10 @@ tag_format = "{name}-v{version}"`;
       <div class="section-head">
         <h2>Opinionated, but modular.</h2>
         <p>
-          Trellis has one way of doing each job — TOML change fragments, a
+          Trellis has one way of doing each job: TOML change fragments, a
           tag per package, bumps derived from fragment kinds. But the jobs
-          are independent: nothing requires the piece above it, so you adopt
-          a layer at a time and keep whatever already works.
+          are independent, and nothing requires the piece above it, so you
+          adopt a layer at a time and keep whatever already works.
         </p>
       </div>
       <ol class="adopt-paths">
@@ -86,8 +86,8 @@ tag_format = "{name}-v{version}"`;
           <h3>Just the task runner</h3>
           <p>
             <code>run</code>, <code>exec</code>, <code>list</code>, and{" "}
-            <code>graph</code> need no configuration at all — members are
-            auto-discovered from git. Your changelog tool and CI stay untouched.
+            <code>graph</code> need no configuration at all, because members
+            are auto-discovered from git. Your changelog tool and CI stay untouched.
           </p>
         </li>
         <li>
@@ -95,7 +95,7 @@ tag_format = "{name}-v{version}"`;
           <p>
             Fragments, <code>version plan</code>, and <code>version apply</code>{" "}
             manage bumps and changelogs without trellis owning your release
-            workflow — or any CI at all.
+            workflow, or any CI at all.
           </p>
         </li>
         <li>
@@ -124,7 +124,7 @@ tag_format = "{name}-v{version}"`;
         <h2>The glue this replaces.</h2>
         <p>
           Without a workspace concept, a multi-package repository builds one by
-          hand — bash loops, YAML blocks, duplicated config. Every row below is
+          hand out of bash loops, YAML blocks, and duplicated config. Every row below is
           something a Gleam repository has to maintain itself, and every row can
           go quietly wrong:
         </p>
@@ -191,21 +191,22 @@ tag_format = "{name}-v{version}"`;
           <h3>From that, trellis computes:</h3>
           <ul>
             <li>
-              <strong>The member set and its topological order</strong> — new
+              <strong>The member set and its topological order.</strong> New
               packages join every command the moment their directory matches a
               glob.
             </li>
             <li>
-              <strong>Change impact</strong> — <code>--since origin/main</code>{" "}
+              <strong>Change impact.</strong> <code>--since origin/main</code>{" "}
               maps a diff to owning packages, plus the reverse-dependency
               closure. Only test what a PR touched.
             </li>
             <li>
-              <strong>Publish order and path-dep rewrites</strong> — dependencies
-              publish first, path references become Hex versions automatically.
+              <strong>Publish order and path-dep rewrites.</strong> Dependencies
+              publish first, and path references become Hex versions
+              automatically.
             </li>
             <li>
-              <strong>A tag per releasable package</strong> — and a{" "}
+              <strong>A tag per releasable package,</strong> plus a{" "}
               <code>doctor</code> that fails loudly when anything drifts.
             </li>
           </ul>
@@ -283,7 +284,7 @@ tag_format = "{name}-v{version}"`;
         <h2>One binary across the lifecycle.</h2>
         <p>
           The same tool runs locally and in CI. Commands work from anywhere in
-          the workspace — the root is found by walking up, like{" "}
+          the workspace, since the root is found by walking up, like{" "}
           <code>git</code> or <code>cargo</code>.
         </p>
       </div>
@@ -293,7 +294,7 @@ tag_format = "{name}-v{version}"`;
           <dl class="cmds">
             <div><dt><code>init</code></dt><dd>Write the workspace table; only needed to configure something</dd></div>
             <div><dt><code>run</code></dt><dd>Run a task across packages, graph-parallel by default</dd></div>
-            <div><dt><code>list</code></dt><dd>Packages in topological order — dependencies first</dd></div>
+            <div><dt><code>list</code></dt><dd>Packages in topological order, dependencies first</dd></div>
             <div><dt><code>graph</code></dt><dd>The dependency graph, as text, DOT, Mermaid, or JSON</dd></div>
             <div><dt><code>exec</code></dt><dd>Any command, in each package directory</dd></div>
             <div><dt><code>doctor</code></dt><dd>Validate workspace invariants; non-zero exit on any error</dd></div>
@@ -302,7 +303,7 @@ tag_format = "{name}-v{version}"`;
         <li class="phase">
           <h3><span class="phase-index" aria-hidden="true">2</span>Cut a release</h3>
           <dl class="cmds">
-            <div><dt><code>changelog</code></dt><dd>Native fragment engine — no second tool to install</dd></div>
+            <div><dt><code>changelog</code></dt><dd>Native fragment engine, with no second tool to install</dd></div>
             <div><dt><code>version</code></dt><dd>Plan and apply bumps from unreleased fragments</dd></div>
             <div><dt><code>tag</code></dt><dd>Compare versions against git tags; create what's missing</dd></div>
             <div><dt><code>publish</code></dt><dd>To Hex, in dependency order, path deps rewritten</dd></div>
@@ -327,7 +328,7 @@ tag_format = "{name}-v{version}"`;
       <div class="section-head">
         <h2>Checks for drift.</h2>
         <p>
-          Some things can't be derived — locked versions, changelogs, tags,
+          Some things can't be derived: locked versions, changelogs, tags,
           toolchain pins. For those, <code>trellis doctor</code> checks the
           invariants that remain explicit and exits non-zero when one breaks.
         </p>
@@ -402,7 +403,7 @@ tag_format = "{name}-v{version}"`;
       <p class="install-coda">
         Windows installer and pinned-version URLs are on the
         <a href="https://github.com/tylerbutler/trellis/releases">releases page</a>.
-        From there, <code>trellis doctor</code> works immediately — no setup.
+        From there, <code>trellis doctor</code> works immediately, with no setup.
         Run <code>trellis init</code> only when you want to configure something;
         the <a href="/docs/configuration/">configuration guide</a> covers what it
         writes.


### PR DESCRIPTION
Docs only. README.md + website. No code changed.

**Corrections** — checked every command, flag, key, and output sample against the binary in a fixture workspace:

- `release pr` and `tag create --github-release` use the GitHub REST API, not the `gh` CLI. `gh` is only a token fallback, and exit 3 means a missing token, not a missing `gh`.
- Fragment key is `package`, not the pre-0.8 `project` alias.
- `publish --package <name>` does not exist. Positional.
- `kinds` sample showed 3 of 10 defaults; setting the key replaces the list.
- Added a `pin` section (had none), `tag create --dry-run`, stale pins, missing template context.
- Em dashes 225 → 77. Trimmed to the author's own baseline (~20 per 346 lines in the first README, 56 per 682 here), not banned.
- "— no second tool to install, no config file" tic, 14×, now full clauses.
- "both spellings are wrong" → "the two values you can give it are wrong in opposite ways". A ref and a SHA are different values, not two spellings.